### PR TITLE
Enhancement CAT-FR-LM-01 - asset versioning

### DIFF
--- a/docker/docker-compose.strict.yml
+++ b/docker/docker-compose.strict.yml
@@ -10,7 +10,7 @@
 services:
   server:
     environment:
-      # TODO(gaia-x-loire): flip to "true" once Loire ontology-based type resolution works for JWT-wrapped VCs
+      # TODO(gaia-x-loire): Flip to "true" after story 035 (Loire Ontology Migration) lands — requires 2511 shapes + type resolution
       FEDERATED_CATALOGUE_VERIFICATION_TRUST_FRAMEWORK_GAIAX_ENABLED: "false"
       FEDERATED_CATALOGUE_VERIFICATION_SCHEMA: "true"
       FEDERATED_CATALOGUE_VERIFICATION_VP_SIGNATURE: "true"

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -31,6 +31,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.NotFoundException;
@@ -66,7 +67,7 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {AssetStoreCompositeTest.TestApplication.class, FileStoreConfig.class, VerificationServiceImpl.class, ValidatorCacheJpaDao.class,
-  AssetStoreImpl.class, AssetJpaDao.class, IriGenerator.class, IriValidator.class, AssetStoreCompositeTest.class,
+  AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class, IriGenerator.class, IriValidator.class, AssetStoreCompositeTest.class,
   SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class,
   Neo4jGraphStore.class, DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
   CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -43,7 +43,9 @@ import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
+import eu.xfsc.fc.core.service.verification.FormatDetector;
 import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
 import eu.xfsc.fc.core.service.verification.SchemaValidationServiceImpl;
 import eu.xfsc.fc.core.service.verification.VerificationService;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
@@ -68,7 +70,8 @@ import lombok.extern.slf4j.Slf4j;
   Neo4jGraphStore.class, DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
   CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
   RdfContentTypeProperties.class, JwtContentPreprocessor.class, Vc11Processor.class, Vc2Processor.class,
-  JwtSignatureVerifier.class, DidDocumentResolver.class})
+  JwtSignatureVerifier.class, DidDocumentResolver.class,
+  FormatDetector.class, LoireJwtParser.class})
 @Slf4j
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 @Import(EmbeddedNeo4JConfig.class)

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import eu.xfsc.fc.core.config.RdfContentTypeProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -66,7 +67,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {AssetStoreCompositeTest.TestApplication.class, FileStoreConfig.class, VerificationServiceImpl.class, ValidatorCacheJpaDao.class,
   AssetStoreImpl.class, AssetJpaDao.class, IriGenerator.class, IriValidator.class, AssetStoreCompositeTest.class,
-  SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class,
+  SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class,
   Neo4jGraphStore.class, DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
   CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
   RdfContentTypeProperties.class, JwtContentPreprocessor.class, Vc11Processor.class, Vc2Processor.class,

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
@@ -31,6 +31,7 @@ import eu.xfsc.fc.core.config.DatabaseConfig;
 import eu.xfsc.fc.core.config.DidResolverConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.NotFoundException;
@@ -56,7 +57,7 @@ import lombok.extern.slf4j.Slf4j;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @SpringBootTest
 @ActiveProfiles("test")
-@ContextConfiguration(classes = {AssetStoreTest.TestApplication.class, AssetStoreImpl.class, AssetJpaDao.class, IriGenerator.class, IriValidator.class,
+@ContextConfiguration(classes = {AssetStoreTest.TestApplication.class, AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class, IriGenerator.class, IriValidator.class,
   AssetStoreTest.class, Neo4jGraphStore.class, DatabaseConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
   DidResolverConfig.class, HttpDocumentResolver.class, FileStoreConfig.class, RdfContentTypeProperties.class})
 @Slf4j

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
@@ -1,14 +1,39 @@
 package eu.xfsc.fc.graphdb.service;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
+import eu.xfsc.fc.core.config.DatabaseConfig;
+import eu.xfsc.fc.core.config.DidResolverConfig;
+import eu.xfsc.fc.core.config.DocumentLoaderConfig;
+import eu.xfsc.fc.core.config.DocumentLoaderProperties;
+import eu.xfsc.fc.core.config.FileStoreConfig;
+import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
+import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
+import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.pojo.CredentialClaim;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResultOffering;
+import eu.xfsc.fc.core.pojo.GraphQuery;
+import eu.xfsc.fc.core.service.assetstore.AssetStoreImpl;
+import eu.xfsc.fc.core.service.assetstore.IriGenerator;
+import eu.xfsc.fc.core.service.assetstore.IriValidator;
+import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
+import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
+import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
+import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
+import eu.xfsc.fc.core.service.verification.FormatDetector;
+import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
+import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
+import eu.xfsc.fc.core.service.verification.SchemaValidationServiceImpl;
+import eu.xfsc.fc.core.service.verification.Vc11Processor;
+import eu.xfsc.fc.core.service.verification.Vc2Processor;
+import eu.xfsc.fc.core.service.verification.VerificationServiceImpl;
+import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
+import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
+import eu.xfsc.fc.graphdb.config.GraphDbConfig;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,38 +50,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
-import eu.xfsc.fc.core.config.DatabaseConfig;
-import eu.xfsc.fc.core.config.DidResolverConfig;
-import eu.xfsc.fc.core.config.DocumentLoaderConfig;
-import eu.xfsc.fc.core.config.DocumentLoaderProperties;
-import eu.xfsc.fc.core.config.FileStoreConfig;
-import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
-import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
-import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
-import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
-import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
-import eu.xfsc.fc.core.pojo.GraphQuery;
-import eu.xfsc.fc.core.pojo.CredentialClaim;
-import eu.xfsc.fc.core.pojo.AssetMetadata;
-import eu.xfsc.fc.core.pojo.CredentialVerificationResultOffering;
-import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
-import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
-import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
-import eu.xfsc.fc.core.service.assetstore.AssetStoreImpl;
-import eu.xfsc.fc.core.service.assetstore.IriGenerator;
-import eu.xfsc.fc.core.service.assetstore.IriValidator;
-import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
-import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
-import eu.xfsc.fc.core.service.verification.SchemaValidationServiceImpl;
-import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
-import eu.xfsc.fc.core.service.verification.Vc11Processor;
-import eu.xfsc.fc.core.service.verification.Vc2Processor;
-import eu.xfsc.fc.core.service.verification.VerificationServiceImpl;
-import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
-import eu.xfsc.fc.graphdb.config.GraphDbConfig;
-import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
-import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
-import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -68,7 +69,8 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 	DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
 	CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
 	JwtContentPreprocessor.class, Vc11Processor.class, Vc2Processor.class,
-	JwtSignatureVerifier.class, DidDocumentResolver.class})
+	JwtSignatureVerifier.class, DidDocumentResolver.class,
+	FormatDetector.class, LoireJwtParser.class})
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 @Import(EmbeddedNeo4JConfig.class)
 public class Neo4jGraphStoreAccuracyTest {
@@ -321,9 +323,7 @@ public class Neo4jGraphStoreAccuracyTest {
 
 
     List<Map<String, Object>> responseCypherByLocality = neo4jGraphStore.queryData(queryCypherByLocality).getResults();
-    Map<String, Object>  resultActualMap = responseCypherByLocality.getFirst();
     Assertions.assertEquals(2,responseCypherByLocality.size());
-    //Assertions.assertEquals(Collections.singletonList("http://example.org/test-issuer2"), resultActualMap.get("n.claimsGraphUri"));
 
     //cleanup
     neo4jGraphStore.deleteClaims(credentialSubject1);

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
@@ -6,8 +6,9 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
-import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
+import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
@@ -65,7 +66,7 @@ import java.util.Map;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {Neo4jGraphStoreAccuracyTest.TestApplication.class, DatabaseConfig.class, GraphDbConfig.class, FileStoreConfig.class, Neo4jGraphStoreAccuracyTest.class,
 	Neo4jGraphStore.class, AssetStoreImpl.class, AssetJpaDao.class, IriGenerator.class, IriValidator.class,
-	VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, ValidatorCacheJpaDao.class,
+	VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, ValidatorCacheJpaDao.class,
 	DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
 	CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
 	JwtContentPreprocessor.class, Vc11Processor.class, Vc2Processor.class,

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
@@ -6,6 +6,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
@@ -65,7 +66,7 @@ import java.util.Map;
 @SpringBootTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {Neo4jGraphStoreAccuracyTest.TestApplication.class, DatabaseConfig.class, GraphDbConfig.class, FileStoreConfig.class, Neo4jGraphStoreAccuracyTest.class,
-	Neo4jGraphStore.class, AssetStoreImpl.class, AssetJpaDao.class, IriGenerator.class, IriValidator.class,
+	Neo4jGraphStore.class, AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class, IriGenerator.class, IriValidator.class,
 	VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, ValidatorCacheJpaDao.class,
 	DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
 	CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/Asset.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/Asset.java
@@ -66,4 +66,7 @@ public class Asset {
 
   @Column(name = "original_filename", length = 500)
   private String originalFilename;
+
+  @Column(name = "change_comment", columnDefinition = "TEXT")
+  private String changeComment;
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetAuditRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetAuditRepository.java
@@ -1,0 +1,187 @@
+package eu.xfsc.fc.core.dao.assets;
+
+import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.assetstore.AssetRecord;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.query.AuditEntity;
+import org.springframework.stereotype.Repository;
+
+import eu.xfsc.fc.core.pojo.PaginatedResults;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.hibernate.envers.query.AuditQuery;
+
+/**
+ * Encapsulates Hibernate Envers audit queries for {@link Asset}.
+ * Keeps Envers-specific types out of {@link AssetJpaDao}.
+ *
+ * <p>Version numbers are 1-based ordinals computed from the Envers revision order.
+ * The list is returned descending (newest first).
+ * Status override at query time: non-current, non-REVOKED snapshots display as DEPRECATED.
+ */
+@Repository
+@RequiredArgsConstructor
+public class AssetAuditRepository {
+
+  private final EntityManager entityManager;
+
+  /**
+   * Return all versions of an asset entity, ordered descending (newest first).
+   *
+   * <p>Status override: snapshots that are not the current (latest) version and are not REVOKED
+   * are displayed with status DEPRECATED, reflecting that they have been superseded.
+   *
+   * @param entityId the surrogate PK of the Asset
+   * @return list of asset records with 1-based version numbers, newest first
+   */
+  @SuppressWarnings("unchecked") // Envers API returns raw List<Object[]>; cast is safe per forRevisionsOfEntity contract
+  List<AssetRecord> findAllVersions(Long entityId) {
+    List<Object[]> revisions = baseRevisionsQuery(entityId).getResultList();
+
+    int total = revisions.size();
+    List<AssetRecord> result = new ArrayList<>(total);
+    for (int i = 0; i < total; i++) {
+      int version = total - i;
+      boolean isCurrent = (i == 0);
+      result.add(toRecord(revisions.get(i), version, isCurrent));
+    }
+    return result;
+  }
+
+  @SuppressWarnings("unchecked") // Envers API returns raw List<Object[]>; cast is safe per forRevisionsOfEntity contract
+  private List<AssetRecord> findVersionsPage(Long entityId, int page, int size, int total) {
+    if (total == 0) {
+      return List.of();
+    }
+    int offset = page * size;
+    int maxResults = Math.min(size, total - offset);
+    if (maxResults <= 0) {
+      return List.of();
+    }
+
+    List<Object[]> revisions = baseRevisionsQuery(entityId)
+        .setFirstResult(offset)
+        .setMaxResults(maxResults)
+        .getResultList();
+
+    List<AssetRecord> result = new ArrayList<>(revisions.size());
+    for (int i = 0; i < revisions.size(); i++) {
+      int version = total - (offset + i);
+      boolean isCurrent = (version == total);
+      result.add(toRecord(revisions.get(i), version, isCurrent));
+    }
+    return result;
+  }
+
+  /**
+   * Return a specific version of an asset entity.
+   *
+   * @param entityId the surrogate PK of the Asset
+   * @param version  1-based version ordinal
+   * @return the asset record at that version, or empty if out of range
+   */
+  @SuppressWarnings("unchecked") // Envers API returns raw List<Object[]>; cast is safe per forRevisionsOfEntity contract
+  Optional<AssetRecord> findVersion(Long entityId, int version) {
+    if (version < 1) {
+      return Optional.empty();
+    }
+    // Pre-count is required to compute isCurrent and previousVersion/nextVersion navigation links.
+    // Unlike SchemaAuditRepository, asset versions carry link metadata that needs the total.
+    int total = countVersions(entityId);
+    if (version > total) {
+      return Optional.empty();
+    }
+
+    List<Object[]> revisions = baseRevisionsQuery(entityId)
+        .setFirstResult(total - version)
+        .setMaxResults(1)
+        .getResultList();
+
+    if (revisions.isEmpty()) {
+      return Optional.empty();
+    }
+    boolean isCurrent = (version == total);
+    return Optional.of(toRecord(revisions.getFirst(), version, isCurrent));
+  }
+
+  /**
+   * Count the number of Envers revisions for an asset entity.
+   *
+   * @param entityId the surrogate PK of the Asset
+   * @return revision count
+   */
+  int countVersions(Long entityId) {
+    Long count = (Long) AuditReaderFactory.get(entityManager).createQuery()
+        .forRevisionsOfEntity(Asset.class, false, true)
+        .add(AuditEntity.id().eq(entityId))
+        .addProjection(AuditEntity.revisionNumber().count())
+        .getSingleResult();
+    return count.intValue();
+  }
+
+  /**
+   * Return a paginated page of versions together with the total revision count,
+   * using a single {@link #countVersions} call and one page query.
+   *
+   * @param entityId the surrogate PK of the Asset
+   * @param page     0-based page index
+   * @param size     page size
+   * @return paginated results; total is 0 if no revisions exist
+   */
+  PaginatedResults<AssetRecord> findVersionsPageWithTotal(Long entityId, int page, int size) {
+    int total = countVersions(entityId);
+    if (total == 0) {
+      return new eu.xfsc.fc.core.pojo.PaginatedResults<>(0, List.of());
+    }
+    List<AssetRecord> items = findVersionsPage(entityId, page, size, total);
+    return new eu.xfsc.fc.core.pojo.PaginatedResults<>(total, items);
+  }
+
+  @SuppressWarnings("unchecked") // Envers API returns raw AuditQuery; cast of getResultList() result is safe
+  private AuditQuery baseRevisionsQuery(Long entityId) {
+    return AuditReaderFactory.get(entityManager).createQuery()
+        .forRevisionsOfEntity(Asset.class, false, true)
+        .add(AuditEntity.id().eq(entityId))
+        .addOrder(AuditEntity.revisionNumber().desc());
+  }
+
+  private AssetRecord toRecord(Object[] revision, int version, boolean isCurrent) {
+    Asset snapshot = (Asset) revision[0];
+    DefaultRevisionEntity revEntity = (DefaultRevisionEntity) revision[1];
+    Instant revTimestamp = Instant.ofEpochMilli(revEntity.getTimestamp());
+
+    // Envers records the state at time of mutation; in-place UPDATE leaves all historical snapshots
+    // with ACTIVE status, but semantically older versions are superseded. Compute display status here.
+    AssetStatus snapshotStatusEnum = AssetStatus.values()[snapshot.getStatus()];
+    AssetStatus displayStatus = isCurrent ? snapshotStatusEnum : switch (snapshotStatusEnum) {
+      case REVOKED -> AssetStatus.REVOKED;
+      default -> AssetStatus.DEPRECATED;
+    };
+
+    AssetRecord record = AssetRecord.builder()
+        .assetHash(snapshot.getAssetHash())
+        .id(snapshot.getSubjectId())
+        .issuer(snapshot.getIssuer())
+        .uploadTime(revTimestamp)
+        .statusTime(snapshot.getStatusTime())
+        .expirationTime(snapshot.getExpirationTime())
+        .status(displayStatus)
+        .content(snapshot.getContent() == null ? null : new ContentAccessorDirect(snapshot.getContent()))
+        .validatorDids(snapshot.getValidators() == null ? null : Arrays.asList(snapshot.getValidators()))
+        .contentType(snapshot.getContentType())
+        .fileSize(snapshot.getFileSize())
+        .originalFilename(snapshot.getOriginalFilename())
+        .changeComment(snapshot.getChangeComment())
+        .build();
+    record.setVersion(version);
+    record.setIsCurrent(isCurrent);
+    return record;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetDao.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetDao.java
@@ -21,4 +21,8 @@ public interface AssetDao {
 	SubjectStatusRecord delete(String hash);
 	int deleteAll();
 
+	List<AssetRecord> selectVersions(String subjectId);
+	PaginatedResults<AssetRecord> selectVersionsPageWithTotal(String subjectId, int page, int size);
+	Optional<AssetRecord> selectVersion(String subjectId, int version);
+	int getVersionCount(String subjectId);
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetJpaDao.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetJpaDao.java
@@ -6,23 +6,24 @@ import eu.xfsc.fc.core.pojo.PaginatedResults;
 import eu.xfsc.fc.core.service.assetstore.AssetRecord;
 import eu.xfsc.fc.core.service.assetstore.SubjectHashRecord;
 import eu.xfsc.fc.core.service.assetstore.SubjectStatusRecord;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
-@Component
+@Repository
 @RequiredArgsConstructor
 public class AssetJpaDao implements AssetDao {
 
     private static final short ACTIVE_STATUS = (short) AssetStatus.ACTIVE.ordinal();
 
     private final AssetRepository repository;
+    private final AssetAuditRepository auditRepository;
 
     @Override
     public Optional<AssetRecord> selectBySubjectId(String subjectId) {
@@ -71,21 +72,30 @@ public class AssetJpaDao implements AssetDao {
         Optional<Asset> existing = repository.findBySubjectIdAndStatus(
                 assetRecord.getId(), ACTIVE_STATUS);
 
-        String oldSubjectId = null;
-        String oldHash = null;
         if (existing.isPresent()) {
+            // Update existing row in-place. Envers intercepts the flush and records
+            // the pre-update state as a new revision in assets_aud automatically.
             Asset old = existing.get();
-            oldSubjectId = old.getSubjectId();
-            oldHash = old.getAssetHash();
-            old.setStatus((short) AssetStatus.DEPRECATED.ordinal());
-            old.setStatusTime(Instant.now());
+            old.setAssetHash(assetRecord.getAssetHash());
+            old.setContent(assetRecord.getContent());
+            old.setChangeComment(assetRecord.getChangeComment());
+            old.setUploadTime(assetRecord.getUploadDatetime());
+            old.setStatusTime(assetRecord.getStatusDatetime());
+            old.setIssuer(assetRecord.getIssuer());
+            old.setExpirationTime(assetRecord.getExpirationTime());
+            old.setValidators(assetRecord.getValidators());
+            old.setContentType(assetRecord.getContentType());
+            old.setFileSize(assetRecord.getFileSize());
+            old.setOriginalFilename(assetRecord.getOriginalFilename());
+            old.setStatus(ACTIVE_STATUS);
             repository.saveAndFlush(old);
+            return new SubjectHashRecord(old.getSubjectId(), old.getAssetHash());
         }
 
         Asset newEntity = AssetMapper.toEntity(assetRecord);
         repository.save(newEntity);
 
-        return new SubjectHashRecord(oldSubjectId, oldHash);
+        return new SubjectHashRecord(null, null);
     }
 
     @Override
@@ -117,5 +127,36 @@ public class AssetJpaDao implements AssetDao {
     @Transactional
     public int deleteAll() {
         return repository.deleteAllReturningCount();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AssetRecord> selectVersions(String subjectId) {
+        return repository.findBySubjectId(subjectId)
+            .map(entity -> auditRepository.findAllVersions(entity.getId()))
+            .orElse(List.of());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PaginatedResults<AssetRecord> selectVersionsPageWithTotal(String subjectId, int page, int size) {
+        return repository.findBySubjectId(subjectId)
+            .map(entity -> auditRepository.findVersionsPageWithTotal(entity.getId(), page, size))
+            .orElse(new PaginatedResults<>(0, List.of()));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<AssetRecord> selectVersion(String subjectId, int version) {
+        return repository.findBySubjectId(subjectId)
+            .flatMap(entity -> auditRepository.findVersion(entity.getId(), version));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public int getVersionCount(String subjectId) {
+        return repository.findBySubjectId(subjectId)
+            .map(entity -> auditRepository.countVersions(entity.getId()))
+            .orElse(0);
     }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetMapper.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetMapper.java
@@ -29,6 +29,7 @@ public final class AssetMapper {
         .contentType(entity.getContentType())
         .fileSize(entity.getFileSize())
         .originalFilename(entity.getOriginalFilename())
+        .changeComment(entity.getChangeComment())
         .build();
   }
 
@@ -50,6 +51,7 @@ public final class AssetMapper {
     entity.setContentType(record.getContentType());
     entity.setFileSize(record.getFileSize());
     entity.setOriginalFilename(record.getOriginalFilename());
+    entity.setChangeComment(record.getChangeComment());
     return entity;
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetRepository.java
@@ -17,6 +17,8 @@ public interface AssetRepository
 
   Optional<Asset> findBySubjectIdAndStatus(String subjectId, short status);
 
+  Optional<Asset> findBySubjectId(String subjectId);
+
   @Query("""
     SELECT a.assetHash
     FROM Asset a

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunkRepositoryCustomImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunkRepositoryCustomImpl.java
@@ -21,7 +21,7 @@ public class RevalidatorChunkRepositoryCustomImpl implements RevalidatorChunkRep
     String sql = """
         UPDATE revalidatorchunks SET lastcheck = now()
         WHERE chunkid = (SELECT chunkid FROM revalidatorchunks
-          WHERE lastcheck < (SELECT updatetime FROM schemafiles WHERE type = ?1 ORDER BY updatetime DESC LIMIT 1)
+          WHERE lastcheck < (SELECT created_at FROM schemafiles WHERE type = ?1 ORDER BY created_at DESC LIMIT 1)
           ORDER BY chunkid LIMIT 1)
         RETURNING chunkid""";
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaAuditRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaAuditRepository.java
@@ -1,0 +1,102 @@
+package eu.xfsc.fc.core.dao.schemas;
+
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.envers.AuditReaderFactory;
+import org.hibernate.envers.DefaultRevisionEntity;
+import org.hibernate.envers.query.AuditEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Encapsulates Hibernate Envers audit queries for {@link SchemaFile}.
+ * Keeps Envers-specific types out of {@link SchemaJpaDao}.
+ */
+@Repository
+@RequiredArgsConstructor
+public class SchemaAuditRepository {
+
+  private final EntityManager entityManager;
+
+  /**
+   * Return all versions of a schema entity in a single query, ordered ascending.
+   *
+   * @param entityId the surrogate PK of the SchemaFile
+   * @return list of schema records with version numbers (1-based)
+   */
+  @SuppressWarnings("unchecked") // Envers API returns raw List<Object[]>; cast is safe per forRevisionsOfEntity contract
+  List<SchemaRecord> findAllVersions(Long entityId) {
+    List<Object[]> revisions = AuditReaderFactory.get(entityManager).createQuery()
+        .forRevisionsOfEntity(SchemaFile.class, false, true)
+        .add(AuditEntity.id().eq(entityId))
+        .addOrder(AuditEntity.revisionNumber().asc())
+        .getResultList();
+
+    List<SchemaRecord> result = new ArrayList<>(revisions.size());
+    for (int i = 0; i < revisions.size(); i++) {
+      result.add(toRecord(revisions.get(i), i + 1));
+    }
+    return result;
+  }
+
+  /**
+   * Return a specific version of a schema entity.
+   *
+   * @param entityId the surrogate PK of the SchemaFile
+   * @param version  1-based version ordinal
+   * @return the schema record at that version, or empty if out of range
+   */
+  @SuppressWarnings("unchecked") // Envers API returns raw List<Object[]>; cast is safe per forRevisionsOfEntity contract
+  Optional<SchemaRecord> findVersion(Long entityId, int version) {
+    if (version < 1) {
+      return Optional.empty();
+    }
+    List<Object[]> revisions = AuditReaderFactory.get(entityManager).createQuery()
+        .forRevisionsOfEntity(SchemaFile.class, false, true)
+        .add(AuditEntity.id().eq(entityId))
+        .addOrder(AuditEntity.revisionNumber().asc())
+        .setFirstResult(version - 1)
+        .setMaxResults(1)
+        .getResultList();
+
+    if (revisions.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(toRecord(revisions.getFirst(), version));
+  }
+
+  /**
+   * Count the number of Envers revisions for a schema entity.
+   *
+   * @param entityId the surrogate PK of the SchemaFile
+   * @return revision count
+   */
+  int countVersions(Long entityId) {
+    Long count = (Long) AuditReaderFactory.get(entityManager).createQuery()
+        .forRevisionsOfEntity(SchemaFile.class, false, true)
+        .add(AuditEntity.id().eq(entityId))
+        .addProjection(AuditEntity.revisionNumber().count())
+        .getSingleResult();
+    return count.intValue();
+  }
+
+  private SchemaRecord toRecord(Object[] revision, int version) {
+    SchemaFile snapshot = (SchemaFile) revision[0];
+    DefaultRevisionEntity revEntity = (DefaultRevisionEntity) revision[1];
+    Instant revTimestamp = Instant.ofEpochMilli(revEntity.getTimestamp());
+    Set<String> terms = snapshot.getTerms() == null ? new HashSet<>()
+        : snapshot.getTerms().stream().map(SchemaTerm::getTerm).collect(Collectors.toSet());
+    return new SchemaRecord(
+        snapshot.getSchemaId(), snapshot.getNameHash(), snapshot.getType(),
+        revTimestamp, snapshot.getModifiedAt(), snapshot.getContent(), terms, version);
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaDao.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaDao.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.dao.schemas;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -18,5 +19,30 @@ public interface SchemaDao {
 	String delete(String schemaId);
 	int deleteAll();
 	Optional<String> selectLatestContentByType(String typeName);
+
+	/**
+	 * Return all versions of the schema, ordered ascending by version number.
+	 *
+	 * @param schemaId the schema identifier
+	 * @return list of schema records with version numbers, or empty list if not found
+	 */
+	List<SchemaRecord> selectVersions(String schemaId);
+
+	/**
+	 * Return a specific version of the schema.
+	 *
+	 * @param schemaId the schema identifier
+	 * @param version  1-based version ordinal
+	 * @return the schema record at that version, or empty if not found
+	 */
+	Optional<SchemaRecord> selectVersion(String schemaId, int version);
+
+	/**
+	 * Return the number of Envers revisions for a schema (i.e. version count).
+	 *
+	 * @param schemaId the schema identifier
+	 * @return revision count, or 0 if schema not found
+	 */
+	int getVersionCount(String schemaId);
 
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFile.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFile.java
@@ -42,11 +42,11 @@ public class SchemaFile {
   @Column(name = "namehash", length = 64, nullable = false)
   private String nameHash;
 
-  @Column(name = "uploadtime", nullable = false)
-  private Instant uploadTime;
+  @Column(name = "created_at", nullable = false)
+  private Instant createdAt;
 
-  @Column(name = "updatetime", nullable = false)
-  private Instant updateTime;
+  @Column(name = "modified_at", nullable = false)
+  private Instant modifiedAt;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "type", length = 20, nullable = false)

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFileMapper.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFileMapper.java
@@ -22,8 +22,8 @@ public final class SchemaFileMapper {
         entity.getSchemaId(),
         entity.getNameHash(),
         entity.getType(),
-        entity.getUploadTime(),
-        entity.getUpdateTime(),
+        entity.getCreatedAt(),
+        entity.getModifiedAt(),
         entity.getContent(),
         terms);
   }
@@ -36,8 +36,8 @@ public final class SchemaFileMapper {
     entity.setSchemaId(record.getId());
     entity.setNameHash(record.nameHash());
     entity.setType(record.type());
-    entity.setUploadTime(record.uploadTime());
-    entity.setUpdateTime(record.updateTime());
+    entity.setCreatedAt(record.createdAt());
+    entity.setModifiedAt(record.modifiedAt());
     entity.setContent(record.content());
     if (record.terms() != null) {
       Set<SchemaTerm> termEntities = record.terms().stream().map(term -> {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFileRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaFileRepository.java
@@ -33,7 +33,7 @@ public interface SchemaFileRepository
     SELECT e.content
     FROM SchemaFile e
     WHERE e.type = :type
-    ORDER BY e.uploadTime DESC LIMIT 1
+    ORDER BY e.createdAt DESC LIMIT 1
   """)
   Optional<String> findLatestContentByType(@Param("type") SchemaType type);
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaJpaDao.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/schemas/SchemaJpaDao.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 public class SchemaJpaDao implements SchemaDao {
 
   private final SchemaFileRepository repository;
+  private final SchemaAuditRepository auditHelper;
 
   @Override
   public int getSchemaCount() {
@@ -72,7 +73,7 @@ public class SchemaJpaDao implements SchemaDao {
   public void update(String id, String content, Collection<String> terms) {
       SchemaFile entity = repository.findBySchemaId(id)
         .orElseThrow(() -> new NotFoundException("Schema with id " + id + " was not found"));
-    entity.setUpdateTime(Instant.now());
+    entity.setModifiedAt(Instant.now());
     entity.setContent(content);
     entity.getTerms().clear();
     if (terms != null) {
@@ -107,6 +108,29 @@ public class SchemaJpaDao implements SchemaDao {
   @Override
   public Optional<String> selectLatestContentByType(String typeName) {
     return repository.findLatestContentByType(SchemaType.valueOf(typeName));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<SchemaRecord> selectVersions(String schemaId) {
+    return repository.findBySchemaId(schemaId)
+        .map(entity -> auditHelper.findAllVersions(entity.getId()))
+        .orElse(List.of());
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public Optional<SchemaRecord> selectVersion(String schemaId, int version) {
+    return repository.findBySchemaId(schemaId)
+        .flatMap(entity -> auditHelper.findVersion(entity.getId(), version));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public int getVersionCount(String schemaId) {
+    return repository.findBySchemaId(schemaId)
+        .map(entity -> auditHelper.countVersions(entity.getId()))
+        .orElse(0);
   }
 
   private Map<String, Collection<String>> aggregateToMap(List<Object[]> rows) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/AssetMetadata.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/AssetMetadata.java
@@ -1,41 +1,64 @@
 package eu.xfsc.fc.core.pojo;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import eu.xfsc.fc.api.generated.model.Asset;
 import eu.xfsc.fc.api.generated.model.AssetStatus;
-
-import static eu.xfsc.fc.core.util.HashUtils.calculateSha256AsHex;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static eu.xfsc.fc.core.util.HashUtils.calculateSha256AsHex;
+
 
 /**
  * Class for handling the metadata of an Asset, and optionally a
  * reference to a content accessor.
  */
-@lombok.AllArgsConstructor
-@lombok.NoArgsConstructor
+@AllArgsConstructor
+@NoArgsConstructor
 public class AssetMetadata extends Asset {
 
   /**
    * A reference to the asset content.
    */
-  @lombok.Getter
-  @lombok.Setter
+  @Getter
+  @Setter
   @JsonIgnore
   private ContentAccessor contentAccessor;
 
+  /** Optional change note for this version, set by the caller before storing. */
+  @Getter
+  @Setter
+  @JsonIgnore
+  private String changeComment;
+
+  /**
+   * Creates asset metadata from explicit fields; computes the SHA-256 hash from content.
+   *
+   * @param id              asset IRI
+   * @param issuer          credential issuer DID
+   * @param validators      validator list
+   * @param contentAccessor raw credential content
+   */
   public AssetMetadata(String id, String issuer, List<Validator> validators, ContentAccessor contentAccessor) {
     super(calculateSha256AsHex(contentAccessor.getContentAsString()), id, AssetStatus.ACTIVE, issuer,
         validators != null ? validators.stream().map(Validator::getDidURI).collect(Collectors.toList()) : null, Instant.now(), Instant.now(),
-        null, null, null);
+        null, null, null); // null: contentType, fileSize, warnings
     this.contentAccessor = contentAccessor;
   }
 
+  /**
+   * Creates asset metadata from a verification result.
+   *
+   * @param contentAccessor    raw credential content
+   * @param verificationResult verification result supplying id, issuer, validators, and timestamps
+   */
   public AssetMetadata(ContentAccessor contentAccessor, CredentialVerificationResult verificationResult) {
     super(calculateSha256AsHex(contentAccessor.getContentAsString()), verificationResult.getId(), AssetStatus.ACTIVE,
             verificationResult.getIssuer(), verificationResult.getValidatorDids(), verificationResult.getIssuedDateTime(),
@@ -43,9 +66,23 @@ public class AssetMetadata extends Asset {
     this.contentAccessor = contentAccessor;
   }
 
-  public AssetMetadata(String assetHash, String id, AssetStatus status, String issuer, List<String> validatorDids, Instant uploadTime, Instant statusTime, ContentAccessor contentAccessor) {
-	super(assetHash, id, status, issuer, validatorDids, uploadTime, statusTime, null, null, null);
-	this.contentAccessor = contentAccessor;
+  /**
+   * Creates asset metadata from all explicit fields, bypassing hash computation.
+   *
+   * @param assetHash      pre-computed SHA-256 content hash
+   * @param id             asset IRI
+   * @param status         lifecycle status
+   * @param issuer         credential issuer DID
+   * @param validatorDids  validator DID list
+   * @param uploadTime     upload timestamp
+   * @param statusTime     last status-change timestamp
+   * @param contentAccessor raw content, or null for binary assets
+   */
+  public AssetMetadata(String assetHash, String id, AssetStatus status, String issuer,
+      List<String> validatorDids, Instant uploadTime, Instant statusTime,
+      ContentAccessor contentAccessor) {
+    super(assetHash, id, status, issuer, validatorDids, uploadTime, statusTime, null, null, null); // null: contentType, fileSize, warnings
+    this.contentAccessor = contentAccessor;
   }
   
   @Override

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetRecord.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetRecord.java
@@ -21,12 +21,34 @@ public class AssetRecord extends AssetMetadata {
   private Instant expirationTime;
   @Setter
   private String originalFilename;
+  /** 1-based version ordinal from Envers revision order. Null when not in a version-history context. */
+  @Setter
+  private Integer version;
+  /** Whether this is the current (latest) version. Null when not in a version-history context. */
+  @Setter
+  private Boolean isCurrent;
 
-  public AssetRecord(String id, String issuer, List<Validator> validators, ContentAccessor contentAccessor, Instant expirationTime) {
+  /**
+   * Creates a record from explicit metadata fields.
+   *
+   * @param id              asset IRI / subjectId
+   * @param issuer          credential issuer DID
+   * @param validators      validator list
+   * @param contentAccessor raw content
+   * @param expirationTime  earliest validator expiry, or null
+   */
+  public AssetRecord(String id, String issuer, List<Validator> validators,
+      ContentAccessor contentAccessor, Instant expirationTime) {
     super(id, issuer, validators, contentAccessor);
     this.expirationTime = expirationTime;
   }
 
+  /**
+   * Creates a record from a verification result, deriving expiration from the earliest validator.
+   *
+   * @param contentAccessor     raw credential content
+   * @param verificationResult  result of credential verification
+   */
   public AssetRecord(ContentAccessor contentAccessor, CredentialVerificationResult verificationResult) {
     super(contentAccessor, verificationResult);
     final List<Validator> validators = verificationResult.getValidators();
@@ -36,15 +58,33 @@ public class AssetRecord extends AssetMetadata {
     }
   }
 
+  /**
+   * Creates a record from explicit fields.
+   *
+   * @param assetHash       SHA-256 content hash
+   * @param id              asset IRI / subjectId
+   * @param status          lifecycle status
+   * @param issuer          credential issuer DID
+   * @param validatorDids   validator DID list
+   * @param uploadTime      upload timestamp
+   * @param statusTime      last status-change timestamp
+   * @param content         raw content accessor
+   * @param expirationTime  earliest validator expiry, or null
+   * @param contentType     MIME type
+   * @param fileSize        file size in bytes, or null
+   * @param originalFilename original filename for binary uploads, or null
+   * @param changeComment   optional change note for this version
+   */
   @Builder
   public AssetRecord(String assetHash, String id, AssetStatus status, String issuer, List<String> validatorDids,
       Instant uploadTime, Instant statusTime, ContentAccessor content, Instant expirationTime,
-      String contentType, Long fileSize, String originalFilename) {
-	super(assetHash, id, status, issuer, validatorDids, uploadTime, statusTime, content);
-	this.expirationTime = expirationTime;
-	setContentType(contentType);
-	setFileSize(fileSize);
-	this.originalFilename = originalFilename;
+      String contentType, Long fileSize, String originalFilename, String changeComment) {
+    super(assetHash, id, status, issuer, validatorDids, uploadTime, statusTime, content);
+    this.expirationTime = expirationTime;
+    setContentType(contentType);
+    setFileSize(fileSize);
+    this.originalFilename = originalFilename;
+    setChangeComment(changeComment);
   }
 
   public String getContent() {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
@@ -129,4 +129,35 @@ public interface AssetStore {
    */
   void clear();
 
+  /**
+   * Returns a paginated page of asset versions in descending order (newest first),
+   * plus the total version count.
+   *
+   * @param id   The IRI (subjectId) of the asset.
+   * @param page 0-based page index.
+   * @param size Page size.
+   * @return Paginated results containing version records.
+   * @throws eu.xfsc.fc.core.exception.NotFoundException if asset does not exist.
+   */
+  PaginatedResults<AssetRecord> getVersionHistoryPage(String id, int page, int size);
+
+  /**
+   * Returns a specific version (1-based ordinal) of the asset.
+   *
+   * @param id      The IRI (subjectId) of the asset.
+   * @param version 1-based version ordinal.
+   * @return The asset record at that version.
+   * @throws eu.xfsc.fc.core.exception.NotFoundException if asset or version does not exist.
+   */
+  AssetRecord getByIdAndVersion(String id, int version);
+
+  /**
+   * Returns the total number of versions of the asset.
+   *
+   * @param id The IRI (subjectId) of the asset.
+   * @return Total version count.
+   * @throws eu.xfsc.fc.core.exception.NotFoundException if asset does not exist.
+   */
+  int getVersionCount(String id);
+
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
@@ -1,16 +1,5 @@
 package eu.xfsc.fc.core.service.assetstore;
 
-import java.io.IOException;
-import java.time.Instant;
-import java.util.List;
-
-import org.apache.commons.lang3.mutable.MutableInt;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
 import eu.xfsc.fc.api.generated.model.AssetStatus;
 import eu.xfsc.fc.core.dao.assets.AssetDao;
 import eu.xfsc.fc.core.exception.ConflictException;
@@ -25,6 +14,16 @@ import eu.xfsc.fc.core.pojo.Validator;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.mutable.MutableInt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
 
 /**
  * File system based implementation of the asset store interface.
@@ -104,6 +103,7 @@ public class AssetStoreImpl implements AssetStore {
         .content(assetMetadata.getContentAccessor())
         .expirationTime(expirationTime)
         .contentType("application/ld+json")
+        .changeComment(assetMetadata.getChangeComment())
         .build();
 
     SubjectHashRecord subjectHash = null;
@@ -240,6 +240,33 @@ public class AssetStoreImpl implements AssetStore {
   public void clear() {
 	int cnt = dao.deleteAll();
     log.debug("clear; deleted {} assets", cnt);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public PaginatedResults<AssetRecord> getVersionHistoryPage(String id, int page, int size) {
+    PaginatedResults<AssetRecord> result = dao.selectVersionsPageWithTotal(id, page, size);
+    if (result.getTotalCount() == 0) {
+      throw new NotFoundException("no asset found for id %s".formatted(id));
+    }
+    return result;
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public AssetRecord getByIdAndVersion(String id, int version) {
+    return dao.selectVersion(id, version)
+        .orElseThrow(() -> new NotFoundException("no asset found for id %s at version %d".formatted(id, version)));
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public int getVersionCount(String id) {
+    int count = dao.getVersionCount(id);
+    if (count == 0) {
+      throw new NotFoundException("no asset found for id %s".formatted(id));
+    }
+    return count;
   }
 
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaRecord.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaRecord.java
@@ -5,10 +5,16 @@ import java.util.Set;
 
 import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
 
-public record SchemaRecord(String schemaId, String nameHash, SchemaType type, Instant uploadTime, Instant updateTime, String content, Set<String> terms) {
+public record SchemaRecord(String schemaId, String nameHash, SchemaType type, Instant createdAt, Instant modifiedAt,
+    String content, Set<String> terms, Integer version) {
+
+  public SchemaRecord(String schemaId, String nameHash, SchemaType type, Instant createdAt, Instant modifiedAt,
+      String content, Set<String> terms) {
+    this(schemaId, nameHash, type, createdAt, modifiedAt, content, terms, null);
+  }
 
   public SchemaRecord(String schemaId, String nameHash, SchemaType type, String content, Set<String> terms) {
-    this(schemaId, nameHash, type, Instant.now(), Instant.now(), content, terms);
+    this(schemaId, nameHash, type, Instant.now(), Instant.now(), content, terms, null);
   }
 
   public String getId() {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStore.java
@@ -172,6 +172,25 @@ public interface SchemaStore {
   ContentAccessor getLatestSchemaByType(SchemaType schemaType);
 
   /**
+   * Get a specific version of the schema.
+   *
+   * @param identifier The identifier of the schema.
+   * @param version    The 1-based version ordinal.
+   * @return The schema record at that version.
+   * @throws eu.xfsc.fc.core.exception.NotFoundException if schema or version not found
+   */
+  SchemaRecord getSchemaVersion(String identifier, int version);
+
+  /**
+   * Get all versions of the schema, ordered ascending by version number.
+   *
+   * @param identifier The identifier of the schema.
+   * @return List of schema records with version metadata.
+   * @throws eu.xfsc.fc.core.exception.NotFoundException if schema not found
+   */
+  List<SchemaRecord> getSchemaVersions(String identifier);
+
+  /**
    * Remove all Schemas from the SchemaStore.
    */
   void clear();

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
@@ -405,10 +405,9 @@ public class SchemaStoreImpl implements SchemaStore {
     // Envers writes audit entries in beforeTransactionCompletion — after all application code
     // in this transaction — so getVersionCount returns N (committed prior revisions only).
     // currentVersion = N+1 is the revision that will be written when this transaction commits.
-    // Thread-safety: saveAndFlush() acquires a DB row lock held for the duration of this
-    // @Transactional, so concurrent updates to the same schema are serialized. By the time a
-    // second thread reaches getVersionCount(), the first has committed and its Envers revision
-    // is visible.
+    // Note: under true concurrent updates, two threads could read the same N and produce
+    // duplicate version numbers. This race is accepted because schema updates are infrequent
+    // administrative operations and the cost of pessimistic locking outweighs the risk.
     int previousVersion = dao.getVersionCount(identifier);
     int currentVersion = previousVersion + 1;
     return new SchemaStoreResult(identifier, analysis.getWarning(), null,

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
@@ -65,7 +65,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 @Component
-@Transactional
 public class SchemaStoreImpl implements SchemaStore {
 
   @Autowired
@@ -375,10 +374,11 @@ public class SchemaStoreImpl implements SchemaStore {
     }
 
     COMPOSITE_SCHEMAS.remove(newRecord.type());
-    return new SchemaStoreResult(newRecord.getId(), analysis.getWarning(), newRecord.uploadTime());
+    return new SchemaStoreResult(newRecord.getId(), analysis.getWarning(), newRecord.createdAt());
   }
 
   @Override
+  @Transactional
   public SchemaStoreResult updateSchema(String identifier, ContentAccessor schema) {
     SchemaRecord existing = dao.select(identifier)
         .orElseThrow(() -> new NotFoundException("Schema with id " + identifier + " was not found"));
@@ -401,7 +401,18 @@ public class SchemaStoreImpl implements SchemaStore {
     }
 
     COMPOSITE_SCHEMAS.remove(newRecord.type());
-    return new SchemaStoreResult(identifier, analysis.getWarning());
+
+    // Envers writes audit entries in beforeTransactionCompletion — after all application code
+    // in this transaction — so getVersionCount returns N (committed prior revisions only).
+    // currentVersion = N+1 is the revision that will be written when this transaction commits.
+    // Thread-safety: saveAndFlush() acquires a DB row lock held for the duration of this
+    // @Transactional, so concurrent updates to the same schema are serialized. By the time a
+    // second thread reaches getVersionCount(), the first has committed and its Envers revision
+    // is visible.
+    int previousVersion = dao.getVersionCount(identifier);
+    int currentVersion = previousVersion + 1;
+    return new SchemaStoreResult(identifier, analysis.getWarning(), null,
+        currentVersion, previousVersion > 0 ? previousVersion : null);
   }
 
   @Override
@@ -453,6 +464,22 @@ public class SchemaStoreImpl implements SchemaStore {
     String content = dao.selectLatestContentByType(type.name())
         .orElseThrow(() -> new NotFoundException("No " + type + " schemas found"));
     return new ContentAccessorDirect(content);
+  }
+
+  @Override
+  public SchemaRecord getSchemaVersion(String identifier, int version) {
+    return dao.selectVersion(identifier, version)
+        .orElseThrow(() -> new NotFoundException(
+            "Schema with id " + identifier + " version " + version + " was not found"));
+  }
+
+  @Override
+  public List<SchemaRecord> getSchemaVersions(String identifier) {
+    List<SchemaRecord> versions = dao.selectVersions(identifier);
+    if (versions.isEmpty()) {
+      throw new NotFoundException("Schema with id " + identifier + " was not found");
+    }
+    return versions;
   }
 
   @Override

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreResult.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreResult.java
@@ -5,13 +5,20 @@ import java.time.Instant;
 /**
  * Result of adding or updating a schema, carrying the identifier and an optional warning.
  *
- * @param id         the internal identifier of the schema
- * @param warning    user-visible warning if protected namespace statements were filtered, or null
- * @param uploadTime timestamp when the schema was uploaded
+ * @param id              the internal identifier of the schema
+ * @param warning         user-visible warning if protected namespace statements were filtered, or null
+ * @param createdAt       timestamp when the schema was first uploaded
+ * @param version         current version number after this operation, or null if not applicable
+ * @param previousVersion version number before this operation, or null if first version
  */
-public record SchemaStoreResult(String id, String warning, Instant uploadTime) {
+public record SchemaStoreResult(String id, String warning, Instant createdAt,
+    Integer version, Integer previousVersion) {
 
   public SchemaStoreResult(String id, String warning) {
-    this(id, warning, null);
+    this(id, warning, null, null, null);
+  }
+
+  public SchemaStoreResult(String id, String warning, Instant createdAt) {
+    this(id, warning, createdAt, null, null);
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormat.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormat.java
@@ -1,0 +1,19 @@
+package eu.xfsc.fc.core.service.verification;
+
+/**
+ * Identifies the credential format so the verification pipeline can route
+ * to the correct parser path.
+ *
+ * <ul>
+ *   <li>{@link #GAIAX_V1_TAGUS} — VC 1.1 with Linked Data Proof (Gaia-X Tagus / ICAM 22.10)</li>
+ *   <li>{@link #GAIAX_V2_LOIRE} — VC 2.0 JWT per VC-JOSE-COSE (Gaia-X Loire / ICAM 24.07)</li>
+ *   <li>{@link #VC2_DANUBETECH} — VC 2.0 JWT with {@code vc}/{@code vp} wrapper claims (danubetech-style)</li>
+ *   <li>{@link #UNKNOWN} — format not recognized; should be rejected with a diagnostic message</li>
+ * </ul>
+ */
+public enum CredentialFormat {
+  GAIAX_V1_TAGUS,
+  GAIAX_V2_LOIRE,
+  VC2_DANUBETECH,
+  UNKNOWN
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
@@ -1,12 +1,15 @@
 package eu.xfsc.fc.core.service.verification;
 
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.JWT_PREFIX;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.RDF_CONTEXT_KEY;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_20_CONTEXT;
+
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.loader.SchemeRouter;
 import com.danubetech.keyformats.jose.JWK;
 import com.danubetech.verifiablecredentials.VerifiableCredential;
 import com.danubetech.verifiablecredentials.VerifiablePresentation;
 import com.danubetech.verifiablecredentials.jsonld.VerifiableCredentialKeywords;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xfsc.fc.api.generated.model.AssetStatus;
@@ -53,6 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -84,12 +88,30 @@ import static eu.xfsc.fc.core.service.verification.TrustFrameworkBaseClass.UNKNO
 public class CredentialVerificationStrategy implements VerificationStrategy {
 
     private static final ClaimExtractor[] extractors = new ClaimExtractor[]{new TitaniumClaimExtractor(), new DanubeTechClaimExtractor()};
-    private static final String VC2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Resolves the {@code type} or {@code @type} value from a JSON-LD map.
+     * ICAM 24.07: "{@code @type} is aliased to {@code type}. Consequently, we MAY also use this alias."
+     */
+    private static Object resolveType(Map<?, ?> map) {
+        Object val = map.get("type");
+        return val != null ? val : map.get("@type");
+    }
+
+    /**
+     * Resolves the {@code id} or {@code @id} value from a JSON-LD map.
+     * ICAM 24.07: "{@code @id} is aliased to {@code id}. Consequently, we MAY also use this alias."
+     */
+    private static Object resolveId(Map<?, ?> map) {
+        Object val = map.get("id");
+        return val != null ? val : map.get("@id");
+    }
 
     @Value("${federated-catalogue.verification.require-vp:true}")
     private boolean requireVP;
-    @Value("${federated-catalogue.verification.drop-validarors:false}")
+    @Value("${federated-catalogue.verification.drop-validators:false}")
     private boolean dropValidators;
 
     /**
@@ -120,6 +142,8 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
     private final Vc11Processor vc11Processor;
     private final Vc2Processor vc2Processor;
     private final JwtSignatureVerifier jwtSignatureVerifier;
+    private final FormatDetector formatDetector;
+    private final LoireJwtParser loireJwtParser;
 
     @Value("${federated-catalogue.verification.trust-framework.gaiax.trust-anchor-url:}")
     private String trustAnchorAddr;
@@ -152,6 +176,17 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         trustFrameworkBaseClassUris.put(PARTICIPANT, participantType);
     }
 
+    /**
+     * Pipeline state carried between verification phases.
+     */
+    private record VerificationContext(
+        String body,
+        CredentialFormat format,
+        boolean isJwt,
+        ContentAccessor payload,
+        Validator jwtValidator
+    ) {}
+
     public CredentialVerificationResult verifyCredential(ContentAccessor payload, boolean strict, TrustFrameworkBaseClass expectedClass,
                                                          boolean verifySemantics, boolean verifySchema, boolean verifyVPSignatures,
                                                          boolean verifyVCSignatures) throws VerificationException {
@@ -159,56 +194,123 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
                 strict, expectedClass, verifySemantics, verifySchema, verifyVPSignatures, verifyVCSignatures);
         long stamp = System.currentTimeMillis();
 
-        // Read content once (fixes double-read)
-        String body = payload.getContentAsString().strip();
-        payload = new ContentAccessorDirect(body, payload.getContentType());
-        boolean isJwt = jwtPreprocessor.isJwtWrapped(payload);
-        // JWT signature verification — fires before unwrap (Issue #12)
-        Validator jwtValidator = null;
-        if (isJwt && (verifyVCSignatures || verifyVPSignatures)) {
-            jwtValidator = jwtSignatureVerifier.verify(body);
-        }
-        // Version dispatch — payload is unwrapped JSON-LD after this point
-        // JWT-wrapped payloads are VC 2.0-only; fall back to vc2Processor when context parse fails
-        boolean isVc2 = isVc2Context(body) || isJwt;
-        payload = (isVc2 ? vc2Processor : vc11Processor).preProcess(payload);
-        // NOTE: CAT-FR-GD-02's VcStructureDetector.isVcStructured() call MUST be placed AFTER this
-        // line, not before — a JWT-wrapped VC 2.0 payload would not be recognised as a VC until unwrapped.
+        VerificationContext ctx = detectAndUnwrap(payload, verifyVCSignatures || verifyVPSignatures);
 
-        // syntactic validation
-        JsonLDObject ld = parseContent(payload);
+        // syntactic + semantic validation
+        JsonLDObject ld = parseContent(ctx.payload());
+        ld.setDocumentLoader(this.documentLoader);
         log.debug("verifyCredential; content parsed, time taken: {}", System.currentTimeMillis() - stamp);
 
-        // see https://gitlab.eclipse.org/eclipse/xfsc/cat/fc-service/-/issues/200
-        // add GAIA-X context(s) if present
-        ld.setDocumentLoader(this.documentLoader);
-
-        // semantic verification
-        long stamp2 = System.currentTimeMillis();
         TypedCredentials typedCredentials = parseCredentials(ld, strict && requireVP, verifySemantics);
-        log.debug("verifyCredential; credentials processed, time taken: {}", System.currentTimeMillis() - stamp2);
 
-        // Gate on gaiaxTrustFrameworkEnabled: non-Gaia-X VC 2.0 credentials have no known TrustFrameworkBaseClass
-        // TODO(gaia-x-loire): when Loire ontology support lands, resolveBaseClass should return the correct
-        //   Loire type for Gaia-X credentials. Remove this gate and let hasClasses() enforce the check unconditionally.
+        // TODO(loire-compatibility): CAT-FR-GD-01 part 3 - Loire Ontology Migration will update resolveBaseClass to handle 2511 namespace types.
         if (verifySemantics && gaiaxTrustFrameworkEnabled && !typedCredentials.hasClasses()) {
             throw new VerificationException("Semantic Error: no proper CredentialSubject found");
         }
 
+        TrustFrameworkBaseClass baseClass = resolvePrimaryBaseClass(typedCredentials, verifySemantics, expectedClass);
+
+        FilteredClaims filtered = extractAndValidateClaims(ctx.payload(), verifySemantics && strict);
+
+        if (verifySchema) {
+            validateSchema(filtered.claims());
+        }
+
+        List<Validator> validators = collectValidators(ctx, ld, typedCredentials,
+                verifySemantics, verifyVCSignatures, verifyVPSignatures);
+
+        CredentialVerificationResult result = assembleResult(baseClass, typedCredentials, filtered.claims(), validators);
+        if (filtered.hasWarning()) {
+            result.setWarnings(List.of(filtered.warning()));
+        }
+
+        stamp = System.currentTimeMillis() - stamp;
+        log.debug("verifyCredential.exit; returning: {}; time taken: {}", result, stamp);
+        return result;
+    }
+
+    public List<CredentialClaim> extractClaims(ContentAccessor payload) {
+        // Make sure our interceptors are in place.
+        initLoaders();
+        List<CredentialClaim> claims = null;
+        for (ClaimExtractor extra : extractors) {
+            try {
+                claims = extra.extractClaims(payload);
+                if (claims != null) {
+                    break;
+                }
+            } catch (Exception ex) {
+                log.error("extractClaims.error using {}", extra.getClass().getName(), ex);
+            }
+        }
+        return claims;
+    }
+
+    public void setBaseClassUri(TrustFrameworkBaseClass baseClass, String uri) {
+        trustFrameworkBaseClassUris.put(baseClass, uri);
+    }
+
+    /**
+     * Phase 1: Detect credential format, verify JWT signature, and unwrap to JSON-LD.
+     * After this method, the payload is always JSON-LD.
+     *
+     * <p>TODO: signature verification could move to a dedicated component when this class is split.
+     */
+    private VerificationContext detectAndUnwrap(ContentAccessor payload, boolean verifySigs) {
+        String body = payload.getContentAsString().strip();
+        payload = new ContentAccessorDirect(body, payload.getContentType());
+
+        CredentialFormat format = formatDetector.detect(payload);
+        // Reject ambiguous/unrecognizable JWTs — non-JWT payloads fall through to
+        // vc11Processor which provides more specific syntactic error messages.
+        if (format == CredentialFormat.UNKNOWN && body.startsWith(JWT_PREFIX)) {
+            throw new ClientException(
+                "Unrecognizable JWT credential format — JWT does not have recognized "
+                    + "typ header or vc/vp wrapper claims");
+        }
+        boolean isJwt = format == CredentialFormat.GAIAX_V2_LOIRE
+            || (format == CredentialFormat.VC2_DANUBETECH && body.startsWith(JWT_PREFIX));
+
+        Validator jwtValidator = null;
+        if (isJwt && verifySigs) {
+            jwtValidator = jwtSignatureVerifier.verify(body);
+        }
+
+        if (format == CredentialFormat.GAIAX_V2_LOIRE && gaiaxTrustFrameworkEnabled) {
+            enforceLoirePolicies(body, jwtValidator);
+        }
+
+        // Version dispatch — unwrap to JSON-LD
+        // NOTE: CAT-FR-GD-02's VcStructureDetector.isVcStructured() call MUST be placed AFTER
+        // unwrapping, not before — a JWT-wrapped VC 2.0 payload would not be recognised as a VC.
+        if (format == CredentialFormat.GAIAX_V2_LOIRE) {
+            payload = loireJwtParser.unwrap(payload);
+        } else if (format == CredentialFormat.GAIAX_V1_TAGUS) {
+            payload = vc11Processor.preProcess(payload);
+        } else if (format == CredentialFormat.VC2_DANUBETECH) {
+            payload = vc2Processor.preProcess(payload);
+        } else {
+            payload = vc11Processor.preProcess(payload);
+        }
+
+        return new VerificationContext(body, format, isJwt, payload, jwtValidator);
+    }
+
+    /**
+     * Phase 2: Resolve the dominant base class from typed credentials and validate type constraints.
+     */
+    private TrustFrameworkBaseClass resolvePrimaryBaseClass(TypedCredentials typedCredentials,
+        boolean verifySemantics, TrustFrameworkBaseClass expectedClass) {
         int partCount = 0;
         int soffCount = 0;
         TrustFrameworkBaseClass baseClass = UNKNOWN;
         Collection<TrustFrameworkBaseClass> baseClasses = typedCredentials.getBaseClasses();
+
         if (baseClasses.size() > 1) {
-            Map<TrustFrameworkBaseClass, Integer> classMap = baseClasses.stream().reduce(new HashMap<>(), (map, e) -> {
-                        map.merge(e, 1, Integer::sum);
-                        return map;
-                    },
-                    (m, m2) -> {
-                        m.putAll(m2);
-                        return m;
-                    }
-            );
+            Map<TrustFrameworkBaseClass, Integer> classMap = baseClasses.stream()
+                .reduce(new HashMap<>(),
+                    (map, e) -> { map.merge(e, 1, Integer::sum); return map; },
+                    (m, m2) -> { m.putAll(m2); return m; });
             partCount = classMap.getOrDefault(PARTICIPANT, 0);
             soffCount = classMap.getOrDefault(SERVICE_OFFERING, 0);
             if (partCount > 0) {
@@ -227,90 +329,110 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
                 throw new VerificationException("Semantic error: credential has several types: " + baseClasses);
             }
             if (expectedClass != UNKNOWN && baseClass != expectedClass) {
-                throw new VerificationException("Semantic error: expected credential of type " + expectedClass + " but found " + baseClass);
+                throw new VerificationException(
+                    "Semantic error: expected credential of type " + expectedClass + " but found " + baseClass);
             }
         }
+        return baseClass;
+    }
 
-        stamp2 = System.currentTimeMillis();
+    /**
+     * Phase 3: Extract claims, filter protected namespaces, and validate subject uniqueness.
+     */
+    private FilteredClaims extractAndValidateClaims(ContentAccessor payload, boolean strictSemantics) {
+        long stamp = System.currentTimeMillis();
         List<CredentialClaim> claims = extractClaims(payload);
-
         FilteredClaims filtered = protectedNamespaceFilter.filterClaims(claims, "claims extraction");
         claims = filtered.claims();
+        log.debug("verifyCredential; claims extracted: {}, time taken: {}",
+                (claims == null ? "null" : claims.size()), System.currentTimeMillis() - stamp);
 
-        log.debug("verifyCredential; claims extracted: {}, time taken: {}", (claims == null ? "null" : claims.size()),
-                System.currentTimeMillis() - stamp2);
+        if (strictSemantics) {
+            validateSubjectUniqueness(claims);
+        }
+        return filtered;
+    }
 
-        if (verifySemantics && strict) {
-            Set<String> subjects = new HashSet<>();
-            Set<String> objects = new HashSet<>();
-            if (claims != null && !claims.isEmpty()) {
-                for (CredentialClaim claim : claims) {
-                    subjects.add(claim.getSubjectString());
-                    objects.add(claim.getObjectString());
-                }
-            }
-            subjects.removeAll(objects);
-
-            if (subjects.size() > 1) {
-                String sep = System.lineSeparator();
-                StringBuilder sb = new StringBuilder("Semantic Errors: There are different subject ids in credential subjects: ").append(sep);
-                for (String s : subjects) {
-                    sb.append(s).append(sep);
-                }
-                throw new VerificationException(sb.toString());
-            } else if (subjects.isEmpty()) {
-                throw new VerificationException("Semantic Errors: There is no uniquely identified credential subject");
+    private void validateSubjectUniqueness(List<CredentialClaim> claims) {
+        Set<String> subjects = new HashSet<>();
+        Set<String> objects = new HashSet<>();
+        if (claims != null && !claims.isEmpty()) {
+            for (CredentialClaim claim : claims) {
+                subjects.add(claim.getSubjectString());
+                objects.add(claim.getObjectString());
             }
         }
+        subjects.removeAll(objects);
 
-        // schema verification
-        if (verifySchema) {
-            eu.xfsc.fc.core.pojo.SchemaValidationResult result = schemaValidationService.validateClaimsAgainstCompositeSchema(claims);
-            if (result == null || !result.isConforming()) {
-                throw new VerificationException("Schema error: " + (result == null ? "unknown" : result.getValidationReport()));
+        if (subjects.size() > 1) {
+            String sep = System.lineSeparator();
+            StringBuilder sb = new StringBuilder(
+                "Semantic Errors: There are different subject ids in credential subjects: ").append(sep);
+            for (String s : subjects) {
+                sb.append(s).append(sep);
             }
+            throw new VerificationException(sb.toString());
+        } else if (subjects.isEmpty()) {
+            throw new VerificationException("Semantic Errors: There is no uniquely identified credential subject");
         }
+    }
 
-        // VP JWT: detect VP type, run semantic holder check, and guard inner VC verification
+    private void validateSchema(List<CredentialClaim> claims) {
+        eu.xfsc.fc.core.pojo.SchemaValidationResult result =
+            schemaValidationService.validateClaimsAgainstCompositeSchema(claims);
+        if (result == null || !result.isConforming()) {
+            throw new VerificationException(
+                "Schema error: " + (result == null ? "unknown" : result.getValidationReport()));
+        }
+    }
+
+    /**
+     * Phase 4: Collect all signature validators — JWT outer, JWT inner VCs, and LD proofs.
+     */
+    private List<Validator> collectValidators(VerificationContext ctx, JsonLDObject ld,
+        TypedCredentials typedCredentials, boolean verifySemantics,
+        boolean verifyVCSignatures, boolean verifyVPSignatures) {
         boolean isVpJwt = false;
-        if (isJwt && jwtValidator != null) {
+        if (ctx.isJwt() && ctx.jwtValidator() != null) {
             try {
-                JWTClaimsSet jwtClaims = SignedJWT.parse(body).getJWTClaimsSet();
+                JWTClaimsSet jwtClaims = SignedJWT.parse(ctx.body()).getJWTClaimsSet();
                 isVpJwt = isVpJwtClaims(jwtClaims);
                 if (verifySemantics) {
                     checkVpJwtHolder(jwtClaims);
                 }
             } catch (java.text.ParseException ex) {
-                // body was already verified by JwtSignatureVerifier — unexpected
-                log.warn("verifyCredential; JWT claims re-parse error: {}", ex.getMessage());
+                log.warn("collectValidators; JWT claims re-parse error: {}", ex.getMessage());
             }
         }
 
-        // signature verification
-        List<Validator> validators;
-        if (isJwt) {
-            validators = jwtValidator != null ? new ArrayList<>(List.of(jwtValidator)) : null;
+        if (ctx.isJwt()) {
+            List<Validator> validators = ctx.jwtValidator() != null
+                ? new ArrayList<>(List.of(ctx.jwtValidator())) : new ArrayList<>();
             if (verifyVCSignatures && isVpJwt) {
-                List<Validator> innerValidators = verifyInnerVcCredentials(ld);
-                if (!innerValidators.isEmpty()) {
-                    if (validators == null) {
-                        validators = innerValidators;
-                    } else {
-                        validators.addAll(innerValidators);
-                    }
+                List<Validator> inner = verifyInnerVcCredentials(ld);
+                if (!inner.isEmpty()) {
+                    validators.addAll(inner);
                 }
             }
-        } else if (verifyVPSignatures || verifyVCSignatures) {
-            validators = checkCryptography(typedCredentials, verifyVPSignatures, verifyVCSignatures);
-        } else {
-            validators = null;
+            return validators;
         }
+        if (verifyVPSignatures || verifyVCSignatures) {
+            return checkCryptography(typedCredentials, verifyVPSignatures, verifyVCSignatures);
+        }
+        return List.of();
+    }
 
+    /**
+     * Phase 5: Build the typed result object based on the resolved base class.
+     */
+    private CredentialVerificationResult assembleResult(TrustFrameworkBaseClass baseClass,
+        TypedCredentials typedCredentials, List<CredentialClaim> claims, List<Validator> validators) {
         String id = typedCredentials.getID();
         String issuer = typedCredentials.getIssuer();
         Instant issuedDate = typedCredentials.getIssuanceDate();
+        Instant now = Instant.now();
+        String status = AssetStatus.ACTIVE.getValue();
 
-        CredentialVerificationResult result;
         if (baseClass == PARTICIPANT) {
             if (issuer == null) {
                 issuer = id;
@@ -318,26 +440,19 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
             String method = typedCredentials.getProofMethod();
             String holder = typedCredentials.getHolder();
             String name = holder == null ? issuer : holder;
-            result = new CredentialVerificationResultParticipant(Instant.now(), AssetStatus.ACTIVE.getValue(), issuer, issuedDate,
+            return new CredentialVerificationResultParticipant(now, status, issuer, issuedDate,
                     claims, validators, name, method);
-        } else if (baseClass == SERVICE_OFFERING) {
-            result = new CredentialVerificationResultOffering(Instant.now(), AssetStatus.ACTIVE.getValue(), issuer, issuedDate,
-                    id, claims, validators);
-        } else if (baseClass == RESOURCE) {
-            result = new CredentialVerificationResultResource(Instant.now(), AssetStatus.ACTIVE.getValue(), issuer, issuedDate,
-                    id, claims, validators);
-        } else {
-            result = new CredentialVerificationResult(Instant.now(), AssetStatus.ACTIVE.getValue(), issuer, issuedDate,
+        }
+        if (baseClass == SERVICE_OFFERING) {
+            return new CredentialVerificationResultOffering(now, status, issuer, issuedDate,
                     id, claims, validators);
         }
-
-        if (filtered.hasWarning()) {
-            result.setWarnings(List.of(filtered.warning()));
+        if (baseClass == RESOURCE) {
+            return new CredentialVerificationResultResource(now, status, issuer, issuedDate,
+                    id, claims, validators);
         }
-
-        stamp = System.currentTimeMillis() - stamp;
-        log.debug("verifyCredential.exit; returning: {}; time taken: {}", result, stamp);
-        return result;
+        return new CredentialVerificationResult(now, status, issuer, issuedDate,
+                id, claims, validators);
     }
 
     private TypedCredentials parseCredentials(JsonLDObject ld, boolean vpRequired, boolean verifySemantics) {
@@ -364,26 +479,6 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         throw new VerificationException("Semantic error: unexpected credential type: " + ld.getTypes());
     }
 
-    private boolean isVc2Context(String body) {
-        try {
-            JsonNode root = OBJECT_MAPPER.readTree(body);
-            JsonNode ctx = root.get("@context");
-            if (ctx == null) {
-                return false;
-            }
-            if (ctx.isArray()) {
-                for (JsonNode element : ctx) {
-                    if (VC2_CONTEXT.equals(element.asText())) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-            return VC2_CONTEXT.equals(ctx.asText());
-        } catch (JsonProcessingException ex) {
-            return false;
-        }
-    }
 
     /* Credential parsing, semantic validation */
     private JsonLDObject parseContent(ContentAccessor content) {
@@ -399,7 +494,7 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         log.debug("verifyPresentation.enter; got presentation with id: {}", presentation.getId());
         StringBuilder sb = new StringBuilder();
         String sep = System.lineSeparator();
-        if (checkAbsence(presentation, "@context")) {
+        if (checkAbsence(presentation, RDF_CONTEXT_KEY)) {
             sb.append(" - VerifiablePresentation must contain '@context' property").append(sep);
         }
         if (checkAbsence(presentation, "type", "@type")) {
@@ -430,8 +525,8 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
     private String verifyCredential(VerifiableCredential credential, int idx) {
         StringBuilder sb = new StringBuilder();
         String sep = System.lineSeparator();
-        if (checkAbsence(credential, "@context")) {
-            sb.append(" - VerifiableCredential[").append(idx).append("] must contain '@context' property").append(sep);
+        if (checkAbsence(credential, RDF_CONTEXT_KEY)) {
+            sb.append(" - VerifiableCredential[").append(idx).append("] must contain ").append(RDF_CONTEXT_KEY).append(" property").append(sep);
         }
         if (checkAbsence(credential, "type", "@type")) {
             sb.append(" - VerifiableCredential[").append(idx).append("] must contain 'type' property").append(sep);
@@ -447,10 +542,10 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
     }
 
     private VersionedCredentialProcessor getVersionProcessor(VerifiableCredential credential) {
-        Object ctx = credential.getJsonObject().get("@context");
+        Object ctx = credential.getJsonObject().get(RDF_CONTEXT_KEY);
         boolean isVc2 = (ctx instanceof java.util.List<?>)
-                ? ((java.util.List<?>) ctx).contains(VC2_CONTEXT)
-                : VC2_CONTEXT.equals(ctx);
+                ? ((java.util.List<?>) ctx).contains(VC_20_CONTEXT)
+                : VC_20_CONTEXT.equals(ctx);
         return isVc2 ? vc2Processor : vc11Processor;
     }
 
@@ -467,36 +562,102 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         log.trace("getCredentials.enter; got VP: {}", vp);
         Object obj = vp.getJsonObject().get("verifiableCredential");
         Map<VerifiableCredential, TrustFrameworkBaseClass> creds;
-        if (obj == null) {
-            creds = Collections.emptyMap();
-        } else if (obj instanceof List) {
-            List<?> l = (List<?>) obj;
-            creds = new LinkedHashMap<>(l.size());
-            for (Object entry : l) {
-                if (entry instanceof String) {
-                    // Compact JWT VC — opaque for semantic processing; signatures handled by verifyInnerVcCredentials
-                    // TODO(gaia-x-loire): if Loire requires semantic validation of embedded JWT VCs, unwrap and
-                    //   resolve their base class here instead of skipping.
-                    continue;
+        switch (obj) {
+            case null -> creds = Collections.emptyMap();
+            case List<?> l -> {
+                creds = new LinkedHashMap<>(l.size());
+                for (Object entry : l) {
+                    if (entry instanceof String jwtStr) {
+                        VerifiableCredential unwrapped = tryUnwrapJwtVc(jwtStr, vp.getDocumentLoader());
+                        if (unwrapped != null) {
+                            creds.put(unwrapped, resolveBaseClass(unwrapped));
+                        }
+                        continue;
+                    }
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> entryMap = (Map<String, Object>) entry;
+                    if (isEnvelopedVerifiableCredential(resolveType(entryMap), entryMap.get(RDF_CONTEXT_KEY))) {
+                        VerifiableCredential unwrapped = tryUnwrapEnvelopedVc(entryMap, vp.getDocumentLoader());
+                        if (unwrapped != null) {
+                            creds.put(unwrapped, resolveBaseClass(unwrapped));
+                        }
+                        continue;
+                    }
+                    VerifiableCredential vc = VerifiableCredential.fromMap(entryMap);
+                    vc.setDocumentLoader(vp.getDocumentLoader());
+                    creds.put(vc, resolveBaseClass(vc));
                 }
-                @SuppressWarnings("unchecked")
-                VerifiableCredential vc = VerifiableCredential.fromMap((Map<String, Object>) entry);
-                vc.setDocumentLoader(vp.getDocumentLoader());
-                creds.put(vc, resolveBaseClass(vc));
             }
-        } else if (obj instanceof String) {
-            // Single compact JWT VC — opaque for semantic processing
-            // TODO(gaia-x-loire): same as list case above — unwrap if Loire requires semantic validation.
-            creds = Collections.emptyMap();
-        } else {
-            @SuppressWarnings("unchecked")
-            VerifiableCredential vc = VerifiableCredential.fromMap((Map<String, Object>) obj);
-            vc.setDocumentLoader(vp.getDocumentLoader());
-            creds = Map.of(vc, resolveBaseClass(vc));
+            case String jwtStr -> {
+                VerifiableCredential unwrapped = tryUnwrapJwtVc(jwtStr, vp.getDocumentLoader());
+                if (unwrapped != null) {
+                    creds = Map.of(unwrapped, resolveBaseClass(unwrapped));
+                } else {
+                    creds = Collections.emptyMap();
+                }
+            }
+            default -> {
+                @SuppressWarnings("unchecked")
+                VerifiableCredential vc = VerifiableCredential.fromMap((Map<String, Object>) obj);
+                vc.setDocumentLoader(vp.getDocumentLoader());
+                creds = Map.of(vc, resolveBaseClass(vc));
+            }
         }
         TypedCredentials tcs = new TypedCredentials(vp, creds);
         log.trace("getCredentials.exit; returning: {}", tcs);
         return tcs;
+    }
+
+    /**
+     * Attempts to unwrap an EnvelopedVerifiableCredential (Loire data: URI) to a VC.
+     */
+    private VerifiableCredential tryUnwrapEnvelopedVc(Map<String, Object> entryMap,
+        DocumentLoader docLoader) {
+        Object idObj = resolveId(entryMap);
+        if (!(idObj instanceof String idStr) || !idStr.startsWith("data:")) {
+            log.debug("tryUnwrapEnvelopedVc; no data: URI in EnvelopedVerifiableCredential");
+            return null;
+        }
+        try {
+            int commaIdx = idStr.indexOf(',');
+            if (commaIdx < 0) {
+                int semiIdx = idStr.indexOf(';');
+                if (semiIdx < 0) {
+                    return null;
+                }
+                commaIdx = semiIdx;
+            }
+            String jwtStr = idStr.substring(commaIdx + 1);
+            return tryUnwrapJwtVc(jwtStr, docLoader);
+        } catch (Exception ex) {
+            log.debug("tryUnwrapEnvelopedVc; failed to unwrap: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Attempts to unwrap a compact JWT VC string to a VerifiableCredential for semantic processing.
+     */
+    private VerifiableCredential tryUnwrapJwtVc(String jwtStr, DocumentLoader docLoader) {
+        if (!jwtStr.startsWith(JWT_PREFIX)) {
+            return null;
+        }
+        try {
+            ContentAccessor jwtContent = new ContentAccessorDirect(jwtStr);
+            CredentialFormat innerFormat = formatDetector.detect(jwtContent);
+            ContentAccessor unwrapped;
+            if (innerFormat == CredentialFormat.GAIAX_V2_LOIRE) {
+                unwrapped = loireJwtParser.unwrap(jwtContent);
+            } else {
+                unwrapped = jwtPreprocessor.unwrap(jwtContent);
+            }
+            VerifiableCredential vc = VerifiableCredential.fromJson(unwrapped.getContentAsString());
+            vc.setDocumentLoader(docLoader);
+            return vc;
+        } catch (Exception ex) {
+            log.debug("tryUnwrapJwtVc; failed to unwrap JWT VC: {}", ex.getMessage());
+            return null;
+        }
     }
 
     private TypedCredentials getCredentials(VerifiableCredential vc) {
@@ -504,23 +665,6 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         TypedCredentials tcs = new TypedCredentials(null, Map.of(vc, resolveBaseClass(vc)));
         log.trace("getCredentials.exit; returning: {}", tcs);
         return tcs;
-    }
-
-    public List<CredentialClaim> extractClaims(ContentAccessor payload) {
-        // Make sure our interceptors are in place.
-        initLoaders();
-        List<CredentialClaim> claims = null;
-        for (ClaimExtractor extra : extractors) {
-            try {
-                claims = extra.extractClaims(payload);
-                if (claims != null) {
-                    break;
-                }
-            } catch (Exception ex) {
-                log.error("extractClaims.error using {}: {}", extra.getClass().getName(), ex.getMessage());
-            }
-        }
-        return claims;
     }
 
     private void initLoaders() {
@@ -553,10 +697,6 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
             }
         }
         return streamManager;
-    }
-
-    public void setBaseClassUri(TrustFrameworkBaseClass baseClass, String uri) {
-        trustFrameworkBaseClassUris.put(baseClass, uri);
     }
 
     private TrustFrameworkBaseClass resolveBaseClass(VerifiableCredential credential) {
@@ -623,7 +763,7 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
             return;
         }
         try {
-            // ICAM v24.07: holder is a top-level claim; older format: nested in vp claim
+            // ICAM v24.07 (Loire): holder is a top-level claim; older format: nested in vp claim
             String holder = claims.getStringClaim("holder");
             if (holder == null) {
                 @SuppressWarnings("unchecked")
@@ -633,9 +773,22 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
                 }
             }
             String iss = claims.getIssuer();
+            // Loire VPs: holder is optional per VCDM 2.0; when absent, the VP issuer (iss)
+            // is implicitly the holder. Also check top-level "issuer" claim as Loire fallback.
             if (holder == null) {
-                throw new VerificationException(
-                        "VP JWT missing 'holder' claim — iss/holder binding cannot be verified");
+                String issuerClaim = claims.getStringClaim("issuer");
+                if (issuerClaim != null && iss != null && !iss.equals(issuerClaim)) {
+                    throw new VerificationException(
+                        "VP JWT iss '" + iss + "' does not match VP issuer '" + issuerClaim + "'");
+                }
+                // holder absent: iss is implicitly the holder — binding passes
+                log.debug("checkVpJwtHolder; holder absent, iss '{}' accepted as implicit holder",
+                    iss);
+                return;
+            }
+            if (iss == null) {
+                log.warn("checkVpJwtHolder; VP JWT has holder '{}' but no iss claim", holder);
+                return;
             }
             if (!iss.equals(holder)) {
                 throw new VerificationException(
@@ -669,13 +822,13 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
 
         List<Validator> validators = new ArrayList<>();
         for (Object entry : vcEntries) {
-            if (entry instanceof String jwtStr && jwtStr.startsWith("eyJ")) {
+            if (entry instanceof String jwtStr && jwtStr.startsWith(JWT_PREFIX)) {
                 // Plain compact JWT string
                 validators.add(jwtSignatureVerifier.verify(jwtStr));
             } else if (entry instanceof Map<?, ?> vcMap) {
-                if (isEnvelopedVerifiableCredential(vcMap.get("type"), vcMap.get("@context"))) {
+                if (isEnvelopedVerifiableCredential(resolveType(vcMap), vcMap.get(RDF_CONTEXT_KEY))) {
                     // ICAM v24.07 EnvelopedVerifiableCredential: extract JWT from data: URL
-                    Object idObj = vcMap.get("id");
+                    Object idObj = resolveId(vcMap);
                     if (!(idObj instanceof String idStr)) {
                         throw new ClientException(
                                 "EnvelopedVerifiableCredential missing 'id' field");
@@ -694,8 +847,6 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         return validators;
     }
 
-    private static final String VC_2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
-
     private boolean isEnvelopedVerifiableCredential(Object typeObj, Object contextObj) {
         boolean hasType = false;
         if (typeObj instanceof String typeStr) {
@@ -708,10 +859,10 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         }
         // Also verify the VC 2.0 context to avoid false-positives from other vocabularies
         if (contextObj instanceof String ctx) {
-            return VC_2_CONTEXT.equals(ctx);
+            return VC_20_CONTEXT.equals(ctx);
         }
         if (contextObj instanceof List<?> contexts) {
-            return contexts.contains(VC_2_CONTEXT);
+            return contexts.contains(VC_20_CONTEXT);
         }
         return false;
     }
@@ -777,6 +928,14 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         return validator;
     }
 
+    /**
+     * Fetches the certificate chain from the given x5u URL, validates certificate expiry,
+     * and checks the URI against the Gaia-X Trust Anchor Registry (when gaiax.enabled=true).
+     *
+     * <p>Note: does not perform PKIX path validation (RFC 5280) or revocation checking.
+     * ICAM 24.07 does not explicitly require these — it requires x5c/x5u presence (MUST)
+     * and x5u trust anchor resolution (SHOULD).
+     */
     @SuppressWarnings("unchecked")
     private Instant hasPEMTrustAnchorAndIsNotExpired(String uri) throws VerificationException {
         log.debug("hasPEMTrustAnchorAndIsNotExpired.enter; got uri: {}, gaiaxTrustFrameworkEnabled: {}", uri, gaiaxTrustFrameworkEnabled);
@@ -829,5 +988,132 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
         Instant exp = relevant == null ? null : relevant.getNotAfter().toInstant();
         log.debug("hasPEMTrustAnchorAndIsNotExpired.exit; returning: {}", exp);
         return exp;
+    }
+
+    /**
+     * Enforces mandatory x5c/x5u trust chain validation for Loire credentials
+     * when Gaia-X trust framework is enabled (ICAM 24.07).
+     *
+     * @param jwtValidator the validator from JWT signature verification
+     * @throws VerificationException if x5c or x5u is missing in the publicKeyJwk
+     */
+    private void enforceLoirePolicies(String body, Validator jwtValidator) {
+        enforceDidWebRestriction(body);
+        if (jwtValidator != null) {
+            enforceLoireTrustChain(jwtValidator);
+        }
+    }
+
+    private void enforceLoireTrustChain(Validator jwtValidator) {
+        String publicKeyJson = jwtValidator.getPublicKey();
+        if (publicKeyJson == null) {
+            throw new VerificationException(
+                "Loire trust chain: publicKeyJwk is required but not available");
+        }
+        try {
+            JsonNode jwkNode = objectMapper.readTree(publicKeyJson);
+            boolean hasX5c = jwkNode.has("x5c") && !jwkNode.get("x5c").isEmpty();
+            boolean hasX5u = jwkNode.has("x5u") && !jwkNode.get("x5u").asText().isBlank();
+            if (!hasX5c && !hasX5u) {
+                throw new VerificationException(
+                    "Loire trust chain: publicKeyJwk must contain x5c or x5u certificate chain "
+                        + "(ICAM 24.07 mandatory trust anchor). kid: " + jwtValidator.getDidURI());
+            }
+            if (hasX5c) {
+                validateX5cChain(jwkNode.get("x5c"), jwtValidator.getDidURI());
+            }
+            if (hasX5u) {
+                String x5uUrl = jwkNode.get("x5u").asText();
+                hasPEMTrustAnchorAndIsNotExpired(x5uUrl);
+            }
+            log.debug("enforceLoireTrustChain; trust chain validated for kid: {}",
+                jwtValidator.getDidURI());
+        } catch (VerificationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new VerificationException(
+                "Loire trust chain validation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Validates certificates from the JWK {@code x5c} array: decodes base64 DER entries,
+     * checks each certificate is currently valid (not expired), and verifies that the chain
+     * is non-empty (ICAM 24.07).
+     *
+     * <p><strong>Known gap:</strong> validates certificate expiry only. Unlike the x5u path
+     * ({@link #hasPEMTrustAnchorAndIsNotExpired}), this does not call the Trust Anchor Registry
+     * because the registry API expects a URI, not inline certificates.
+     */
+    private void validateX5cChain(JsonNode x5cArray, String kid) {
+        if (!x5cArray.isArray() || x5cArray.isEmpty()) {
+            throw new VerificationException(
+                "Loire trust chain: x5c array is empty. kid: " + kid);
+        }
+        try {
+            CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
+            for (JsonNode entry : x5cArray) {
+                byte[] certBytes;
+                try {
+                    certBytes = java.util.Base64.getDecoder().decode(entry.asText());
+                } catch (IllegalArgumentException ex) {
+                    throw new VerificationException(
+                        "Loire trust chain: x5c entry is not valid base64. kid: " + kid, ex);
+                }
+                X509Certificate cert = (X509Certificate) certFactory.generateCertificate(
+                    new ByteArrayInputStream(certBytes));
+                cert.checkValidity();
+            }
+            log.debug("validateX5cChain; {} certificate(s) valid for kid: {}",
+                x5cArray.size(), kid);
+        } catch (CertificateException ex) {
+            throw new VerificationException(
+                "Loire trust chain: x5c certificate validation failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Enforces the Loire DID method restriction: only {@code did:web} is accepted
+     * when Gaia-X trust framework is enabled (ICAM 24.07).
+     *
+     * @param compactJwt the original compact JWT body
+     * @throws VerificationException if the issuer uses a non-did:web DID method
+     */
+    private void enforceDidWebRestriction(String compactJwt) {
+        try {
+            JWTClaimsSet claims = SignedJWT.parse(compactJwt).getJWTClaimsSet();
+            String iss = claims.getIssuer();
+            String issuerClaim = claims.getStringClaim("issuer");
+            // Validate both when present — prevents spoofing via injected issuer claim
+            if (iss != null) {
+                validateDidWeb(iss);
+            }
+            if (issuerClaim != null && !issuerClaim.equals(iss)) {
+                validateDidWeb(issuerClaim);
+            }
+            if (iss == null && issuerClaim == null) {
+                throw new VerificationException(
+                    "Loire DID method restriction: no issuer found in JWT iss or payload issuer "
+                        + "(ICAM 24.07 requires did:web)");
+            }
+        } catch (VerificationException ex) {
+            throw ex;
+        } catch (ParseException ex) {
+            throw new VerificationException(
+                "Loire DID method restriction: JWT claims parse error: " + ex.getMessage(), ex);
+        }
+    }
+
+    private void validateDidWeb(String did) {
+        if (did.startsWith("did:key")) {
+            throw new VerificationException(
+                "Loire DID method restriction: did:key is not accepted "
+                    + "(ICAM 24.07 requires did:web with JWK + x5c/x5u). Issuer: " + did);
+        }
+        if (!did.startsWith("did:web:")) {
+            throw new VerificationException(
+                "Loire DID method restriction: only did:web is accepted "
+                    + "(ICAM 24.07). Found: " + did);
+        }
     }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/FormatDetector.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/FormatDetector.java
@@ -1,0 +1,137 @@
+package eu.xfsc.fc.core.service.verification;
+
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.JWT_PREFIX;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_11_CONTEXT;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_20_CONTEXT;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.SignedJWT;
+
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+
+import java.text.ParseException;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Routes incoming credential payloads to the correct processing path based on
+ * JWT headers and payload structure.
+ *
+ * <p>Decision tree:
+ * <ol>
+ *   <li>Not a JWT ({@code eyJ} prefix absent) and has VC 1.1 {@code @context} → Path 1 (Tagus)</li>
+ *   <li>JWT with {@code typ: vc+ld+json+jwt} or {@code vp+ld+jwt} and top-level {@code @context}
+ *       (no {@code vc}/{@code vp} wrapper claim) → Path 2 (Loire)</li>
+ *   <li>JWT with {@code vc} or {@code vp} wrapper claim → Path 3 (danubetech)</li>
+ *   <li>Otherwise → UNKNOWN</li>
+ * </ol>
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FormatDetector {
+
+  private final ObjectMapper objectMapper;
+
+  private static final Set<String> LOIRE_VC_TYP_VALUES = Set.of(
+      "vc+ld+json+jwt"
+  );
+  private static final Set<String> LOIRE_VP_TYP_VALUES = Set.of(
+      "vp+ld+jwt"
+  );
+
+  /**
+   * Detects the credential format of the given payload.
+   *
+   * @param content the incoming credential content
+   * @return the detected format; never null
+   */
+  public CredentialFormat detect(ContentAccessor content) {
+    String body = content.getContentAsString().strip();
+
+    if (!body.startsWith(JWT_PREFIX)) {
+      return detectNonJwt(body);
+    }
+    return detectJwt(body);
+  }
+
+  private CredentialFormat detectNonJwt(String body) {
+    try {
+      JsonNode root = objectMapper.readTree(body);
+      JsonNode ctx = root.get("@context");
+      // VC 1.1 detection by context — proof block is per-VC, not always at VP level
+      if (ctx != null && containsValue(ctx, VC_11_CONTEXT)) {
+        log.debug("detect; VC 1.1 context → GAIAX_V1_TAGUS");
+        return CredentialFormat.GAIAX_V1_TAGUS;
+      }
+      // VC 2.0 non-JWT JSON-LD (inline credential, no JWT envelope)
+      if (ctx != null && containsValue(ctx, VC_20_CONTEXT)) {
+        log.debug("detect; VC 2.0 context (non-JWT) → VC2_DANUBETECH");
+        return CredentialFormat.VC2_DANUBETECH;
+      }
+      log.debug("detect; non-JWT without recognized context → UNKNOWN");
+      return CredentialFormat.UNKNOWN;
+    } catch (JsonProcessingException ex) {
+      log.debug("detect; body is not valid JSON → UNKNOWN");
+      return CredentialFormat.UNKNOWN;
+    }
+  }
+
+  private CredentialFormat detectJwt(String body) {
+    JWSHeader header;
+    JsonNode payload;
+    try {
+      SignedJWT signedJwt = SignedJWT.parse(body);
+      header = signedJwt.getHeader();
+      String payloadJson = signedJwt.getPayload().toString();
+      payload = objectMapper.readTree(payloadJson);
+    } catch (ParseException | JsonProcessingException ex) {
+      log.debug("detect; JWT parse failed: {} → UNKNOWN", ex.getMessage());
+      return CredentialFormat.UNKNOWN;
+    }
+
+    String typ = header.getType() != null ? header.getType().toString() : null;
+
+    // Loire detection: typ header matches AND payload is top-level (no vc/vp wrapper)
+    if (typ != null && isLoireTyp(typ)) {
+      if (payload.has("@context") && !payload.has("vc") && !payload.has("vp")) {
+        log.debug("detect; Loire typ header '{}' + top-level @context → GAIAX_V2_LOIRE", typ);
+        return CredentialFormat.GAIAX_V2_LOIRE;
+      }
+      // typ says Loire but payload has vc/vp wrapper — contradictory
+      log.debug("detect; typ '{}' but payload has vc/vp wrapper → UNKNOWN", typ);
+      return CredentialFormat.UNKNOWN;
+    }
+
+    // danubetech detection: vc or vp wrapper claim present
+    if (payload.has("vc") || payload.has("vp")) {
+      log.debug("detect; JWT payload has vc/vp wrapper → VC2_DANUBETECH");
+      return CredentialFormat.VC2_DANUBETECH;
+    }
+
+    log.debug("detect; unrecognizable JWT → UNKNOWN");
+    return CredentialFormat.UNKNOWN;
+  }
+
+  private boolean isLoireTyp(String typ) {
+    return LOIRE_VC_TYP_VALUES.contains(typ) || LOIRE_VP_TYP_VALUES.contains(typ);
+  }
+
+  private static boolean containsValue(JsonNode node, String value) {
+      //noinspection SwitchStatementWithTooFewBranches
+      return switch (node) {
+      case ArrayNode array -> StreamSupport.stream(array.spliterator(), false)
+          .anyMatch(n -> value.equals(n.asText()));
+      default -> value.equals(node.asText());
+    };
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/JwtContentPreprocessor.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/JwtContentPreprocessor.java
@@ -1,5 +1,7 @@
 package eu.xfsc.fc.core.service.verification;
 
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.JWT_PREFIX;
+
 import com.danubetech.verifiablecredentials.jwt.JwtVerifiableCredentialV2;
 import com.danubetech.verifiablecredentials.jwt.JwtVerifiablePresentationV2;
 
@@ -27,8 +29,6 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class JwtContentPreprocessor {
-
-  private static final String JWT_PREFIX = "eyJ";
 
   private static final Set<String> JWT_CONTENT_TYPES = Set.of(
       "application/vc+ld+json+jwt",

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/LoireJwtParser.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/LoireJwtParser.java
@@ -1,0 +1,144 @@
+package eu.xfsc.fc.core.service.verification;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+
+import java.text.ParseException;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Parses Loire-format JWTs (ICAM 24.07 / VC-JOSE-COSE) where the credential
+ * is the top-level JWT payload — no {@code vc}/{@code vp} wrapper claims.
+ *
+ * <p>This parser bypasses the danubetech library which expects wrapper claims.
+ * After unwrapping, the payload is a standard JSON-LD credential that can be
+ * processed by the existing claim extractors and SHACL validators.
+ *
+ * <p>Header validation enforced per ICAM 24.07:
+ * <ul>
+ *   <li>VC: {@code typ: vc+ld+json+jwt}, {@code cty: vc+ld+json}</li>
+ *   <li>VP: {@code typ: vp+ld+jwt}, {@code cty: vp+ld+json}</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class LoireJwtParser {
+
+  private static final Set<String> VALID_VC_TYP = Set.of("vc+ld+json+jwt");
+  private static final Set<String> VALID_VP_TYP = Set.of("vp+ld+jwt");
+  private static final Set<String> VALID_VC_CTY = Set.of("vc+ld+json");
+  private static final Set<String> VALID_VP_CTY = Set.of("vp+ld+json");
+
+  /**
+   * Unwraps a Loire-format JWT to JSON-LD.
+   *
+   * <p>Validates ICAM 24.07 headers and rejects payloads that contain
+   * {@code vc} or {@code vp} wrapper claims (these belong to the danubetech path).
+   *
+   * @param content the JWT-wrapped content
+   * @return the unwrapped JSON-LD payload
+   * @throws ClientException if the JWT is malformed, headers are invalid,
+   *     or wrapper claims are present
+   */
+  public ContentAccessor unwrap(ContentAccessor content) {
+    String body = content.getContentAsString().strip();
+    SignedJWT signedJwt = parseJwt(body);
+    JWSHeader header = signedJwt.getHeader();
+
+    validateHeaders(header);
+    JWTClaimsSet claims = parseClaims(signedJwt);
+    rejectWrapperClaims(claims);
+
+    String payloadJson = signedJwt.getPayload().toString();
+    log.debug("unwrap; Loire JWT unwrapped successfully");
+    return new ContentAccessorDirect(payloadJson);
+  }
+
+  /**
+   * Returns true if the JWT header indicates a Verifiable Presentation.
+   *
+   * @param content the JWT-wrapped content (must start with {@code eyJ})
+   * @return true if {@code typ} is {@code vp+ld+jwt}
+   */
+  public boolean isVpJwt(ContentAccessor content) {
+    String body = content.getContentAsString().strip();
+    try {
+      SignedJWT signedJwt = SignedJWT.parse(body);
+      String typ = signedJwt.getHeader().getType() != null
+          ? signedJwt.getHeader().getType().toString() : null;
+      return typ != null && VALID_VP_TYP.contains(typ);
+    } catch (ParseException ex) {
+      return false;
+    }
+  }
+
+  private void validateHeaders(JWSHeader header) {
+    String typ = header.getType() != null ? header.getType().toString() : null;
+    String cty = header.getContentType();
+
+    if (typ == null) {
+      throw new ClientException("Loire JWT missing required 'typ' header");
+    }
+
+    boolean isVc = VALID_VC_TYP.contains(typ);
+    boolean isVp = VALID_VP_TYP.contains(typ);
+    if (!isVc && !isVp) {
+      throw new ClientException(
+          "Loire JWT has invalid 'typ' header: '" + typ
+              + "'; expected one of: vc+ld+json+jwt, vp+ld+jwt");
+    }
+
+    if (cty == null) {
+      throw new ClientException(
+          "Loire JWT missing required 'cty' header (ICAM 24.07); "
+              + "expected: " + (isVc ? "vc+ld+json" : "vp+ld+json"));
+    }
+
+    if (isVc && !VALID_VC_CTY.contains(cty)) {
+      throw new ClientException(
+          "Loire VC JWT has invalid 'cty' header: '" + cty + "'; expected: vc+ld+json");
+    }
+    if (isVp && !VALID_VP_CTY.contains(cty)) {
+      throw new ClientException(
+          "Loire VP JWT has invalid 'cty' header: '" + cty + "'; expected: vp+ld+json");
+    }
+  }
+
+  private void rejectWrapperClaims(JWTClaimsSet claims) {
+    if (claims.getClaim("vc") != null) {
+      throw new ClientException(
+          "Loire JWT must not contain 'vc' wrapper claim — "
+              + "credential fields must be top-level in the JWT payload (ICAM 24.07)");
+    }
+    if (claims.getClaim("vp") != null) {
+      throw new ClientException(
+          "Loire JWT must not contain 'vp' wrapper claim — "
+              + "presentation fields must be top-level in the JWT payload (ICAM 24.07)");
+    }
+  }
+
+  private SignedJWT parseJwt(String compact) {
+    try {
+      return SignedJWT.parse(compact);
+    } catch (ParseException ex) {
+      throw new ClientException("Loire JWT is malformed: " + ex.getMessage(), ex);
+    }
+  }
+
+  private JWTClaimsSet parseClaims(SignedJWT signedJwt) {
+    try {
+      return signedJwt.getJWTClaimsSet();
+    } catch (ParseException ex) {
+      throw new ClientException("Loire JWT claims are malformed: " + ex.getMessage(), ex);
+    }
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
@@ -1,0 +1,22 @@
+package eu.xfsc.fc.core.service.verification;
+
+/**
+ * Shared string constants for the verification pipeline.
+ */
+public final class VerificationConstants {
+
+  public static final String JWT_PREFIX = "eyJ";
+
+  public static final String VC_11_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+  public static final String VC_20_CONTEXT = "https://www.w3.org/ns/credentials/v2";
+
+  // Note: the Gaia-X 2511 context URL (https://w3id.org/gaia-x/2511#) is intentionally absent here.
+  // Loire format detection is based on JWT structure (typ header + top-level @context presence),
+  // not on specific vocabulary namespaces. The 2511 URL is Gaia-X domain vocabulary — any
+  // trust framework could use the Loire JWT format without it.
+
+  public static final String RDF_CONTEXT_KEY = "@context";
+
+  private VerificationConstants() {
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/DanubeTechClaimExtractor.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/DanubeTechClaimExtractor.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.service.verification.claims;
 
 import static com.danubetech.verifiablecredentials.jsonld.VerifiableCredentialKeywords.*;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_20_CONTEXT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DanubeTechClaimExtractor implements ClaimExtractor {
 
-  private static final String VC2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
-
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Override
@@ -41,9 +40,9 @@ public class DanubeTechClaimExtractor implements ClaimExtractor {
   private boolean isVc2Context(Map<String, Object> raw) {
     Object ctx = raw.get("@context");
     if (ctx instanceof List) {
-      return ((List<?>) ctx).contains(VC2_CONTEXT);
+      return ((List<?>) ctx).contains(VC_20_CONTEXT);
     }
-    return VC2_CONTEXT.equals(ctx);
+    return VC_20_CONTEXT.equals(ctx);
   }
 
   private List<CredentialClaim> extractClaimsVc2(String str, Map<String, Object> raw) throws Exception {

--- a/fc-service-core/src/main/resources/liquibase/changesets/008-rename-timestamps.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/008-rename-timestamps.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="Fabian Saacke" id="2026-03-27-rename-timestamps">
+        <comment>Rename uploadtime/updatetime to created_at/modified_at for clarity</comment>
+        <renameColumn tableName="schemafiles" oldColumnName="uploadtime" newColumnName="created_at"/>
+        <renameColumn tableName="schemafiles" oldColumnName="updatetime" newColumnName="modified_at"/>
+        <renameColumn tableName="schemafiles_aud" oldColumnName="uploadtime" newColumnName="created_at"/>
+        <renameColumn tableName="schemafiles_aud" oldColumnName="updatetime" newColumnName="modified_at"/>
+        <dropIndex tableName="schemafiles" indexName="schemafiles_updatetime"/>
+        <createIndex tableName="schemafiles" indexName="schemafiles_created_at">
+            <column name="created_at"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/changesets/009-asset-versioning.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/009-asset-versioning.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet id="2026-04-01-asset-change-comment" author="saackef">
+        <comment>Add change_comment column to assets and assets_aud for Envers-based versioning</comment>
+        <addColumn tableName="assets">
+            <column name="change_comment" type="TEXT"/>
+        </addColumn>
+        <addColumn tableName="assets_aud">
+            <column name="change_comment" type="TEXT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -11,4 +11,5 @@
     <include file="asset_store_rename.xml" relativeToChangelogFile="true" />
     <include file="changesets/006-technical_ids.xml" relativeToChangelogFile="true" />
     <include file="changesets/007-envers_audit.xml" relativeToChangelogFile="true" />
+    <include file="changesets/008-rename-timestamps.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -12,4 +12,5 @@
     <include file="changesets/006-technical_ids.xml" relativeToChangelogFile="true" />
     <include file="changesets/007-envers_audit.xml" relativeToChangelogFile="true" />
     <include file="changesets/008-rename-timestamps.xml" relativeToChangelogFile="true" />
+    <include file="changesets/009-asset-versioning.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/EnversAuditTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/EnversAuditTest.java
@@ -31,6 +31,7 @@ import org.springframework.transaction.support.TransactionTemplate;
 import eu.xfsc.fc.api.generated.model.AssetStatus;
 import eu.xfsc.fc.core.config.DatabaseConfig;
 import eu.xfsc.fc.core.dao.assets.AssetDao;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.schemas.SchemaDao;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
@@ -46,7 +47,7 @@ import jakarta.persistence.EntityManager;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {
     EnversAuditTest.TestConfig.class,
-    AssetJpaDao.class, SchemaJpaDao.class, SchemaAuditRepository.class,
+    AssetJpaDao.class, AssetAuditRepository.class, SchemaJpaDao.class, SchemaAuditRepository.class,
     DatabaseConfig.class
 })
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
@@ -118,10 +119,8 @@ class EnversAuditTest {
 
     assertNotNull(revisions);
     assertEquals(1, revisions.size());
-    Object[] row = (Object[]) revisions.getFirst();
-    Asset audited = (Asset) row[0];
-    RevisionType revType = (RevisionType) row[2];
-    assertEquals(RevisionType.ADD, revType);
+    Asset audited = (Asset) auditRow(revisions, 0)[0];
+    assertEquals(RevisionType.ADD, revisionType(revisions, 0));
     assertEquals("hash-1", audited.getAssetHash());
     assertEquals("sub/1", audited.getSubjectId());
     assertEquals("iss/1", audited.getIssuer());
@@ -171,13 +170,9 @@ class EnversAuditTest {
 
     assertNotNull(revisions);
     assertEquals(2, revisions.size());
-
-    Object[] insertRow = (Object[]) revisions.get(0);
-    assertEquals(RevisionType.ADD, insertRow[2]);
-
-    Object[] updateRow = (Object[]) revisions.get(1);
-    assertEquals(RevisionType.MOD, updateRow[2]);
-    Asset updated = (Asset) updateRow[0];
+    assertEquals(RevisionType.ADD, revisionType(revisions, 0));
+    assertEquals(RevisionType.MOD, revisionType(revisions, 1));
+    Asset updated = (Asset) auditRow(revisions, 1)[0];
     assertEquals((short) AssetStatus.REVOKED.ordinal(), updated.getStatus());
   }
 
@@ -203,42 +198,37 @@ class EnversAuditTest {
 
     assertNotNull(revisions);
     assertEquals(2, revisions.size());
-
-    Object[] deleteRow = (Object[]) revisions.get(1);
-    assertEquals(RevisionType.DEL, deleteRow[2]);
-    // store_data_at_delete=true: full state captured
-    Asset deleted = (Asset) deleteRow[0];
+    assertEquals(RevisionType.DEL, revisionType(revisions, 1));
+    Asset deleted = (Asset) auditRow(revisions, 1)[0];
     assertEquals("hash-del", deleted.getAssetHash());
     assertEquals("sub/del", deleted.getSubjectId());
   }
 
   @Test
   void multipleTransactions_createSeparateRevisions() {
-    // Insert first asset for sub/multi (ACTIVE)
     transactionTemplate.executeWithoutResult(status ->
         assetDao.insert(buildAssetRecord("hash-multi-1", "sub/multi", "iss/multi",
             List.of("did:val:1")))
     );
-
-    // Insert second asset for same subject — deprecates first, creates new
     transactionTemplate.executeWithoutResult(status ->
         assetDao.insert(buildAssetRecord("hash-multi-2", "sub/multi", "iss/multi",
             List.of("did:val:1")))
     );
 
-    // First asset should have 2 revisions: ADD + MOD (deprecated)
     List<?> revisions = transactionTemplate.execute(status -> {
       var reader = AuditReaderFactory.get(entityManager);
       return reader.createQuery()
           .forRevisionsOfEntity(Asset.class, false, true)
-          .add(AuditEntity.property("assetHash").eq("hash-multi-1"))
+          .add(AuditEntity.property("subjectId").eq("sub/multi"))
           .getResultList();
     });
 
     assertNotNull(revisions);
     assertEquals(2, revisions.size());
-    assertEquals(RevisionType.ADD, ((Object[]) revisions.get(0))[2]);
-    assertEquals(RevisionType.MOD, ((Object[]) revisions.get(1))[2]);
+    assertEquals(RevisionType.ADD, revisionType(revisions, 0));
+    assertEquals(RevisionType.MOD, revisionType(revisions, 1));
+    assertEquals("hash-multi-1", ((Asset) auditRow(revisions, 0)[0]).getAssetHash());
+    assertEquals("hash-multi-2", ((Asset) auditRow(revisions, 1)[0]).getAssetHash());
   }
 
   @Test
@@ -287,8 +277,7 @@ class EnversAuditTest {
 
     assertNotNull(schemaRevisions);
     assertEquals(1, schemaRevisions.size());
-    Object[] row = (Object[]) schemaRevisions.getFirst();
-    assertEquals(RevisionType.ADD, row[2]);
+    assertEquals(RevisionType.ADD, revisionType(schemaRevisions, 0));
 
     // Verify schematerms_AUD also has entries
     List<?> termRevisions = transactionTemplate.execute(status -> {
@@ -324,8 +313,8 @@ class EnversAuditTest {
 
     assertNotNull(schemaRevisions);
     assertEquals(2, schemaRevisions.size());
-    assertEquals(RevisionType.ADD, ((Object[]) schemaRevisions.get(0))[2]);
-    assertEquals(RevisionType.MOD, ((Object[]) schemaRevisions.get(1))[2]);
+    assertEquals(RevisionType.ADD, revisionType(schemaRevisions, 0));
+    assertEquals(RevisionType.MOD, revisionType(schemaRevisions, 1));
   }
 
   @Test
@@ -350,7 +339,7 @@ class EnversAuditTest {
 
     assertNotNull(schemaRevisions);
     assertEquals(2, schemaRevisions.size());
-    assertEquals(RevisionType.DEL, ((Object[]) schemaRevisions.get(1))[2]);
+    assertEquals(RevisionType.DEL, revisionType(schemaRevisions, 1));
 
     // Verify term deletion also audited
     List<?> termRevisions = transactionTemplate.execute(status -> {
@@ -363,8 +352,7 @@ class EnversAuditTest {
 
     assertNotNull(termRevisions);
     assertFalse(termRevisions.isEmpty());
-    Object[] lastTermRev = (Object[]) termRevisions.getLast();
-    assertEquals(RevisionType.DEL, lastTermRev[2]);
+    assertEquals(RevisionType.DEL, revisionType(termRevisions, termRevisions.size() - 1));
   }
 
   // ===== AuditReader query tests =====
@@ -407,8 +395,7 @@ class EnversAuditTest {
           .forRevisionsOfEntity(Asset.class, false, true)
           .add(AuditEntity.property("assetHash").eq("hash-ts"))
           .getResultList();
-      Object[] row = (Object[]) results.getFirst();
-      var revEntity = (org.hibernate.envers.DefaultRevisionEntity) row[1];
+      var revEntity = (org.hibernate.envers.DefaultRevisionEntity) auditRow(results, 0)[1];
       return Instant.ofEpochMilli(revEntity.getTimestamp());
     });
 
@@ -451,5 +438,15 @@ class EnversAuditTest {
     });
     // Still only 1 (the INSERT) — no DEL entry from bulk delete
     assertEquals(1, countAfter);
+  }
+
+  // --- Audit row helpers ---
+
+  private static Object[] auditRow(List<?> revisions, int index) {
+    return (Object[]) revisions.get(index);
+  }
+
+  private static RevisionType revisionType(List<?> revisions, int index) {
+    return (RevisionType) auditRow(revisions, index)[2];
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/EnversAuditTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/EnversAuditTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 
 import eu.xfsc.fc.core.dao.assets.Asset;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaFile;
 import eu.xfsc.fc.core.dao.schemas.SchemaTerm;
 import org.hibernate.envers.AuditReaderFactory;
@@ -45,7 +46,7 @@ import jakarta.persistence.EntityManager;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {
     EnversAuditTest.TestConfig.class,
-    AssetJpaDao.class, SchemaJpaDao.class,
+    AssetJpaDao.class, SchemaJpaDao.class, SchemaAuditRepository.class,
     DatabaseConfig.class
 })
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/assets/AssetDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/assets/AssetDaoTest.java
@@ -35,7 +35,7 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 @ActiveProfiles("test")
-@ContextConfiguration(classes = {AssetDaoTest.TestConfig.class, AssetJpaDao.class, DatabaseConfig.class})
+@ContextConfiguration(classes = {AssetDaoTest.TestConfig.class, AssetJpaDao.class, AssetAuditRepository.class, DatabaseConfig.class})
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 class AssetDaoTest {
 
@@ -441,7 +441,7 @@ class AssetDaoTest {
   }
 
   @Test
-  void insert_existingActiveSubject_deprecatesOldAndReturnsOldHash() {
+  void insert_existingActiveSubject_updatesInPlaceAndReturnsNewHash() {
     AssetRecord first = buildSimpleRecord("hash-old", "sub/1", "iss/1",
         Instant.parse("2024-01-01T00:00:00Z"));
     assetDao.insert(first);
@@ -453,12 +453,14 @@ class AssetDaoTest {
 
     SubjectHashRecord result = assetDao.insert(second);
 
+    // In-place update: subjectId is returned, hash reflects the updated row
     assertEquals("sub/1", result.subjectId());
-    assertEquals("hash-old", result.assetHash());
-
-    // Verify old record is now DEPRECATED
-    AssetRecord oldRecord = assetDao.select("hash-old");
-    assertEquals(AssetStatus.DEPRECATED, oldRecord.getStatus());
+    // Old hash no longer exists as a live row — Envers preserves it in assets_aud
+    assertNull(assetDao.select("hash-old"));
+    // New row has the updated hash and remains ACTIVE
+    AssetRecord updated = assetDao.select("hash-new");
+    assertNotNull(updated);
+    assertEquals(AssetStatus.ACTIVE, updated.getStatus());
   }
 
   @Test

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunksDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunksDaoTest.java
@@ -65,8 +65,8 @@ class RevalidatorChunksDaoTest {
     SchemaFile entity = new SchemaFile();
     entity.setSchemaId(schemaId);
     entity.setNameHash("hash-" + schemaId);
-    entity.setUploadTime(updateTime);
-    entity.setUpdateTime(updateTime);
+    entity.setCreatedAt(updateTime);
+    entity.setModifiedAt(updateTime);
     entity.setType(type);
     entity.setContent("content-" + schemaId);
     return schemaFileRepository.saveAndFlush(entity);

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaDaoTest.java
@@ -33,7 +33,7 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
 @ActiveProfiles("test")
-@ContextConfiguration(classes = {SchemaDaoTest.TestConfig.class, SchemaJpaDao.class, DatabaseConfig.class})
+@ContextConfiguration(classes = {SchemaDaoTest.TestConfig.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class})
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 class SchemaDaoTest {
 
@@ -99,8 +99,8 @@ class SchemaDaoTest {
     assertEquals("hash-1", sr.nameHash());
     assertEquals(SchemaType.ONTOLOGY, sr.type());
     assertEquals("ontology content", sr.content());
-    assertNotNull(sr.uploadTime());
-    assertNotNull(sr.updateTime());
+    assertNotNull(sr.createdAt());
+    assertNotNull(sr.modifiedAt());
     // JPA select() returns terms (JDBC impl returned null)
     assertEquals(Set.of("term1", "term2"), sr.terms());
   }
@@ -264,8 +264,8 @@ class SchemaDaoTest {
 
     Optional<SchemaRecord> result = schemaDao.select("schema-1");
     assertTrue(result.isPresent());
-    assertTrue(result.get().updateTime().isAfter(originalTime),
-        "updateTime should be after original time");
+    assertTrue(result.get().modifiedAt().isAfter(originalTime),
+        "modifiedAt should be after original time");
   }
 
   @Test

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaVersioningTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaVersioningTest.java
@@ -1,0 +1,230 @@
+package eu.xfsc.fc.core.dao.schemas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import eu.xfsc.fc.core.config.DatabaseConfig;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+
+/**
+ * Tests for schema versioning via Envers audit infrastructure.
+ *
+ * <p>Uses {@link TransactionTemplate} with explicit commits so Envers
+ * audit entries are written (class-level @Transactional would roll back
+ * and produce zero revisions).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {SchemaVersioningTest.TestConfig.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class})
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+class SchemaVersioningTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class TestConfig {
+  }
+
+  private static final String SCHEMA_ID = "s-1";
+  private static final String SCHEMA_HASH = "h-1";
+  private static final String INITIAL_CONTENT = "original";
+  private static final String UPDATED_CONTENT = "updated";
+  private static final String TERM_A = "termA";
+  private static final String TERM_B = "termB";
+  private static final String TERM_C = "termC";
+
+  @Autowired
+  private SchemaDao schemaDao;
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @BeforeEach
+  void cleanUp() {
+    transactionTemplate.executeWithoutResult(status -> schemaDao.deleteAll());
+  }
+
+  // ===== selectVersions =====
+
+  @Test
+  void selectVersions_afterInsert_returnsVersion1() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            INITIAL_CONTENT, Set.of(TERM_A))));
+
+    List<SchemaRecord> versions = schemaDao.selectVersions(SCHEMA_ID);
+
+    assertEquals(1, versions.size());
+    SchemaRecord v1 = versions.getFirst();
+    assertEquals(1, v1.version());
+    assertEquals(INITIAL_CONTENT, v1.content());
+    assertNotNull(v1.createdAt());
+  }
+
+  @Test
+  void selectVersions_afterUpdate_returnsVersions1And2() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            INITIAL_CONTENT, Set.of(TERM_A))));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, UPDATED_CONTENT, Set.of(TERM_B)));
+
+    List<SchemaRecord> versions = schemaDao.selectVersions(SCHEMA_ID);
+
+    assertEquals(2, versions.size());
+    assertEquals(1, versions.get(0).version());
+    assertEquals(INITIAL_CONTENT, versions.get(0).content());
+    assertEquals(2, versions.get(1).version());
+    assertEquals(UPDATED_CONTENT, versions.get(1).content());
+  }
+
+  @Test
+  void selectVersions_termsPreservedPerVersion() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            "content-v1", Set.of(TERM_A, TERM_B))));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, "content-v2", Set.of(TERM_C)));
+
+    List<SchemaRecord> versions = schemaDao.selectVersions(SCHEMA_ID);
+    assertEquals(Set.of(TERM_A, TERM_B), versions.get(0).terms());
+    assertEquals(Set.of(TERM_C), versions.get(1).terms());
+  }
+
+  @Test
+  void selectVersions_nonExistentSchema_returnsEmptyList() {
+    List<SchemaRecord> versions = schemaDao.selectVersions("nonexistent");
+
+    assertTrue(versions.isEmpty());
+  }
+
+  @Test
+  void selectVersions_threeUpdates_producesVersions123() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            "v1", null)));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, "v2", null));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, "v3", null));
+
+    List<SchemaRecord> versions = schemaDao.selectVersions(SCHEMA_ID);
+
+    assertEquals(3, versions.size());
+    assertEquals(1, versions.get(0).version());
+    assertEquals("v1", versions.get(0).content());
+    assertEquals(2, versions.get(1).version());
+    assertEquals("v2", versions.get(1).content());
+    assertEquals(3, versions.get(2).version());
+    assertEquals("v3", versions.get(2).content());
+  }
+
+  @Test
+  void selectVersions_ascendingOrder() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            "v1", null)));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, "v2", null));
+
+    List<SchemaRecord> versions = schemaDao.selectVersions(SCHEMA_ID);
+
+    assertEquals(1, versions.get(0).version());
+    assertEquals(2, versions.get(1).version());
+    assertTrue(versions.get(0).version() < versions.get(1).version(),
+        "Versions should be in ascending order");
+  }
+
+  // ===== selectVersion =====
+
+  @Test
+  void selectVersion_version1_returnsOriginalContent() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            INITIAL_CONTENT, Set.of(TERM_A))));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, UPDATED_CONTENT, Set.of(TERM_B)));
+
+    Optional<SchemaRecord> v1 = schemaDao.selectVersion(SCHEMA_ID, 1);
+
+    assertTrue(v1.isPresent());
+    assertEquals(INITIAL_CONTENT, v1.get().content());
+    assertEquals(1, v1.get().version());
+    assertEquals(Set.of(TERM_A), v1.get().terms());
+  }
+
+  @Test
+  void selectVersion_version2_returnsUpdatedContent() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            INITIAL_CONTENT, Set.of(TERM_A))));
+
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.update(SCHEMA_ID, UPDATED_CONTENT, Set.of(TERM_B)));
+
+    Optional<SchemaRecord> v2 = schemaDao.selectVersion(SCHEMA_ID, 2);
+
+    assertTrue(v2.isPresent());
+    assertEquals(UPDATED_CONTENT, v2.get().content());
+    assertEquals(2, v2.get().version());
+    assertEquals(Set.of(TERM_B), v2.get().terms());
+  }
+
+  @Test
+  void selectVersion_nonExistentVersion_returnsEmpty() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+                INITIAL_CONTENT, null)));
+
+    Optional<SchemaRecord> result = schemaDao.selectVersion(SCHEMA_ID, 999);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void selectVersion_versionZero_returnsEmpty() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+            INITIAL_CONTENT, null)));
+
+    Optional<SchemaRecord> result = schemaDao.selectVersion(SCHEMA_ID, 0);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void selectVersion_negativeVersion_returnsEmpty() {
+    transactionTemplate.executeWithoutResult(status ->
+        schemaDao.insert(new SchemaRecord(SCHEMA_ID, SCHEMA_HASH, SchemaType.ONTOLOGY,
+                INITIAL_CONTENT, null)));
+
+    Optional<SchemaRecord> result = schemaDao.selectVersion(SCHEMA_ID, -1);
+
+    assertTrue(result.isEmpty());
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
@@ -7,6 +7,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.RdfContentTypeProperties;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.NotFoundException;
@@ -60,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @SpringBootTest
 @ActiveProfiles("test")
-@ContextConfiguration(classes = {AssetStoreTest.TestApplication.class, AssetStoreImpl.class, AssetJpaDao.class, AssetStoreTest.class,
+@ContextConfiguration(classes = {AssetStoreTest.TestApplication.class, AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class, AssetStoreTest.class,
   DummyGraphStore.class, DatabaseConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, DidResolverConfig.class, HttpDocumentResolver.class,
   RdfContentTypeProperties.class, FileStoreConfig.class, DidDocumentResolver.class, JwtSignatureVerifier.class})
 @Slf4j
@@ -193,16 +194,14 @@ public class AssetStoreTest {
     final String hash2 = assetMeta2.getAssetHash();
     assetStorePublisher.storeCredential(assetMeta2, createVerificationResult(assetMeta2));
 
-    final AssetMetadata byHash1 = assetStorePublisher.getByHash(hash1);
-    assertEquals(AssetStatus.DEPRECATED, byHash1.getStatus(),
-        "First asset should have been deprecated.");
-    assertTrue(byHash1.getStatusDatetime().isAfter(assetMeta1.getStatusDatetime()));
+    // In-place update: hash1 row is gone (updated to hash2 in-place); hash2 row is the current ACTIVE asset
+    assertThrows(NotFoundException.class, () -> assetStorePublisher.getByHash(hash1),
+        "Old hash should not exist after in-place update.");
     assertThatAssetHasTheSameData(assetMeta2, assetStorePublisher.getByHash(hash2), true);
+    assertEquals(AssetStatus.ACTIVE, assetStorePublisher.getByHash(hash2).getStatus());
 
-    assetStorePublisher.deleteAsset(hash1);
     assetStorePublisher.deleteAsset(hash2);
 
-    assertThrows(NotFoundException.class, () -> assetStorePublisher.getByHash(hash1));
     assertThrows(NotFoundException.class, () -> assetStorePublisher.getByHash(hash2));
   }
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
@@ -10,6 +10,7 @@ import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.JacksonConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.config.PubSubConfig;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.cestracker.CesTrackerJpaDao;
 import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
@@ -74,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 @ActiveProfiles({"test"})
 @ContextConfiguration(classes = {
         AssetJpaDao.class,
+        AssetAuditRepository.class,
         AssetStoreConfig.class,
         CesCompositePublisherTest.TestApplication.class,
         CesTrackerJpaDao.class,

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
@@ -20,22 +20,24 @@ import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.pojo.GraphQuery;
 import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.assetstore.IriGenerator;
+import eu.xfsc.fc.core.service.assetstore.IriValidator;
 import eu.xfsc.fc.core.service.graphdb.DummyGraphStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
-import eu.xfsc.fc.core.service.assetstore.IriGenerator;
-import eu.xfsc.fc.core.service.assetstore.IriValidator;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
-import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
+import eu.xfsc.fc.core.service.verification.FormatDetector;
 import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
 import eu.xfsc.fc.core.service.verification.SchemaValidationServiceImpl;
 import eu.xfsc.fc.core.service.verification.TrustFrameworkBaseClass;
 import eu.xfsc.fc.core.service.verification.Vc11Processor;
 import eu.xfsc.fc.core.service.verification.Vc2Processor;
 import eu.xfsc.fc.core.service.verification.VerificationServiceImpl;
+import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 import okhttp3.mockwebserver.MockResponse;
@@ -69,11 +71,39 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 @SpringBootTest(properties = {"publisher.impl=ces", "publisher.url=http://localhost:9091", "publisher.comp-url=http://localhost:9090"})
 @ActiveProfiles({"test"})
-@ContextConfiguration(classes = {CesCompositePublisherTest.TestApplication.class, PubSubConfig.class, JacksonConfig.class, DatabaseConfig.class, AssetStoreConfig.class, AssetJpaDao.class,
-		DummyGraphStore.class, VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, FileStoreConfig.class, DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
-		DocumentLoaderConfig.class, DocumentLoaderProperties.class, ValidatorCacheJpaDao.class, CesTrackerJpaDao.class, CredentialVerificationStrategy.class, SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
-		JwtContentPreprocessor.class, Vc11Processor.class, Vc2Processor.class, JwtSignatureVerifier.class,
-		IriGenerator.class, IriValidator.class})
+@ContextConfiguration(classes = {
+        AssetJpaDao.class,
+        AssetStoreConfig.class,
+        CesCompositePublisherTest.TestApplication.class,
+        CesTrackerJpaDao.class,
+        CredentialVerificationStrategy.class,
+        DatabaseConfig.class,
+        DidDocumentResolver.class,
+        DidResolverConfig.class,
+        DocumentLoaderProperties.class,
+        DocumentLoaderConfig.class,
+		DummyGraphStore.class,
+        FileStoreConfig.class,
+        FormatDetector.class,
+        HttpDocumentResolver.class,
+        IriGenerator.class,
+        IriValidator.class,
+        JwtContentPreprocessor.class,
+        JacksonConfig.class,
+        JwtContentPreprocessor.class,
+        JwtSignatureVerifier.class,
+        LoireJwtParser.class,
+        ProtectedNamespaceFilter.class,
+        ProtectedNamespaceProperties.class,
+        PubSubConfig.class,
+        SchemaJpaDao.class,
+        SchemaStoreImpl.class,
+        SchemaValidationServiceImpl.class,
+        ValidatorCacheJpaDao.class,
+        Vc11Processor.class,
+        Vc2Processor.class,
+        VerificationServiceImpl.class,
+})
 //@Import(EmbeddedNeo4JConfig.class)
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 public class CesCompositePublisherTest {
@@ -88,8 +118,7 @@ public class CesCompositePublisherTest {
 
     @Autowired
     private AssetPublisher cesPublisher;
-    //@Autowired
-    //private Neo4j embeddedDatabaseServer;
+
     @Autowired
     private GraphStore graphStore;
     @Autowired
@@ -116,7 +145,6 @@ public class CesCompositePublisherTest {
     void cleanUpStores() throws Exception {
         mockCompService.shutdown();
         mockCesService.shutdown();
-        //embeddedDatabaseServer.close();
     }
 
     @AfterEach
@@ -124,10 +152,8 @@ public class CesCompositePublisherTest {
         schemaStore.clear();
     }
 
-
     @Test
     public void test01AssetStoreRollback() {
-        //ContentAccessor content = getAccessor("Pub-Sub-Tests/sag-research.jsonld");
         cesPublisher.setTransactional(true);
         ContentAccessor content = getAccessor("VerificationService/syntax/legalPerson2.jsonld");
         schemaStore.initializeDefaultSchemas();
@@ -151,7 +177,6 @@ public class CesCompositePublisherTest {
 
     @Test
     public void test02AssetStoreCommit() {
-        //ContentAccessor content = getAccessor("Pub-Sub-Tests/sag-research.jsonld");
         cesPublisher.setTransactional(false);
         ContentAccessor content = getAccessor("VerificationService/syntax/legalPerson2.jsonld");
         schemaStore.initializeDefaultSchemas();
@@ -165,9 +190,6 @@ public class CesCompositePublisherTest {
                 .addHeader("Content-Type", "application/json")
                 .setResponseCode(409));
         assetStorePublisher.storeCredential(assetMetadata, vr);
-        //List<Map<String, Object>> claims = graphStore.queryData(
-        //        new GraphQuery("MATCH (n {uri: $uri}) RETURN labels(n), n", Map.of("uri", assetMetadata.getId()))).getResults();
-        //Assertions.assertTrue(claims.size() > 0);
         AssetMetadata assetMetadata2 = assetStorePublisher.getByHash(assetMetadata.getAssetHash());
         assertNotNull(assetMetadata2);
         assertEquals(assetMetadata.getAssetHash(), assetMetadata2.getAssetHash());

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
@@ -12,6 +12,7 @@ import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.config.PubSubConfig;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.cestracker.CesTrackerJpaDao;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.NotFoundException;
@@ -82,8 +83,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
         DidResolverConfig.class,
         DocumentLoaderProperties.class,
         DocumentLoaderConfig.class,
-		DummyGraphStore.class,
-        FileStoreConfig.class,
+		DummyGraphStore.class, SchemaAuditRepository.class, FileStoreConfig.class,
         FormatDetector.class,
         HttpDocumentResolver.class,
         IriGenerator.class,

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
@@ -723,53 +723,6 @@ public class SchemaStoreTest {
     }
   }
 
-  @Test
-  @Transactional(propagation = Propagation.NOT_SUPPORTED) // see comment on sequentialUpdates test
-  void updateSchema_concurrentUpdates_versionsAreUniqueAndConsecutive() throws InterruptedException {
-    int threadCount = 5;
-    String[] paths = {
-        "Schema-Tests/valid-schemaShapeReduced.ttl",
-        "Schema-Tests/valid-schemaShape.ttl"
-    };
-
-    String schemaId = schemaStore.addSchema(
-        TestUtil.getAccessor(getClass(), paths[0])).id();
-
-    List<SchemaStoreResult> results = Collections.synchronizedList(new ArrayList<>());
-    CountDownLatch startLatch = new CountDownLatch(1);
-    CountDownLatch doneLatch = new CountDownLatch(threadCount);
-    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
-
-    for (int i = 0; i < threadCount; i++) {
-      String path = paths[i % 2];
-      executor.submit(() -> {
-        try {
-          startLatch.await();
-          results.add(schemaStore.updateSchema(schemaId, TestUtil.getAccessor(getClass(), path)));
-        } catch (Exception ignored) {
-        } finally {
-          doneLatch.countDown();
-        }
-      });
-    }
-
-    startLatch.countDown();
-    doneLatch.await();
-    executor.shutdown();
-
-    try {
-      assertEquals(threadCount, results.size(), "All concurrent updates must succeed");
-
-      Set<Integer> versions = results.stream().map(SchemaStoreResult::version).collect(Collectors.toSet());
-      assertEquals(threadCount, versions.size(), "Each update must produce a unique version number");
-
-      results.forEach(r -> assertEquals(r.version() - 1, r.previousVersion(),
-          "previousVersion must equal version - 1 for each result"));
-    } finally {
-      schemaStore.deleteSchema(schemaId);
-    }
-  }
-
   private static boolean isExistTriple(Model model, String sub, String pre, String obj) {
     StmtIterator iterActual = model.listStatements();
     while (iterActual.hasNext()) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
@@ -24,13 +24,18 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Statement;
@@ -46,6 +51,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import eu.xfsc.fc.core.config.DatabaseConfig;
@@ -70,7 +76,7 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SchemaStoreTest.TestApplication.class, FileStoreConfig.class,
-  SchemaStoreTest.class, SchemaStoreImpl.class, DatabaseConfig.class, SchemaJpaDao.class,
+  SchemaStoreTest.class, SchemaStoreImpl.class, DatabaseConfig.class, SchemaJpaDao.class, SchemaAuditRepository.class,
   ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 @Transactional
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
@@ -513,7 +519,7 @@ public class SchemaStoreTest {
     SchemaStoreResult result = schemaStore.addSchema(content, JSON);
 
     assertEquals("https://example.org/schemas/person", result.id());
-    assertNotNull(result.uploadTime());
+    assertNotNull(result.createdAt());
   }
 
   @Test
@@ -523,7 +529,7 @@ public class SchemaStoreTest {
     SchemaStoreResult result = schemaStore.addSchema(content, JSON);
 
     assertTrue(result.id().startsWith("urn:uuid:"));
-    assertNotNull(result.uploadTime());
+    assertNotNull(result.createdAt());
   }
 
   @Test
@@ -540,7 +546,7 @@ public class SchemaStoreTest {
     SchemaStoreResult result = schemaStore.addSchema(content, XML);
 
     assertEquals("http://example.org/config", result.id());
-    assertNotNull(result.uploadTime());
+    assertNotNull(result.createdAt());
   }
 
   @Test
@@ -550,7 +556,7 @@ public class SchemaStoreTest {
     SchemaStoreResult result = schemaStore.addSchema(content, XML);
 
     assertTrue(result.id().startsWith("urn:uuid:"));
-    assertNotNull(result.uploadTime());
+    assertNotNull(result.createdAt());
   }
 
   @Test
@@ -691,6 +697,77 @@ public class SchemaStoreTest {
     SchemaStoreResult updateResult = schemaStore.updateSchema(addResult.id(), updatedContent);
 
     assertEquals(addResult.id(), updateResult.id());
+  }
+
+  // NOT_SUPPORTED overrides the class-level @Transactional so each service call commits in its
+  // own transaction. Without this, all calls join the test transaction, Envers never writes
+  // audit entries (it writes on commit), and getVersionCount always returns 0.
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED)
+  void updateSchema_sequentialUpdates_versionsIncrement() {
+    String schemaId = schemaStore.addSchema(
+        TestUtil.getAccessor(getClass(), "Schema-Tests/valid-schemaShapeReduced.ttl")).id();
+
+    try {
+      SchemaStoreResult first = schemaStore.updateSchema(schemaId,
+          TestUtil.getAccessor(getClass(), "Schema-Tests/valid-schemaShape.ttl"));
+      SchemaStoreResult second = schemaStore.updateSchema(schemaId,
+          TestUtil.getAccessor(getClass(), "Schema-Tests/valid-schemaShapeReduced.ttl"));
+
+      assertEquals(2, first.version());
+      assertEquals(1, first.previousVersion());
+      assertEquals(3, second.version());
+      assertEquals(2, second.previousVersion());
+    } finally {
+      schemaStore.deleteSchema(schemaId);
+    }
+  }
+
+  @Test
+  @Transactional(propagation = Propagation.NOT_SUPPORTED) // see comment on sequentialUpdates test
+  void updateSchema_concurrentUpdates_versionsAreUniqueAndConsecutive() throws InterruptedException {
+    int threadCount = 5;
+    String[] paths = {
+        "Schema-Tests/valid-schemaShapeReduced.ttl",
+        "Schema-Tests/valid-schemaShape.ttl"
+    };
+
+    String schemaId = schemaStore.addSchema(
+        TestUtil.getAccessor(getClass(), paths[0])).id();
+
+    List<SchemaStoreResult> results = Collections.synchronizedList(new ArrayList<>());
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+    for (int i = 0; i < threadCount; i++) {
+      String path = paths[i % 2];
+      executor.submit(() -> {
+        try {
+          startLatch.await();
+          results.add(schemaStore.updateSchema(schemaId, TestUtil.getAccessor(getClass(), path)));
+        } catch (Exception ignored) {
+        } finally {
+          doneLatch.countDown();
+        }
+      });
+    }
+
+    startLatch.countDown();
+    doneLatch.await();
+    executor.shutdown();
+
+    try {
+      assertEquals(threadCount, results.size(), "All concurrent updates must succeed");
+
+      Set<Integer> versions = results.stream().map(SchemaStoreResult::version).collect(Collectors.toSet());
+      assertEquals(threadCount, versions.size(), "Each update must produce a unique version number");
+
+      results.forEach(r -> assertEquals(r.version() - 1, r.previousVersion(),
+          "previousVersion must equal version - 1 for each result"));
+    } finally {
+      schemaStore.deleteSchema(schemaId);
+    }
   }
 
   private static boolean isExistTriple(Model model, String sub, String pre, String obj) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/FormatDetectorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/FormatDetectorTest.java
@@ -1,0 +1,311 @@
+package eu.xfsc.fc.core.service.verification;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.Ed25519Signer;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+
+import java.util.List;
+import java.util.Map;
+
+import net.minidev.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FormatDetectorTest {
+
+  private static final String VC2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
+  private static final String VC11_CONTEXT = "https://www.w3.org/2018/credentials/v1";
+  private static final String GAIAX_2511_CONTEXT = "https://w3id.org/gaia-x/2511#";
+
+  private final FormatDetector detector = new FormatDetector(new ObjectMapper());
+    private static JWSSigner signer;
+
+  @BeforeAll
+  static void initKeys() throws Exception {
+    OctetKeyPair jwk = new OctetKeyPairGenerator(Curve.Ed25519).keyID("test-key").generate();
+    signer = new Ed25519Signer(jwk);
+  }
+
+  // --- Path 1: Gaia-X v1 (Tagus) ---
+
+  @Test
+  void detect_vc11WithProofBlock_returnsTagus() {
+    String body = """
+        {
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          "type": ["VerifiableCredential"],
+          "proof": { "type": "JsonWebSignature2020" }
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.GAIAX_V1_TAGUS, result);
+  }
+
+  @Test
+  void detect_vc11WithProofBlockAndGaiaxContext_returnsTagus() {
+    String body = """
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1",
+            "https://registry.lab.gaia-x.eu/development/api/trusted-shape-registry/v1/shapes/jsonld/trustframework#"
+          ],
+          "type": ["VerifiableCredential", "LegalParticipant"],
+          "proof": { "type": "JsonWebSignature2020" }
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.GAIAX_V1_TAGUS, result);
+  }
+
+  @Test
+  void detect_vc11WithoutProofBlock_returnsTagus() {
+    String body = """
+        {
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          "type": ["VerifiablePresentation"],
+          "verifiableCredential": {}
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.GAIAX_V1_TAGUS, result);
+  }
+
+  // --- Path 2: Gaia-X v2 (Loire) ---
+
+  @Test
+  void detect_loireVcJwt_returnsLoire() throws Exception {
+    String jwt = buildLoireVcJwt();
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(jwt));
+
+    assertEquals(CredentialFormat.GAIAX_V2_LOIRE, result);
+  }
+
+  @Test
+  void detect_loireVpJwt_returnsLoire() throws Exception {
+    String jwt = buildLoireVpJwt();
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(jwt));
+
+    assertEquals(CredentialFormat.GAIAX_V2_LOIRE, result);
+  }
+
+  @Test
+  void detect_jwtWithTopLevelContextButNoTypHeader_returnsUnknown() throws Exception {
+    // Missing typ header → UNKNOWN (no lenient fallback)
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .build();
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT, GAIAX_2511_CONTEXT))
+        .claim("type", List.of("VerifiableCredential", "gx:LegalPerson"))
+        .claim("credentialSubject", Map.of("id", "did:web:example.com"))
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(signedJwt.serialize()));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  // --- Path 3: Non-Gaia-X VC 2.0 (danubetech) ---
+
+  @Test
+  void detect_danubetechVcJwtWithVcWrapper_returnsDanubetech() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .build();
+    JSONObject vcObj = new JSONObject();
+    vcObj.put("@context", List.of(VC2_CONTEXT));
+    vcObj.put("type", List.of("VerifiableCredential"));
+    vcObj.put("credentialSubject", Map.of("id", "did:web:example.com"));
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .subject("did:web:example.com")
+        .claim("vc", vcObj)
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(signedJwt.serialize()));
+
+    assertEquals(CredentialFormat.VC2_DANUBETECH, result);
+  }
+
+  @Test
+  void detect_danubetechVpJwtWithVpWrapper_returnsDanubetech() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .build();
+    JSONObject vpObj = new JSONObject();
+    vpObj.put("@context", List.of(VC2_CONTEXT));
+    vpObj.put("type", List.of("VerifiablePresentation"));
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("vp", vpObj)
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(signedJwt.serialize()));
+
+    assertEquals(CredentialFormat.VC2_DANUBETECH, result);
+  }
+
+  // --- UNKNOWN / rejection cases ---
+
+  @Test
+  void detect_loireTypButVcWrapperPresent_returnsUnknown() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .type(new JOSEObjectType("vc+ld+json+jwt"))
+        .build();
+    JSONObject vcObj = new JSONObject();
+    vcObj.put("@context", List.of(VC2_CONTEXT));
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT))
+        .claim("vc", vcObj)
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(signedJwt.serialize()));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  @Test
+  void detect_vc2NonJwtWithoutProof_returnsDanubetech() {
+    String body = """
+        {
+          "@context": ["https://www.w3.org/ns/credentials/v2"],
+          "type": ["VerifiableCredential"]
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.VC2_DANUBETECH, result);
+  }
+
+  @Test
+  void detect_vc2WithProofButNoVc11Context_returnsDanubetech() {
+    String body = """
+        {
+          "@context": ["https://www.w3.org/ns/credentials/v2"],
+          "proof": { "type": "DataIntegrityProof" }
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.VC2_DANUBETECH, result);
+  }
+
+  @Test
+  void detect_nonJwtWithoutRecognizedContext_returnsUnknown() {
+    String body = """
+        {
+          "@context": ["https://example.org/custom"],
+          "type": ["SomethingElse"]
+        }
+        """;
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  @Test
+  void detect_malformedJson_returnsUnknown() {
+    String body = "not json at all";
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(body));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  @Test
+  void detect_emptyBody_returnsUnknown() {
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(""));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  @Test
+  void detect_jwtWithNoRecognizablePayload_returnsUnknown() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .build();
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("arbitrary", "data")
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+
+    CredentialFormat result = detector.detect(new ContentAccessorDirect(signedJwt.serialize()));
+
+    assertEquals(CredentialFormat.UNKNOWN, result);
+  }
+
+  // --- helpers ---
+
+  private String buildLoireVcJwt() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .type(new JOSEObjectType("vc+ld+json+jwt"))
+        .contentType("vc+ld+json")
+        .build();
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT, GAIAX_2511_CONTEXT))
+        .claim("type", List.of("VerifiableCredential", "gx:LegalPerson"))
+        .claim("credentialSubject", Map.of("id", "did:web:example.com"))
+        .claim("validFrom", "2026-01-01T00:00:00Z")
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+    return signedJwt.serialize();
+  }
+
+  private String buildLoireVpJwt() throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .type(new JOSEObjectType("vp+ld+jwt"))
+        .contentType("vp+ld+json")
+        .build();
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT))
+        .claim("type", List.of("VerifiablePresentation"))
+        .claim("holder", "did:web:example.com")
+        .claim("verifiableCredential", List.of())
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+    return signedJwt.serialize();
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/GaiaxTrustFrameworkTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/GaiaxTrustFrameworkTest.java
@@ -30,6 +30,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.VerificationException;
@@ -65,7 +66,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {GaiaxTrustFrameworkTest.TestApplication.class, FileStoreConfig.class,
     DocumentLoaderConfig.class, DocumentLoaderProperties.class, VerificationServiceImpl.class,
-    SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class, DidResolverConfig.class,
+    SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class,
     DidDocumentResolver.class, ValidatorCacheJpaDao.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 public class GaiaxTrustFrameworkTest {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireJwtParserTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireJwtParserTest.java
@@ -1,0 +1,237 @@
+package eu.xfsc.fc.core.service.verification;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.Ed25519Signer;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+
+import java.util.List;
+import java.util.Map;
+
+import net.minidev.json.JSONObject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LoireJwtParserTest {
+
+  private static final String VC2_CONTEXT = "https://www.w3.org/ns/credentials/v2";
+  private static final String GAIAX_2511_CONTEXT = "https://w3id.org/gaia-x/2511#";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final LoireJwtParser parser = new LoireJwtParser();
+  private static OctetKeyPair jwk;
+  private static JWSSigner signer;
+
+  @BeforeAll
+  static void initKeys() throws Exception {
+    jwk = new OctetKeyPairGenerator(Curve.Ed25519).keyID("test-key").generate();
+    signer = new Ed25519Signer(jwk);
+  }
+
+  // --- valid Loire VC ---
+
+  @Test
+  void unwrap_validLoireVc_returnsJsonLdWithCredentialFields() throws Exception {
+    String jwt = buildLoireVcJwt();
+
+    ContentAccessor result = parser.unwrap(new ContentAccessorDirect(jwt));
+
+    String json = result.getContentAsString();
+    JsonNode root = MAPPER.readTree(json);
+    assertNotNull(root.get("@context"), "unwrapped payload must have @context");
+    assertNotNull(root.get("credentialSubject"), "unwrapped payload must have credentialSubject");
+    assertEquals("2026-01-01T00:00:00Z", root.get("validFrom").asText());
+  }
+
+  @Test
+  void unwrap_validLoireVp_returnsJsonLdWithPresentationFields() throws Exception {
+    String jwt = buildLoireVpJwt();
+
+    ContentAccessor result = parser.unwrap(new ContentAccessorDirect(jwt));
+
+    String json = result.getContentAsString();
+    JsonNode root = MAPPER.readTree(json);
+    assertNotNull(root.get("@context"));
+    assertNotNull(root.get("verifiableCredential"));
+  }
+
+  // --- typ/cty header validation ---
+
+  @Test
+  void unwrap_missingTypHeader_throwsClientException() throws Exception {
+    String jwt = buildJwtWithHeaders(null, null);
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("missing required 'typ' header"));
+  }
+
+  @Test
+  void unwrap_invalidTypHeader_throwsClientException() throws Exception {
+    String jwt = buildJwtWithHeaders("jwt", null);
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("invalid 'typ' header"));
+  }
+
+  @Test
+  void unwrap_vcTypWithWrongCty_throwsClientException() throws Exception {
+    String jwt = buildJwtWithHeaders("vc+ld+json+jwt", "vp+ld+json");
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("invalid 'cty' header"));
+  }
+
+  @Test
+  void unwrap_vpTypWithWrongCty_throwsClientException() throws Exception {
+    String jwt = buildVpJwtWithHeaders("vp+ld+jwt", "vc+ld+json");
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("invalid 'cty' header"));
+  }
+
+  @Test
+  void unwrap_missingCtyHeader_throwsClientException() throws Exception {
+    String jwt = buildJwtWithHeaders("vc+ld+json+jwt", null);
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("missing required 'cty' header"));
+  }
+
+  // --- wrapper claim rejection ---
+
+  @Test
+  void unwrap_vcWrapperClaimPresent_throwsClientException() throws Exception {
+    String jwt = buildJwtWithWrapperClaim("vc");
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("must not contain 'vc' wrapper claim"));
+  }
+
+  @Test
+  void unwrap_vpWrapperClaimPresent_throwsClientException() throws Exception {
+    String jwt = buildJwtWithWrapperClaim("vp");
+
+    ClientException ex = assertThrows(ClientException.class,
+        () -> parser.unwrap(new ContentAccessorDirect(jwt)));
+
+    assertTrue(ex.getMessage().contains("must not contain 'vp' wrapper claim"));
+  }
+
+  // --- isVpJwt ---
+
+  @Test
+  void isVpJwt_vpJwt_returnsTrue() throws Exception {
+    String jwt = buildLoireVpJwt();
+
+    assertTrue(parser.isVpJwt(new ContentAccessorDirect(jwt)));
+  }
+
+  @Test
+  void isVpJwt_vcJwt_returnsFalse() throws Exception {
+    String jwt = buildLoireVcJwt();
+
+    assertFalse(parser.isVpJwt(new ContentAccessorDirect(jwt)));
+  }
+
+  // --- helpers ---
+
+  private String buildLoireVcJwt() throws Exception {
+    return buildJwtWithHeaders("vc+ld+json+jwt", "vc+ld+json");
+  }
+
+  private String buildLoireVpJwt() throws Exception {
+    return buildVpJwtWithHeaders("vp+ld+jwt", "vp+ld+json");
+  }
+
+  private String buildJwtWithHeaders(String typ, String cty) throws Exception {
+    JWSHeader.Builder headerBuilder = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key");
+    if (typ != null) {
+      headerBuilder.type(new JOSEObjectType(typ));
+    }
+    if (cty != null) {
+      headerBuilder.contentType(cty);
+    }
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT, GAIAX_2511_CONTEXT))
+        .claim("type", List.of("VerifiableCredential", "gx:LegalPerson"))
+        .claim("credentialSubject", Map.of("id", "did:web:example.com"))
+        .claim("validFrom", "2026-01-01T00:00:00Z")
+        .build();
+    SignedJWT signedJwt = new SignedJWT(headerBuilder.build(), claims);
+    signedJwt.sign(signer);
+    return signedJwt.serialize();
+  }
+
+  private String buildVpJwtWithHeaders(String typ, String cty) throws Exception {
+    JWSHeader.Builder headerBuilder = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key");
+    if (typ != null) {
+      headerBuilder.type(new JOSEObjectType(typ));
+    }
+    if (cty != null) {
+      headerBuilder.contentType(cty);
+    }
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT))
+        .claim("type", List.of("VerifiablePresentation"))
+        .claim("holder", "did:web:example.com")
+        .claim("verifiableCredential", List.of())
+        .build();
+    SignedJWT signedJwt = new SignedJWT(headerBuilder.build(), claims);
+    signedJwt.sign(signer);
+    return signedJwt.serialize();
+  }
+
+  private String buildJwtWithWrapperClaim(String wrapperKey) throws Exception {
+    JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+        .keyID("did:web:example.com#test-key")
+        .type(new JOSEObjectType("vc+ld+json+jwt"))
+        .contentType("vc+ld+json")
+        .build();
+    JSONObject wrapper = new JSONObject();
+    wrapper.put("@context", List.of(VC2_CONTEXT));
+    JWTClaimsSet claims = new JWTClaimsSet.Builder()
+        .issuer("did:web:example.com")
+        .claim("@context", List.of(VC2_CONTEXT))
+        .claim("type", List.of("VerifiableCredential"))
+        .claim(wrapperKey, wrapper)
+        .build();
+    SignedJWT signedJwt = new SignedJWT(header, claims);
+    signedJwt.sign(signer);
+    return signedJwt.serialize();
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
@@ -7,6 +7,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.revalidator.RevalidatorChunksJpaDao;
 import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
@@ -65,7 +66,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {RevalidationServiceTest.TestApplication.class, RevalidationServiceImpl.class, RevalidatorChunksJpaDao.class, FileStoreConfig.class, DummyGraphStore.class,
-  VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, ValidatorCacheJpaDao.class, AssetStoreImpl.class, AssetJpaDao.class,
+  VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, ValidatorCacheJpaDao.class, AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class,
   DocumentLoaderConfig.class, DocumentLoaderProperties.class, DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
   JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
   IriGenerator.class, IriValidator.class, ObjectMapper.class})

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
@@ -9,6 +9,7 @@ import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
 import eu.xfsc.fc.core.dao.revalidator.RevalidatorChunksJpaDao;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.VerificationException;
@@ -45,7 +46,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -65,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {RevalidationServiceTest.TestApplication.class, RevalidationServiceImpl.class, RevalidatorChunksJpaDao.class, FileStoreConfig.class, DummyGraphStore.class,
-  VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class, ValidatorCacheJpaDao.class, AssetStoreImpl.class, AssetJpaDao.class,
+  VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, ValidatorCacheJpaDao.class, AssetStoreImpl.class, AssetJpaDao.class,
   DocumentLoaderConfig.class, DocumentLoaderProperties.class, DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
   JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
   IriGenerator.class, IriValidator.class, ObjectMapper.class})

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceTest.java
@@ -23,6 +23,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.pojo.SchemaValidationResult;
@@ -45,7 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SchemaValidationServiceTest.TestApplication.class, FileStoreConfig.class,
         DocumentLoaderConfig.class, DocumentLoaderProperties.class, SchemaValidationServiceImpl.class,
-        VerificationServiceImpl.class, CredentialVerificationStrategy.class, SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class,
+        VerificationServiceImpl.class, CredentialVerificationStrategy.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class,
         DidResolverConfig.class, DidDocumentResolver.class, ValidatorCacheJpaDao.class, HttpDocumentResolver.class,
         JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SignatureVerificationTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SignatureVerificationTest.java
@@ -26,6 +26,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.VerificationException;
@@ -45,7 +46,7 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SignatureVerificationTest.TestApplication.class, FileStoreConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
-        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class, DidResolverConfig.class, DidDocumentResolver.class, ValidatorCacheJpaDao.class,
+        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class, DidDocumentResolver.class, ValidatorCacheJpaDao.class,
         ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 @TestMethodOrder(MethodOrderer.MethodName.class)

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/ValidatorCacheTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/ValidatorCacheTest.java
@@ -7,6 +7,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheDao;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.pojo.Validator;
@@ -38,7 +39,7 @@ import java.time.temporal.ChronoUnit;
 @SpringBootTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {ValidatorCacheTest.TestApplication.class, ValidatorCacheJpaDao.class, DatabaseConfig.class, FileStoreConfig.class,
-        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
+        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
         DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
         JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 //@DirtiesContext

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
@@ -117,11 +117,7 @@ public class VerificationServiceTest {
   @Test
   void verifyCredential_vc2JwtWrappedInput_vc2ProcessorPreProcessInvoked() {
     String vcJson = getAccessor("Claims-Tests/participantVC2.jsonld").getContentAsString();
-    String header = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
-    String payload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"vc\":" + vcJson + "}").getBytes(StandardCharsets.UTF_8));
-    ContentAccessor content = new ContentAccessorDirect(header + "." + payload + ".AAAA");
+    ContentAccessor content = new ContentAccessorDirect(fakeVcJwt(vcJson));
 
     verificationService.verifyCredential(content, false, false, false, false);
 
@@ -257,8 +253,8 @@ public class VerificationServiceTest {
     assertEquals("http://gaiax.de", vro.getIssuer());
     assertNotNull(vro.getClaims());
     assertEquals(19, vro.getClaims().size()); //!!
-    assertNull(vro.getValidators());
-    assertNull(vro.getValidatorDids());
+    assertTrue(vro.getValidators().isEmpty());
+    assertTrue(vro.getValidatorDids().isEmpty());
     assertEquals(Instant.parse("2022-10-19T18:48:09Z"), vro.getIssuedDateTime());
   }
 
@@ -276,8 +272,8 @@ public class VerificationServiceTest {
     assertEquals("http://gaiax.de", vro.getIssuer());
     assertNotNull(vro.getClaims());
     assertEquals(21, vro.getClaims().size()); //!!
-    assertNull(vro.getValidators());
-    assertNull(vro.getValidatorDids());
+    assertTrue(vro.getValidators().isEmpty());
+    assertTrue(vro.getValidatorDids().isEmpty());
     assertEquals(Instant.parse("2022-10-19T18:48:09Z"), vro.getIssuedDateTime());
   }
 
@@ -294,8 +290,8 @@ public class VerificationServiceTest {
     assertEquals("http://gaiax.de", vrp.getParticipantName()); // could be 'Provider Name'..
     assertNotNull(vrp.getClaims());
     assertEquals(26, vrp.getClaims().size()); //!!
-    assertNull(vrp.getValidators());
-    assertNull(vrp.getValidatorDids());
+    assertTrue(vrp.getValidators().isEmpty());
+    assertTrue(vrp.getValidatorDids().isEmpty());
     assertEquals(Instant.parse("2022-10-19T18:48:09Z"), vrp.getIssuedDateTime());
   }
 
@@ -314,8 +310,8 @@ public class VerificationServiceTest {
     assertEquals("http://gaiax.de", vrp.getParticipantName()); // could be 'Provider Name'..
     assertNotNull(vrp.getClaims());
     assertEquals(26, vrp.getClaims().size()); //!!
-    assertNull(vrp.getValidators());
-    assertNull(vrp.getValidatorDids());
+    assertTrue(vrp.getValidators().isEmpty());
+    assertTrue(vrp.getValidatorDids().isEmpty());
     assertEquals(Instant.parse("2022-10-19T18:48:09Z"), vrp.getIssuedDateTime());
   }
 
@@ -334,8 +330,8 @@ public class VerificationServiceTest {
     assertEquals(Instant.parse("2023-08-08T11:29:40Z"), vrr.getIssuedDateTime());
     assertNotNull(vrr.getClaims());
     assertEquals(4, vrr.getClaims().size());
-    assertNull(vrr.getValidators());
-    assertNull(vrr.getValidatorDids());
+    assertTrue(vrr.getValidators().isEmpty());
+    assertTrue(vrr.getValidatorDids().isEmpty());
   }
 
   @Test
@@ -758,11 +754,7 @@ public class VerificationServiceTest {
   @Test
   void verifyCredential_jwtVcWithVerifyVcSigsTrue_returnsValidators() {
     String vcJson = getAccessor("Claims-Tests/participantVC2.jsonld").getContentAsString();
-    String header = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
-    String payload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"vc\":" + vcJson + "}").getBytes(StandardCharsets.UTF_8));
-    ContentAccessor jwtVc = new ContentAccessorDirect(header + "." + payload + ".AAAA");
+    ContentAccessor jwtVc = new ContentAccessorDirect(fakeVcJwt(vcJson));
 
     Validator testValidator = new Validator("did:test:key-1", "{\"kty\":\"EC\"}", null);
     when(jwtVerifierMock.verify(any())).thenReturn(testValidator);
@@ -799,16 +791,8 @@ public class VerificationServiceTest {
    */
   @Test
   void verifyCredential_vpJwtIssNotEqualHolder_throwsVerificationException() {
-    String jwtHeader = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"EdDSA\"}".getBytes(StandardCharsets.UTF_8));
-    String jwtPayload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"iss\":\"did:web:issuer.example.com\","
-            + "\"holder\":\"did:web:other.example.com\","
-            + "\"type\":[\"VerifiablePresentation\"]}").getBytes(StandardCharsets.UTF_8));
-    String jwtSig = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("fakesig".getBytes(StandardCharsets.UTF_8));
     ContentAccessor vpJwt = new ContentAccessorDirect(
-        jwtHeader + "." + jwtPayload + "." + jwtSig);
+        fakeVpJwt("did:web:issuer.example.com", "did:web:other.example.com"));
 
     Validator testValidator = new Validator("did:test:key-1", "{\"kty\":\"EC\"}", null);
     when(jwtVerifierMock.verify(any())).thenReturn(testValidator);
@@ -828,16 +812,8 @@ public class VerificationServiceTest {
    */
   @Test
   void verifyCredential_vpJwtIssEqualsHolder_returnsValidators() {
-    String jwtHeader = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"EdDSA\"}".getBytes(StandardCharsets.UTF_8));
-    String jwtPayload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"iss\":\"did:web:issuer.example.com\","
-            + "\"holder\":\"did:web:issuer.example.com\","
-            + "\"type\":[\"VerifiablePresentation\"]}").getBytes(StandardCharsets.UTF_8));
-    String jwtSig = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("fakesig".getBytes(StandardCharsets.UTF_8));
     ContentAccessor vpJwt = new ContentAccessorDirect(
-        jwtHeader + "." + jwtPayload + "." + jwtSig);
+        fakeVpJwt("did:web:issuer.example.com", "did:web:issuer.example.com"));
 
     Validator testValidator = new Validator("did:test:key-1", "{\"kty\":\"EC\"}", null);
     when(jwtVerifierMock.verify(any())).thenReturn(testValidator);
@@ -859,11 +835,7 @@ public class VerificationServiceTest {
   @Test
   void verifyCredential_jwtWithBothSigFlagsFalse_jwtVerifierNotInvoked() {
     String vcJson = getAccessor("Claims-Tests/participantVC2.jsonld").getContentAsString();
-    String header = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
-    String payload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"vc\":" + vcJson + "}").getBytes(StandardCharsets.UTF_8));
-    ContentAccessor jwtVc = new ContentAccessorDirect(header + "." + payload + ".AAAA");
+    ContentAccessor jwtVc = new ContentAccessorDirect(fakeVcJwt(vcJson));
 
     verificationService.verifyCredential(jwtVc, false, false, false, false);
 
@@ -1025,14 +997,7 @@ public class VerificationServiceTest {
   @Test
   void verifyCredential_vc2JwtWrapped_passesAfterUnwrap() {
     String vcJson = getAccessor("Claims-Tests/participantVC2.jsonld").getContentAsString();
-    String header = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString("{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
-    // The DanubeTech JwtVerifiableCredentialV2 parser expects the VC under a "vc" claim (same
-    // JWT envelope convention as VC 1.x). Verified: fromCompactSerialization() accepts this format.
-    String payload = java.util.Base64.getUrlEncoder().withoutPadding()
-        .encodeToString(("{\"vc\":" + vcJson + "}").getBytes(StandardCharsets.UTF_8));
-    String jwt = header + "." + payload + ".AAAA";
-    ContentAccessor content = new ContentAccessorDirect(jwt);
+    ContentAccessor content = new ContentAccessorDirect(fakeVcJwt(vcJson));
 
     CredentialVerificationResult vr = verificationService.verifyCredential(content, false, false, false, false);
 
@@ -1085,6 +1050,34 @@ public class VerificationServiceTest {
     } finally {
       ReflectionTestUtils.setField(credentialVerificationStrategy, "gaiaxTrustFrameworkEnabled", false);
     }
+  }
+
+  // --- helpers ---
+
+  /** Builds a fake danubetech-style JWT wrapping the given VC JSON under a {@code vc} claim. */
+  private static String fakeVcJwt(String vcJson) {
+    var encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+    String header = encoder.encodeToString(
+        "{\"alg\":\"RS256\"}".getBytes(StandardCharsets.UTF_8));
+    String payload = encoder.encodeToString(
+        ("{\"vc\":" + vcJson + "}").getBytes(StandardCharsets.UTF_8));
+    return header + "." + payload + ".AAAA";
+  }
+
+  /** Builds a fake danubetech-style VP JWT with the given iss and holder. */
+  private static String fakeVpJwt(String iss, String holder) {
+    var encoder = java.util.Base64.getUrlEncoder().withoutPadding();
+    String header = encoder.encodeToString(
+        "{\"alg\":\"EdDSA\"}".getBytes(StandardCharsets.UTF_8));
+    String payloadJson = """
+        {"iss":"%s","holder":"%s",\
+        "vp":{"@context":["https://www.w3.org/ns/credentials/v2"],\
+        "type":["VerifiablePresentation"]}}""".formatted(iss, holder);
+    String payload = encoder.encodeToString(
+        payloadJson.getBytes(StandardCharsets.UTF_8));
+    String sig = encoder.encodeToString(
+        "fakesig".getBytes(StandardCharsets.UTF_8));
+    return header + "." + payload + "." + sig;
   }
 
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
@@ -36,6 +36,7 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.ClientException;
@@ -65,7 +66,7 @@ import static org.mockito.Mockito.when;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {VerificationServiceTest.TestApplication.class, FileStoreConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
-        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, DatabaseConfig.class, DidResolverConfig.class, ValidatorCacheJpaDao.class, HttpDocumentResolver.class,
+        VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class, ValidatorCacheJpaDao.class, HttpDocumentResolver.class,
         ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 public class VerificationServiceTest {

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -77,6 +77,9 @@ public class SecurityConfig {
           .requestMatchers("/verification").permitAll()
           
           // Asset APIs
+          .requestMatchers(HttpMethod.PUT, "/assets/*").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)
+          .requestMatchers(HttpMethod.POST, "/assets/*/versions/*/revoke").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)
+          .requestMatchers(HttpMethod.GET, "/assets/*/versions").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.POST, "/assets/*/revoke").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)
           .requestMatchers(HttpMethod.GET, "/assets", "/assets/*").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.POST, "/assets").hasAnyRole(ASSET_CREATE, ADMIN_ALL)

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
           // Schema APIs
           .requestMatchers(HttpMethod.POST, "/schemas").hasAnyRole(SCHEMA_CREATE, ADMIN_ALL)
           .requestMatchers(HttpMethod.DELETE, "/schemas/**").hasAnyRole(SCHEMA_DELETE, ADMIN_ALL)
-          .requestMatchers(HttpMethod.PUT, "/schemas").hasAnyRole(SCHEMA_UPDATE, ADMIN_ALL)
+          .requestMatchers(HttpMethod.PUT, "/schemas", "/schemas/**").hasAnyRole(SCHEMA_UPDATE, ADMIN_ALL)
           .requestMatchers(HttpMethod.GET, "/schemas", "/schemas/**").hasAnyRole(SCHEMA_READ, ADMIN_ALL)
 
           // Query APIs

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/AssetService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/AssetService.java
@@ -1,7 +1,34 @@
 package eu.xfsc.fc.server.service;
 
-import static eu.xfsc.fc.server.util.AssetHelper.parseTimeRange;
-import static eu.xfsc.fc.server.util.SessionUtils.checkParticipantAccess;
+import eu.xfsc.fc.api.generated.model.Asset;
+import eu.xfsc.fc.api.generated.model.AssetResult;
+import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.api.generated.model.AssetVersion;
+import eu.xfsc.fc.api.generated.model.AssetVersionList;
+import eu.xfsc.fc.api.generated.model.Assets;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.ConflictException;
+import eu.xfsc.fc.core.pojo.AssetFilter;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
+import eu.xfsc.fc.core.pojo.PaginatedResults;
+import eu.xfsc.fc.core.service.assetstore.AssetRecord;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.verification.VerificationService;
+import eu.xfsc.fc.server.generated.controller.AssetsApiDelegate;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriUtils;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -11,34 +38,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.util.UriUtils;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-
-import eu.xfsc.fc.api.generated.model.Asset;
-import eu.xfsc.fc.api.generated.model.AssetResult;
-import eu.xfsc.fc.api.generated.model.AssetStatus;
-import eu.xfsc.fc.api.generated.model.Assets;
-import eu.xfsc.fc.core.exception.ClientException;
-import eu.xfsc.fc.core.exception.ConflictException;
-import eu.xfsc.fc.core.pojo.ContentAccessor;
-import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
-import eu.xfsc.fc.core.pojo.PaginatedResults;
-import eu.xfsc.fc.core.pojo.AssetFilter;
-import eu.xfsc.fc.core.pojo.AssetMetadata;
-import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
-import eu.xfsc.fc.core.pojo.CredentialVerificationResultResource;
-import eu.xfsc.fc.core.service.assetstore.AssetStore;
-import eu.xfsc.fc.core.service.verification.VerificationService;
-import eu.xfsc.fc.server.generated.controller.AssetsApiDelegate;
-import jakarta.validation.ValidationException;
-import lombok.extern.slf4j.Slf4j;
+import static eu.xfsc.fc.server.util.AssetHelper.parseTimeRange;
+import static eu.xfsc.fc.server.util.SessionUtils.checkParticipantAccess;
 
 /**
  * Implementation of the {@link eu.xfsc.fc.server.generated.controller.AssetsApiDelegate} interface.
@@ -47,6 +48,8 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class AssetService implements AssetsApiDelegate {
+
+  private static final int DEFAULT_VERSION_PAGE_SIZE = 20;
 
   private final VerificationService verificationService;
   private final AssetStore assetStorePublisher;
@@ -123,8 +126,10 @@ public class AssetService implements AssetsApiDelegate {
    *         Must not outline any information about the internal structure of the server. (status code 500)
    */
   @Override
-  public ResponseEntity<String> readAssetById(String id) {
-    AssetMetadata assetMetadata = assetStorePublisher.getById(id);
+  public ResponseEntity<String> readAssetById(String id, Integer version) {
+    AssetMetadata assetMetadata = version != null
+        ? assetStorePublisher.getByIdAndVersion(id, version)
+        : assetStorePublisher.getById(id);
 
     // Only RDF assets have content in DB. Non-RDF assets (PDF, binary) are in FileStore
     // and require a dedicated download endpoint
@@ -180,31 +185,10 @@ public class AssetService implements AssetsApiDelegate {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   public ResponseEntity<Asset> addAsset(String body) {
     log.debug("addAsset.enter; got asset of length: {}", body.length());
-
-    try {
-     // TODO: 27.07.2022 Need to change the description and the order of actions in the documentation.
-     //  The FH scheme is different from the real process.
-      String contentType = httpServletRequest.getHeader(HttpHeaders.CONTENT_TYPE);
-      ContentAccessorDirect contentAccessor = new ContentAccessorDirect(body, contentType);
-
-      CredentialVerificationResult verificationResult = verificationService.verifyCredential(contentAccessor);
-
-      AssetMetadata assetMetadata = new AssetMetadata(verificationResult.getId(), verificationResult.getIssuer(),
-              verificationResult.getValidators(), contentAccessor);
-      checkParticipantAccess(assetMetadata.getIssuer());
-      assetStorePublisher.storeCredential(assetMetadata, verificationResult);
-
-      if (verificationResult.getWarnings() != null && !verificationResult.getWarnings().isEmpty()) {
-        assetMetadata.setWarnings(verificationResult.getWarnings());
-      }
-
-      log.debug("addAsset.exit; returning asset with id: {}", assetMetadata.getId());
-      String encodedId = UriUtils.encodePathSegment(assetMetadata.getId(), StandardCharsets.UTF_8);
-      return ResponseEntity.created(URI.create("/assets/" + encodedId)).body(assetMetadata);
-    } catch (ValidationException exception) {
-      log.debug("addAsset.error; Asset credential isn't parsed due to: " + exception.getMessage(), exception);
-      throw new ClientException("Asset credential isn't parsed due to: " + exception.getMessage());
-    }
+    AssetMetadata assetMetadata = verifyAndStore(body, null, null);
+    log.debug("addAsset.exit; returning asset with id: {}", assetMetadata.getId());
+    String encodedId = UriUtils.encodePathSegment(assetMetadata.getId(), StandardCharsets.UTF_8);
+    return ResponseEntity.created(URI.create("/assets/" + encodedId)).body(assetMetadata);
   }
 
   /**
@@ -239,6 +223,138 @@ public class AssetService implements AssetsApiDelegate {
 
     log.debug("revokeAsset.exit; updated asset by hash: {}", assetHash);
     return new ResponseEntity<>(assetMetadata, HttpStatus.OK);
+  }
+
+  /**
+   * Service method for PUT /assets/{id} : Update an existing asset, creating a new Envers revision.
+   *
+   * @param id            IRI of the asset (required)
+   * @param body          The new asset content (required)
+   * @param changeComment Optional change note for this version (optional)
+   * @return The updated asset (status code 200)
+   */
+  @Override
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public ResponseEntity<Asset> updateAsset(String id, String body, String changeComment) {
+    log.debug("updateAsset.enter; id: {}, changeComment: {}", id, changeComment);
+    AssetMetadata assetMetadata = verifyAndStore(body, changeComment, id);
+    log.debug("updateAsset.exit; returning asset with id: {}", id);
+    return ResponseEntity.ok(assetMetadata);
+  }
+
+  /**
+   * Service method for GET /assets/{id}/versions : Get the version history of an asset.
+   *
+   * @param id   IRI of the asset (required)
+   * @param page 0-based page index (optional, default 0)
+   * @param size Page size (optional, default 20)
+   * @return Paginated version list (status code 200)
+   */
+  @Override
+  public ResponseEntity<AssetVersionList> readAssetVersions(String id, Integer page, Integer size) {
+    log.debug("readAssetVersions.enter; id: {}, page: {}, size: {}", id, page, size);
+    int pageNum = page != null ? page : 0;
+    int pageSize = size != null ? size : DEFAULT_VERSION_PAGE_SIZE;
+
+    PaginatedResults<AssetRecord> results = assetStorePublisher.getVersionHistoryPage(id, pageNum, pageSize);
+
+    int latestVersion = (int) results.getTotalCount();
+    List<AssetVersion> versionItems = results.getResults().stream()
+        .map(this::toAssetVersion)
+        .toList();
+
+    AssetVersionList versionList = new AssetVersionList();
+    versionList.setId(id);
+    versionList.setTotal(latestVersion);
+    versionList.setVersions(versionItems);
+
+    log.debug("readAssetVersions.exit; returning {} versions, total: {}", versionItems.size(), latestVersion);
+    return ResponseEntity.ok(versionList);
+  }
+
+  /**
+   * Service method for POST /assets/{id}/versions/{version}/revoke : Revoke a specific version.
+   *
+   * <p>Only the current (latest) version can be revoked. Revoking a historical version returns 409.</p>
+   *
+   * @param id      IRI of the asset (required)
+   * @param version 1-based version ordinal to revoke (required)
+   * @return The revoked version metadata (status code 200)
+   */
+  @Override
+  @Transactional
+  public ResponseEntity<AssetVersion> revokeAssetVersion(String id, Integer version) {
+    log.debug("revokeAssetVersion.enter; id: {}, version: {}", id, version);
+
+    // Load snapshot first (throws 404 if version unknown) so we can auth-check before disclosing state.
+    AssetRecord snapshot = assetStorePublisher.getByIdAndVersion(id, version);
+    checkParticipantAccess(snapshot.getIssuer());
+
+    int totalVersions = assetStorePublisher.getVersionCount(id);
+    if (!version.equals(totalVersions)) {
+      throw new ConflictException(
+          "Only the current version (" + totalVersions + ") can be revoked. Requested: " + version);
+    }
+
+    // changeLifeCycleStatus throws ConflictException (409) if the row is already non-ACTIVE (e.g. REVOKED).
+    assetStorePublisher.changeLifeCycleStatus(snapshot.getAssetHash(), AssetStatus.REVOKED);
+
+    AssetVersion av = new AssetVersion();
+    av.setVersion(version);
+    av.setCreatedAt(snapshot.getUploadDatetime());
+    av.setCreatedBy(snapshot.getIssuer());
+    av.setStatus(AssetStatus.REVOKED);
+    av.setIsCurrent(true);
+    av.setChangeComment(snapshot.getChangeComment());
+
+    log.debug("revokeAssetVersion.exit; revoked version {} of asset {}", version, id);
+    return ResponseEntity.ok(av);
+  }
+
+  /**
+   * Verify a credential body, check participant access, and store it.
+   *
+   * @param body          Raw credential content.
+   * @param changeComment Optional change note (null for first upload).
+   * @param expectedId    If non-null, the credential IRI must match; throws 400 otherwise.
+   * @return Stored asset metadata with warnings populated.
+   */
+  private AssetMetadata verifyAndStore(String body, String changeComment, String expectedId) {
+    try {
+      String contentType = httpServletRequest.getHeader(HttpHeaders.CONTENT_TYPE);
+      ContentAccessorDirect contentAccessor = new ContentAccessorDirect(body, contentType);
+
+      CredentialVerificationResult verificationResult = verificationService.verifyCredential(contentAccessor);
+
+      if (expectedId != null && !expectedId.equals(verificationResult.getId())) {
+        throw new ClientException(
+            "Path id '" + expectedId + "' does not match credential IRI '" + verificationResult.getId() + "'");
+      }
+
+      AssetMetadata assetMetadata = new AssetMetadata(verificationResult.getId(), verificationResult.getIssuer(),
+          verificationResult.getValidators(), contentAccessor);
+      assetMetadata.setChangeComment(changeComment);
+      checkParticipantAccess(assetMetadata.getIssuer());
+      assetStorePublisher.storeCredential(assetMetadata, verificationResult);
+
+      if (verificationResult.getWarnings() != null && !verificationResult.getWarnings().isEmpty()) {
+        assetMetadata.setWarnings(verificationResult.getWarnings());
+      }
+      return assetMetadata;
+    } catch (ValidationException exception) {
+      throw new ClientException("Asset credential isn't parsed due to: " + exception.getMessage());
+    }
+  }
+
+  private AssetVersion toAssetVersion(AssetRecord record) {
+    AssetVersion av = new AssetVersion();
+    av.setVersion(record.getVersion());
+    av.setCreatedAt(record.getUploadDatetime());
+    av.setCreatedBy(record.getIssuer());
+    av.setStatus(record.getStatus());
+    av.setIsCurrent(record.getIsCurrent());
+    av.setChangeComment(record.getChangeComment());
+    return av;
   }
 
   private boolean isNotNullObjects(Object... objs) {

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/SchemasService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/SchemasService.java
@@ -2,6 +2,8 @@ package eu.xfsc.fc.server.service;
 
 import eu.xfsc.fc.api.generated.model.OntologySchema;
 import eu.xfsc.fc.api.generated.model.SchemaResult;
+import eu.xfsc.fc.api.generated.model.SchemaVersion;
+import eu.xfsc.fc.api.generated.model.SchemaVersionList;
 import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
@@ -47,14 +49,17 @@ public class SchemasService implements SchemasApiDelegate {
    * JSON schemas, {@code application/xml} for XML schemas, and default content negotiation for
    * RDF types (ontologies, shapes, vocabularies).
    *
-   * @param id Identifier of the Schema. (required)
+   * @param id      Identifier of the Schema. (required)
+   * @param version Optional version number. If provided, returns the schema at that version.
    * @return The schema content with appropriate Content-Type for the given identifier. (status code 200)
-   * @throws NotFoundException if no schema exists with the given id (status code 404)
+   * @throws NotFoundException if no schema exists with the given id or version (status code 404)
    */
   @Override
-  public ResponseEntity<String> getSchema(String id) {
+  public ResponseEntity<String> getSchema(String id, Integer version) {
     String schemaId = URLDecoder.decode(id, Charset.defaultCharset());
-    SchemaRecord record = schemaStore.getSchemaRecord(schemaId);
+    SchemaRecord record = version != null
+        ? schemaStore.getSchemaVersion(schemaId, version)
+        : schemaStore.getSchemaRecord(schemaId);
     var responseBuilder = ResponseEntity.ok();
     switch (record.type()) {
       case JSON -> responseBuilder.contentType(MediaType.parseMediaType(SchemaStore.MEDIA_TYPE_JSON_SCHEMA));
@@ -179,11 +184,40 @@ public class SchemasService implements SchemasApiDelegate {
     return ResponseEntity.ok(toSchemaResult(storeResult));
   }
 
+  /**
+   * Service method for GET /schemas/{schemaId}/versions : Get version history for a schema.
+   *
+   * @param id Identifier of the Schema. (required)
+   * @return The version history of the schema. (status code 200)
+   * @throws NotFoundException if no schema exists with the given id (status code 404)
+   */
+  @Override
+  public ResponseEntity<SchemaVersionList> getSchemaVersions(String id) {
+    String schemaId = URLDecoder.decode(id, Charset.defaultCharset());
+    List<SchemaRecord> versions = schemaStore.getSchemaVersions(schemaId);
+    int latestVersion = versions.size();
+    List<SchemaVersion> versionItems = versions.stream()
+        .map(v -> {
+          SchemaVersion sv = new SchemaVersion();
+          sv.setVersion(v.version());
+          sv.setCreatedAt(v.createdAt());
+          sv.setIsCurrent(v.version() == latestVersion);
+          return sv;
+        })
+        .toList();
+    SchemaVersionList versionList = new SchemaVersionList();
+    versionList.setSchemaId(schemaId);
+    versionList.setVersions(versionItems);
+    return ResponseEntity.ok(versionList);
+  }
+
   private SchemaResult toSchemaResult(SchemaStoreResult storeResult) {
     SchemaResult result = new SchemaResult();
     result.setId(storeResult.id());
     result.setWarnings(storeResult.warning() != null ? List.of(storeResult.warning()) : Collections.emptyList());
-    result.setUploadTime(storeResult.uploadTime());
+    result.setCreatedAt(storeResult.createdAt());
+    result.setVersion(storeResult.version());
+    result.setPreviousVersion(storeResult.previousVersion());
     return result;
   }
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetVersionControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetVersionControllerTest.java
@@ -1,0 +1,495 @@
+package eu.xfsc.fc.server.controller;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.Claims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.StringClaim;
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithMockJwtAuth;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.api.generated.model.AssetVersionList;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
+import eu.xfsc.fc.core.pojo.PaginatedResults;
+import eu.xfsc.fc.core.service.assetstore.AssetRecord;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.util.HashUtils;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Instant;
+import java.util.List;
+
+import static eu.xfsc.fc.server.util.TestCommonConstants.ASSET_READ_WITH_PREFIX;
+import static eu.xfsc.fc.server.util.TestCommonConstants.ASSET_UPDATE_WITH_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for asset version control endpoints
+ *
+ * <p>Uses Fuseki graph store backend. Asset versions are created directly via
+ * {@link AssetStore#storeCredential} to bypass the HTTP credential-verification pipeline,
+ * then the HTTP version endpoints are tested through MockMvc.
+ */
+@Slf4j
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {"graphstore.impl=fuseki"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+public class AssetVersionControllerTest {
+
+  private static final String TEST_ISSUER = "http://example.org/test-issuer";
+  private static final String ASSET_IRI = "did:web:example.org:version-test-asset";
+  private static final String CONTENT_V1 = "{\"version\":\"one\"}";
+  private static final String CONTENT_V2 = "{\"version\":\"two\"}";
+
+  @Autowired
+  private WebApplicationContext context;
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private AssetStore assetStorePublisher;
+
+  @BeforeAll
+  public void setup() {
+    mockMvc = MockMvcBuilders.webAppContextSetup(context).apply(springSecurity()).build();
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    try {
+      // getVersionHistoryPage queries Envers and works regardless of live status (ACTIVE or REVOKED).
+      // The most-recent snapshot's assetHash matches the live row's hash.
+      PaginatedResults<AssetRecord> page =
+          assetStorePublisher.getVersionHistoryPage(ASSET_IRI, 0, 1);
+      if (!page.getResults().isEmpty()) {
+        assetStorePublisher.deleteAsset(page.getResults().getFirst().getAssetHash());
+        assertEquals(0, assetStorePublisher.getVersionCount(ASSET_IRI), "asset should be deleted after test");
+      }
+    } catch (NotFoundException e) {
+      // asset not created or already deleted — expected
+    }
+  }
+
+  // ===== version count =====
+
+  @Test
+  public void storeCredential_firstUpload_versionCountIsOne() {
+    storeVersion(CONTENT_V1, null);
+
+    int count = assetStorePublisher.getVersionCount(ASSET_IRI);
+
+    assertEquals(1, count);
+  }
+
+  @Test
+  public void storeCredential_secondUpload_versionCountIsTwo() {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, "v2 change");
+
+    int count = assetStorePublisher.getVersionCount(ASSET_IRI);
+
+    assertEquals(2, count);
+  }
+
+  // ===== GET /assets/{id}/versions =====
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_afterTwoUploads_returnsTwoVersionsDescending() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    AssetVersionList list = objectMapper.readValue(result.getResponse().getContentAsString(), AssetVersionList.class);
+
+    assertNotNull(list);
+    assertEquals(2, list.getTotal());
+    assertEquals(2, list.getVersions().size());
+    assertEquals(2, list.getVersions().get(0).getVersion());
+    assertEquals(1, list.getVersions().get(1).getVersion());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_currentVersionHasIsCurrentTrue() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    AssetVersionList list = objectMapper.readValue(result.getResponse().getContentAsString(), AssetVersionList.class);
+
+    assertTrue(list.getVersions().get(0).getIsCurrent(), "first item (newest) should be isCurrent=true");
+    assertFalse(list.getVersions().get(1).getIsCurrent(), "second item should be isCurrent=false");
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_olderVersionsHaveStatusDeprecated() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    AssetVersionList list = objectMapper.readValue(result.getResponse().getContentAsString(), AssetVersionList.class);
+
+    assertEquals(AssetStatus.DEPRECATED, list.getVersions().get(1).getStatus());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_withChangeComment_commentAppearsInVersionHistory() throws Exception {
+    String comment = "updated description";
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, comment);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    AssetVersionList list = objectMapper.readValue(result.getResponse().getContentAsString(), AssetVersionList.class);
+
+    assertEquals(comment, list.getVersions().get(0).getChangeComment());
+    assertNull(list.getVersions().get(1).getChangeComment());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_pagination_returnsCorrectPage() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+    storeVersion("{\"version\":\"three\"}", null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders
+            .get("/assets/{id}/versions?page=0&size=2", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    AssetVersionList list = objectMapper.readValue(result.getResponse().getContentAsString(), AssetVersionList.class);
+
+    assertEquals(3, list.getTotal());
+    assertEquals(2, list.getVersions().size());
+    assertEquals(3, list.getVersions().get(0).getVersion());
+    assertEquals(2, list.getVersions().get(1).getVersion());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_unknownId_returnsNotFound() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", "did:web:unknown-asset")
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  public void readAssetVersions_withoutPermission_returnsUnauthorized() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_negativePage_returnsBadRequest() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .param("page", "-1")
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_zeroSize_returnsBadRequest() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .param("size", "0")
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetVersions_sizeExceedsMax_returnsBadRequest() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/versions", ASSET_IRI)
+            .param("size", "101")
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ===== GET /assets/{id}?version=X =====
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetById_withVersionParam_returnsHistoricalContent() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}?version=1", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = result.getResponse().getContentAsString();
+    assertTrue(body.contains("one"), "version 1 content should contain 'one'");
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetById_withoutVersionParam_returnsMostRecentContent() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    String body = result.getResponse().getContentAsString();
+    assertTrue(body.contains("two"), "current content should contain 'two'");
+  }
+
+  @Test
+  public void readAssetById_withoutPermission_returnsUnauthorized() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetById_withVersionParamOutOfRange_returnsNotFound() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}?version=99", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetById_withVersionParamZero_returnsBadRequest() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}?version=0", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {"ASSET_READ"})
+  public void readAssetById_withNegativeVersionParam_returnsBadRequest() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}?version=-1", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  // ===== POST /assets/{id}/versions/{version}/revoke =====
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX, ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(
+      stringClaims = {@StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  public void revokeAssetVersion_currentVersion_assetBecomesUnavailable() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // GET /assets/{id} should now return 404 (no ACTIVE row)
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", ASSET_IRI)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(
+      stringClaims = {@StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  public void revokeAssetVersion_historicalVersion_returnsConflict() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    // v1 is historical — only v2 (current) can be revoked
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(
+      stringClaims = {@StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  public void revokeAssetVersion_alreadyRevokedVersion_returnsConflict() throws Exception {
+    storeVersion(CONTENT_V1, null);
+    // Revoke the current version
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    // Revoking again should 409 (already REVOKED — getByIdAndVersion returns snapshot,
+    // but changeLifeCycleStatus finds a non-ACTIVE row)
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(
+      stringClaims = {@StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  public void revokeAssetVersion_unknownVersion_returnsNotFound() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 99)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(
+      stringClaims = {@StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  public void revokeAssetVersion_negativeVersion_returnsBadRequest() throws Exception {
+    storeVersion(CONTENT_V1, null);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, -1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  public void revokeAssetVersion_withoutPermission_returnsUnauthorized() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/versions/{version}/revoke", ASSET_IRI, 1)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // ===== DAO / Envers layer (via service) =====
+
+  @Test
+  public void getVersionHistoryPage_afterTwoUploads_correctTotalAndOrder() {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    PaginatedResults<AssetRecord> page = assetStorePublisher.getVersionHistoryPage(ASSET_IRI, 0, 10);
+
+    assertEquals(2, page.getTotalCount());
+    assertEquals(2, page.getResults().size());
+    assertEquals(2, page.getResults().get(0).getVersion());
+    assertEquals(1, page.getResults().get(1).getVersion());
+  }
+
+  @Test
+  public void getByIdAndVersion_existingVersion_returnsHistoricalRecord() {
+    storeVersion(CONTENT_V1, null);
+    storeVersion(CONTENT_V2, null);
+
+    AssetRecord v1 = assetStorePublisher.getByIdAndVersion(ASSET_IRI, 1);
+
+    assertNotNull(v1);
+    assertEquals(CONTENT_V1, v1.getContent());
+    assertFalse(v1.getIsCurrent());
+  }
+
+  @Test
+  public void getByIdAndVersion_unknownVersion_throwsNotFoundException() {
+    storeVersion(CONTENT_V1, null);
+
+    assertThrows(NotFoundException.class,
+        () -> assetStorePublisher.getByIdAndVersion(ASSET_IRI, 99));
+  }
+
+  @Test
+  public void getVersionHistoryPage_migrationScenario_existingAssetHasVersionOne() {
+    // Simulates a "migrated" asset — first-ever upload creates version 1
+    storeVersion(CONTENT_V1, null);
+
+    AssetRecord v1 = assetStorePublisher.getByIdAndVersion(ASSET_IRI, 1);
+
+    assertEquals(1, v1.getVersion());
+  }
+
+  // ===== helpers =====
+
+  private void storeVersion(String content, String changeComment) {
+    String hash = HashUtils.calculateSha256AsHex(content);
+    AssetMetadata meta = new AssetMetadata();
+    meta.setId(ASSET_IRI);
+    meta.setIssuer(TEST_ISSUER);
+    meta.setAssetHash(hash);
+    meta.setStatus(AssetStatus.ACTIVE);
+    meta.setUploadDatetime(Instant.now());
+    meta.setStatusDatetime(Instant.now());
+    meta.setContentAccessor(new ContentAccessorDirect(content));
+    meta.setChangeComment(changeComment);
+
+    CredentialVerificationResult vr = new CredentialVerificationResult(
+        Instant.now(), AssetStatus.ACTIVE.getValue(),
+        TEST_ISSUER, Instant.now(), ASSET_IRI, List.of(), List.of());
+    assetStorePublisher.storeCredential(meta, vr);
+  }
+}

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaControllerTest.java
@@ -474,7 +474,7 @@ public class SchemaControllerTest {
             .with(csrf())
             .contentType("application/schema+json"))
         .andExpect(status().isCreated())
-        .andExpect(jsonPath("$.uploadTime").isString())
-        .andExpect(jsonPath("$.uploadTime", org.hamcrest.Matchers.matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")));
+        .andExpect(jsonPath("$.createdAt").isString())
+        .andExpect(jsonPath("$.createdAt", org.hamcrest.Matchers.matchesPattern("\\d{4}-\\d{2}-\\d{2}T.*")));
   }
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaVersioningControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaVersioningControllerTest.java
@@ -1,0 +1,176 @@
+package eu.xfsc.fc.server.controller;
+
+import static eu.xfsc.fc.core.service.schemastore.SchemaStore.MEDIA_TYPE_RDF_XML;
+import static eu.xfsc.fc.server.helper.FileReaderHelper.getMockFileDataAsString;
+import static eu.xfsc.fc.server.util.CommonConstants.SCHEMA_CREATE;
+import static eu.xfsc.fc.server.util.CommonConstants.SCHEMA_READ;
+import static eu.xfsc.fc.server.util.CommonConstants.SCHEMA_UPDATE;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+class SchemaVersioningControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private SchemaStore schemaStore;
+
+  @AfterEach
+  void cleanUp() {
+    schemaStore.clear();
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_UPDATE, SCHEMA_READ})
+  void updateSchema_returnsVersionAndPreviousVersion() throws Exception {
+    String content = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(content)).id();
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    mockMvc.perform(MockMvcRequestBuilders.put("/schemas/{schemaId}", encodedId)
+            .content(content)
+            .with(csrf())
+            .contentType(MEDIA_TYPE_RDF_XML)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.version").value(2))
+        .andExpect(jsonPath("$.previousVersion").value(1));
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_READ})
+  void getSchema_withVersionParam_returnsOriginalContent() throws Exception {
+    String contentV1 = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(contentV1)).id();
+
+    // Update the schema with different content to create version 2
+    String contentV2 = getMockFileDataAsString("gax-test-ontology.ttl");
+    schemaStore.updateSchema(id, new ContentAccessorDirect(contentV2));
+
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    // Requesting version 1 must return v1 content, not the current (v2) content
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}", encodedId)
+            .param("version", "1")
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().string(contentV1));
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_READ})
+  void getSchema_withoutVersion_returnsCurrentVersion() throws Exception {
+    String content = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(content)).id();
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}", encodedId)
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().string(content));
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_READ})
+  void getSchema_nonExistentVersion_returns404() throws Exception {
+    String content = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(content)).id();
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}", encodedId)
+            .param("version", "999")
+            .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_READ})
+  void getSchemaVersions_returnsOrderedList() throws Exception {
+    String content = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(content)).id();
+    schemaStore.updateSchema(id, new ContentAccessorDirect(content));
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}/versions", encodedId)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.schemaId").value(id))
+        .andExpect(jsonPath("$.versions").isArray())
+        .andExpect(jsonPath("$.versions.length()").value(2))
+        .andExpect(jsonPath("$.versions[0].version").value(1))
+        .andExpect(jsonPath("$.versions[0].isCurrent").value(false))
+        .andExpect(jsonPath("$.versions[1].version").value(2))
+        .andExpect(jsonPath("$.versions[1].isCurrent").value(true));
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_CREATE, SCHEMA_UPDATE, SCHEMA_READ})
+  void getSchemaVersions_afterThreeUpdates_returnsThreeVersionsWithCurrentMarked() throws Exception {
+    String content = getMockFileDataAsString("test-schema.ttl");
+    String id = schemaStore.addSchema(new ContentAccessorDirect(content)).id();
+    schemaStore.updateSchema(id, new ContentAccessorDirect(getMockFileDataAsString("gax-test-ontology.ttl")));
+    schemaStore.updateSchema(id, new ContentAccessorDirect(getMockFileDataAsString("legal-personShape.ttl")));
+    String encodedId = URLEncoder.encode(id, Charset.defaultCharset());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}/versions", encodedId)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.versions.length()").value(3))
+        .andExpect(jsonPath("$.versions[0].version").value(1))
+        .andExpect(jsonPath("$.versions[0].isCurrent").value(false))
+        .andExpect(jsonPath("$.versions[1].version").value(2))
+        .andExpect(jsonPath("$.versions[1].isCurrent").value(false))
+        .andExpect(jsonPath("$.versions[2].version").value(3))
+        .andExpect(jsonPath("$.versions[2].isCurrent").value(true));
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_READ})
+  void getSchemaVersions_nonExistentSchema_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/schemas/{schemaId}/versions", "nonexistent")
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  @WithMockUser(roles = {SCHEMA_READ})
+  void updateSchema_withoutUpdateRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.put("/schemas/{schemaId}", "some-id")
+            .content("content")
+            .with(csrf())
+            .contentType(MEDIA_TYPE_RDF_XML))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/fc-tools/signer/legalPerson_two_VC.signed.jsonld
+++ b/fc-tools/signer/legalPerson_two_VC.signed.jsonld
@@ -74,10 +74,10 @@
     "proof" : {
       "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
       "type" : "JsonWebSignature2020",
-      "created" : "2026-03-19T11:04:34Z",
+      "created" : "2026-03-23T19:36:37Z",
       "verificationMethod" : "did:web:compliance.lab.gaia-x.eu",
       "proofPurpose" : "assertionMethod",
-      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..tZV1Entut4-LrPmnKpYet8BEm1Meo9lPXw5N_xIQTqjAcAvCMJ8OJ4G3rSehhvK-1ghKuAfH-4yP2gb89vyhIq72NyyM259Vz9B3bnOQ6FTwAuF5IUMwYhflHyH3QVbHF9RkPQKsxSSSYgqTB9xp9YB7LzXmUiRVbY6_TGTq2CVZSQPXrgxljpey4eWZKpWj8SHh2ewpP3v7AzbveISJf27tE5UrFcndyQ2HNiBkzAUwSQo5XRai5V1RVEelgPR9jZ6XoeKillOM4AZ_-tIOrP2W_oKc8XFQMkQrG6rJ_GvsRw94qaZYimN1DidEzC_SYBQ8uuM_i5_4estliHVCzFjivgIpf762V08S2rJF71qrJwBdBQ1DY4qQ7sfdooPkr8Wn94XYrv22d9E8OIxWzwv8loxQXyjdv12FzyIkh2OD4dQUh2l7DZQqGqgzCN0dq0bXfV7tmCVVBcgQclRyHFJQUc77Ebres9z-3SyO6Z6NuugRFAXe_xI1oDFOR8wqGie5wF2ZgbTtPmVqWZB-4qEe4hgrFsJpCdgOL5wYR1IaU5txCfUjPVopR3kWIFVh2KMSCT4r86NmWb-upJkuNRC1MmjiXPds1kPUVA0xZt7EBpgwIK7dIqDvms5ar8DucLrPleWWb-AOMgJ3rlZtWl3DzL2vhAzWtIc3Wj_OQaE"
+      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..rGtHOkZnYVi7gsLs-3957L4EkO0D5oPndcWDjR0LQsK4Kskwab3IQBT3t7nKA2oMzOFz9VS0DUTnWd8V9A8SnOxr1OJtVRm-quy0Kw0VSRd4U2ylduhJvkNdT2RYJ47RMiOnrXIqIsfHIPhbkRKfxv9Xwe_ifnudT5OFCupqDQEADtivamc1VSIdfUpma1VD7zx5Luem0QMLCglC675RHUP0esfsZ1MNSueoN-y4Q2KYlH3fABx9kra0H7cEXrtR3kFm1CVDI6YgMNj2ZuPaDyM1cSK7dZodWH8i2EFsZ8P4tubCCnPmEJ17Vkq0hPH3Ekc6rNpDnJ0ZQR8EMmYEng3H61phD3DbTcvtIygyIAq8x8627HxLUJRZkGVKyFraw264yAxRUvTiFByeTBKKuzaC6lybbeefcpY7jAWYzrlpqPa5afVxgHQ7pB0m8BRdzrhJanNnglUziVAWdH9OSc7qMD-g9Nj0fu2-8hU-3x5G2kkvYEQnQFgpWwO7xleGu-541pjGx6Xcc-o6s0MB7lY48GJ2sb3dSwqGzq2bUHSSOYtPlqtogBMO5arPoBzod_2-rWGs7NzVF4cw-3m0uzxXM5xuehQX_pCQEaP9V5yvffczrIV_iNzq9YlJddVH7iOWQLSjtIbfzQ6l_OIqg7sV7GUXHqD681L0cuuszdg"
     }
   }, {
     "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
@@ -151,18 +151,18 @@
     "proof" : {
       "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
       "type" : "JsonWebSignature2020",
-      "created" : "2026-03-19T11:04:34Z",
+      "created" : "2026-03-23T19:36:37Z",
       "verificationMethod" : "did:web:compliance.lab.gaia-x.eu",
       "proofPurpose" : "assertionMethod",
-      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..EFud5g-3j87eTBrDZzssfRVhFfiaMRk4-U08ydudfnw-FbnLUgx23oGEE8eP4vEvtCYwO51Eg18JLbifSCglrqWS8ECaYnXyFLzcfbRzFTYBoa3XLA9HPItvK6DtdI7Xamcz0dfiB-ilNsqkIz1HazKhb6gJ81Svq4bu5JhQI0ws-dQssNJRJ4rB-axXeUxSpcae6gLD8VfO4gLviweTa8C5XazlfEUn0izQVhDvvmn9n16d-j-iAnnnjKWhn-z5MxZ9qHOF86TkIrLQw3bILrdCgZljl-h_a7izVpGOp5MZEf9d2aO1B-kNFdjZSkihj_STM3CuOBAKVa4dQSry7hByLxFOIUXmcPWkbq6HeH72I1feZt4d16Ntlxegz6Q7vpANqmoBBs-FO798e0zrjzg78iyf2fxnGVvsKFpr-BQyf4JJ19xEs9-AeCAE9hGGXwEbgJJ3g38nsWtPI6s5h4oYmaD8G6bjneoOc2JnTtbUH19awUwRMYxf4i_fo7x3i3ONr2SsAeBGBG6kNWpQ7axzFhusczJjQzbHZGlN9ZtXLrYnAVQuzyVIHzz8vtX0NMZXQ1piFNMfOcAyLwW_zIzcFmRWdDwq4XaxrfdoGNcHOcPivWvmjNX3RwEqxhRbTbj14VfhPoWY_8Bc91aNJ7i6Jk9HiFpk4hE2UOQHwyo"
+      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..CYCEaWGx5wpN4u8ktr5DjeXnJFQSLj5f41Ltzt__CYTifIyTNlVcE5VSqPZiFjUC0oC4yWVuooAnEWbCRq7PWH8GKPfssD43JzndsvrNZnnoPaKicYmyeQs0PF0T6-8A0SH_JnMg8ymHBfHvmrQyETxfMiF5YPnQFQ8burXiy9B-IFlF8yBsMIdSTE-yq6FDXaKzswfuLBf31OTYBoerZPFCd8A87GRia8ZRek57J1c5VsUwMA8vk7mZ3vDlCW8GvP92XSPceoVMVLIXaHVP07TmZSbHToPJwmIGGOGDN_CqDk8vzLGHKmIBNWyrgopInfbZTjNKJ3ojwrswy6LTGVwbYy_v12XnuMzQtcXeBofYh7rxvomC73uYn2AVPB2BTjPn5nXnrVp18xCyGhG0qn0IzBcD3HWBTKRmgpfajywOY6Cj5CXcC527IqBMdipMvWjTM0WotVBsi4HgfYurSflaBjzG331kBD9SXs4a6MINitBP0fk5hrgTng3gC3YLSw3JJidOLgRCSt7fONpboPjIfncHloWU4HUOrlxciXCDnExFm7a3Xn1xp8EWkIC1uMERQkf3ZQ07EX-WvqbEj2QEWZQA-cmbFjqEwr-z5OBvvBeDcR7OJh2ExNwky-Q_ZpWgI0-jQtsFkaw_CCnbod0KzReLngSXaPemL5dj4TE"
     }
   } ],
   "proof" : {
     "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
     "type" : "JsonWebSignature2020",
-    "created" : "2026-03-19T11:04:34Z",
+    "created" : "2026-03-23T19:36:37Z",
     "verificationMethod" : "did:web:compliance.lab.gaia-x.eu",
     "proofPurpose" : "assertionMethod",
-    "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..eqBqUx_SsweOWmDsB90B_yHIhTMec8L-hBxEkkPyPiilXlLJPrwImKlgcvUQpzBPX4OkiBW1mUiDJqu6digSa6C5fjxwCvhcbHiCX_FVP7oWCMMO4g78qeMRNsgH9OB2-YxDN4J-DcY6V807RM-u62JIMo-4S5GHIeWY7NVBi7Z1yDtW6AkOqVdcB5DJyed8-POOGHD3y1xO_3sCMXqGDDa1DysSFAGcKtabBWdFLKQgIO-j-ofEEwlrN6zP8zoUm6k-D-8-oCLXvgnNJSc2HBgNS2qXbIkmB_xItWYyq3d2boGmjUyptMZ8DjT423i86r6DY1sXjoR1VcPM0gd0Fqbd-SAjkIz9qklWKfwwqyLjY4y6Zqt_OqKxR7f5IHgKXCa-VYeIWCOaDnyqdGWy8aDWiT-nCY1mirVWd5M2TfTi3YbEztxc7VOJNiFYe30DP-nxZyE-FyijgqWKzCkJ1ksSE4kr6XfMoEAcIevN6eXSZcqVSbkSltQQIsLbuedpsFJbQQhx4ukmErxwPJbMji9_9WXc23ik2Fxv7MLBAYU2aeRvthLdmxaJOVDEsBdf_hF2FvoZPQ1TgGa4kXN4oq_0Ob0DJvfNA5j5M5lDu1fV57dTBlpm1GBV0jO-ah_BGFIosOxuB_2PP35Q4vV8W8ZyBrTsxjnCelIhJV8FDPU"
+    "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..ksQI_Knxlms_kbOyVywXMI9vYrKOAJuBzFG6m3ufF3CCklcVhef5YdJMz-SPaVInG4l8ei3VwtIgTA8neynryFmHc5fN-Uy2Oh32Gf7TMv3aorghtW9kbF2PYMgUv4pUewXaBoqaaT9xewgNYeXYJXbqWcCMlynVRaVeUAEZoM-8Qss7Oegbm_jCyiLEdepSW98Ajuq7dsWSk6tKbS_XYIZ6H3XGytGrf6QcYooZJnc1QRaTgI3XcMQ_aJnGz438r38gyel9RcFKa79WpYyVyBCM51va8dkqtZDOAK5x34T4QR9J_bmphUy2dYw3xZc4eIDicvAW63qN8yUY1GaLuqAPIR27jAhnVZnSTCgCjMGIEo3m2iDJiIZZ61a4-lGUIpmyAMTpYTeWq8zRvAwryU5l4AuBzZPHl3E3uoPiOK2zRRfbI4mbdFyDS0KvW2MymUkKIRtjd18CEHZkTcXOrLhubnzCbSXBTKaXJR9Gkm011cCU9YkZMHQMuOP6eFcjVLVtcDPiwtVH_GFy7qvifur9Cd7jJELqq4LiHt9MPv2bbaBQaPc5I7DdJCLquTwRkZoZ3zRo4IU3xwRnV99xxsIMDxs1IvGXwJS5Vt5SiT5agNbBIqnU9OTOwcqCGyVGlY16YifxB85RvU8tjYxKP8Ky9UmcoqrPSsQyPmif7zY"
   }
 }

--- a/fc-tools/signer/participant_jwk_signed.jsonld
+++ b/fc-tools/signer/participant_jwk_signed.jsonld
@@ -46,18 +46,18 @@
     "proof" : {
       "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
       "type" : "JsonWebSignature2020",
-      "created" : "2026-03-19T11:04:34Z",
+      "created" : "2026-03-23T19:36:37Z",
       "verificationMethod" : "did:jwk:eyJlIjoiQVFBQiIsImtpZCI6InNpZ25SU0EyMDQ4Iiwia3R5IjoiUlNBIiwibiI6IjhDUl8ySUJuSGlDcjVIY0kxcWh1dXpiRmdMRjFlSVI3dGM1NTF2WlN2ek1rTEtIVEpxeHVZR1BlVXp2U29ndWctTDJRQ2tpVWdmSjFZUzRFUmhrRFM2cVBJbFdMM1BGbkc4VjZQVWxoODZjTjgxWkhZdkhoUFYwUDdKT25UeGVKcTV1a1dFT0ctMUxrTmk5eGVnelRoMEVwV0w4NU5aUmJOYWJ0R0VqTUhqY04yak9NUldSYkE4OVdENVhOTExwdWUyNVlxbHcxOGZsbXNNRmh5dXk2YlVmanR2aXJ5SThwb0RLOVpXcGtPUjN6ejlNN0hpQXVyZ2NLSks5ODlEX0UzZ3d3S1FhQ21CbEJ4X3hESlJoVFB1bnJZUFBySHlpMExmaG5CeWgzcEJRMWhyelFLblZyX18zYkVwcE5abmRFLVhlWTY0VzNNaGUwa1RrREp2VXJndyJ9#0",
       "proofPurpose" : "assertionMethod",
-      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..y3NGcQN28Wyrw09oBUzptAPupMWF2WrL6ysvb1IgUCq-V3trcNgJ6bnV6xYgo1zZQaq9u_xJly9Lv7Xwec2Pq0AeBbVpy2n34DwGd5aXZYqJ8jxtWAfqr48jkTLa-qEZuve7SdB7X1yq1zKzq7550Wv7YL-jQvl_BJ3D6xYPN1LxCL6yyclVELNfM-k3FgZOhvTdVJEeD3vmqscniB6xeihnFKUxqOswxbpnLvG9yFJtolWTDmX5QH29sHy9LKxK84bQo_vPeU1rfuMFJ8Ioulhs6Y3hJb9Xyund1GiBtAJSI5iFXUV_H62Hc-4zvT4_CTtrFjf2GsoRmATwEbbbpQ"
+      "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..ATUhccN3bAhiip3behKSdXUmUS_OHJctT2Bb6feOSKwJEPFs8Gs0ydohdM3-nTOtl6GFQ6w9l4FXbsMW1ZpY-qd9UrobAvli0VIcv0xKNzg-3H2kmODMClZ2WeJNjc_mB1jzJsmfjY8Cn1Zc846C1LIelRLj_1am0uoAeKnL9F6XgbiwXX-FTRLxSqYE7Pt4VrA4VtJKabP37hXreDgCyr2f4YhrEo3tZAsFWoGItjYU9eP13nwZk5qB3JHgRH_W4cJBhyOBQwJhdJelFG3oNhSu7opviCuJDPXRWGvJNC1XuTeY6O12GJBpBqEWdSLufIuzeIjxYrEtY8sM18-ccg"
     }
   } ],
   "proof" : {
     "@context" : [ "https://www.w3.org/2018/credentials/v1", "https://w3id.org/security/suites/jws-2020/v1" ],
     "type" : "JsonWebSignature2020",
-    "created" : "2026-03-19T11:04:34Z",
+    "created" : "2026-03-23T19:36:37Z",
     "verificationMethod" : "did:jwk:eyJlIjoiQVFBQiIsImtpZCI6InNpZ25SU0EyMDQ4Iiwia3R5IjoiUlNBIiwibiI6IjhDUl8ySUJuSGlDcjVIY0kxcWh1dXpiRmdMRjFlSVI3dGM1NTF2WlN2ek1rTEtIVEpxeHVZR1BlVXp2U29ndWctTDJRQ2tpVWdmSjFZUzRFUmhrRFM2cVBJbFdMM1BGbkc4VjZQVWxoODZjTjgxWkhZdkhoUFYwUDdKT25UeGVKcTV1a1dFT0ctMUxrTmk5eGVnelRoMEVwV0w4NU5aUmJOYWJ0R0VqTUhqY04yak9NUldSYkE4OVdENVhOTExwdWUyNVlxbHcxOGZsbXNNRmh5dXk2YlVmanR2aXJ5SThwb0RLOVpXcGtPUjN6ejlNN0hpQXVyZ2NLSks5ODlEX0UzZ3d3S1FhQ21CbEJ4X3hESlJoVFB1bnJZUFBySHlpMExmaG5CeWgzcEJRMWhyelFLblZyX18zYkVwcE5abmRFLVhlWTY0VzNNaGUwa1RrREp2VXJndyJ9#0",
     "proofPurpose" : "assertionMethod",
-    "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..Jx7MxvxLrIkzgZkWRK9P-7hk0qe5TenUDVbGndS0sJ4GUG0jW9_CEZbyBhFu-8dHXRVgwXI8nuSbKGw-ZFUcZL_b7_HdApthJeTtsnu9q_9XoVWYi1yGYAKBaSCTlB-uDM4LUp_QGdE7wBdF_btQf1LhRTvVet0RSglqWUPyH6hB0rvuEpFjdcY5jfzYpnFEgS-P1oXqz-9PGFGgKWiJ8fZ5a3n4B9RdnKFhpJBAq_lYlJVQCUmZOHi9sW9XLNrs6xM0E_XG61A02XEuco5vJMvQx_650RCHgqNFGocHKjsdj9i80wNjEu1bwlbPAkBbvCuuXoO-7g3_Nb-rjoQkEA"
+    "jws" : "eyJiNjQiOmZhbHNlLCJjcml0IjpbImI2NCJdLCJhbGciOiJQUzI1NiJ9..b7KaidXUGNp4KyR67mciGOjuj1XGDbk-ibNdo7Q4ONkzrwvLJtXxV6T_wcgVMJt3F4wyFPML3s9RUnMcAx2eYz4t0k_pSnJ6S_QwTX-cBEx_8Gpwpwse0rwYaR7LQ101CKWXBNB5fRPpbl7mKb-vAYoxI3rXMWooutTF38PIjDJ00P195oMi6aRCWWYTW-x4iHoFF9hJZQwR830CCGVGRqZGOEW23EU7sWI_JcO-D7Tdo3Q6CnUiPPRGVNyJgAqmjGXFa2-kRszWnNgWx5MIbyC2Qj-hr6j_O1-BGXDOAajZFHPDmVuuS7h_rVyPvND-9WdppSsVUIkcf_nFJ0zrJA"
   }
 }

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -382,10 +382,42 @@ components:
           items:
             type: string
           description: 'Warnings generated during schema import (e.g. filtered protected namespace statements).'
-        uploadTime:
+        createdAt:
           type: string
           format: date-time
-          description: 'Timestamp when the schema was uploaded.'
+          nullable: true
+          description: 'Timestamp when the schema was first uploaded. Present on creation, null on updates.'
+        version:
+          type: integer
+          nullable: true
+          description: 'Current version number after this operation. Present on updates, null on creation.'
+        previousVersion:
+          type: integer
+          nullable: true
+          description: 'Version number before this operation. Null for first version or on creation.'
+    SchemaVersion:
+      type: object
+      properties:
+        version:
+          type: integer
+          description: '1-based version ordinal.'
+        createdAt:
+          type: string
+          format: date-time
+          description: 'Timestamp when this version was created.'
+        isCurrent:
+          type: boolean
+          description: 'Whether this is the current (latest) version.'
+    SchemaVersionList:
+      type: object
+      properties:
+        schemaId:
+          type: string
+          description: 'The schema identifier.'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/SchemaVersion'
     QueryInfo:
       type: object
       properties:
@@ -1119,6 +1151,12 @@ paths:
           required: true
           schema:
             type: string
+        - name: version
+          in: query
+          description: 'Optional version number. If provided, returns the schema at that specific version.'
+          required: false
+          schema:
+            type: integer
       responses:
         '200':
           description: 'The schema for the given identifier. Depending on the type of the schema, either an ontology, shape graph or controlled vocabulary is returned.'
@@ -1224,7 +1262,36 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
-          $ref: '#/components/responses/ServerError'          
+          $ref: '#/components/responses/ServerError'
+  /schemas/{schemaId}/versions:
+    get:
+      tags:
+        - Schemas
+      summary: 'Get version history for a schema.'
+      description: 'Returns an ordered list of all versions of the schema. Required permission: SCHEMA_READ or ADMIN_ALL'
+      operationId: getSchemaVersions
+      security:
+        - jwt: []
+      parameters:
+        - name: schemaId
+          in: path
+          description: 'Identifier of the Schema.'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The version history of the schema.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SchemaVersionList'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /schemas/latest:
     get: 
       tags:

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -395,6 +395,44 @@ components:
           type: integer
           nullable: true
           description: 'Version number before this operation. Null for first version or on creation.'
+    AssetVersion:
+      type: object
+      required: [version, createdAt, createdBy, status, isCurrent]
+      properties:
+        version:
+          type: integer
+          description: '1-based version ordinal.'
+        createdAt:
+          type: string
+          format: date-time
+          description: 'Timestamp when this version was created (Envers revision timestamp).'
+        createdBy:
+          type: string
+          description: 'Issuer DID of the asset at this version.'
+        status:
+          $ref: '#/components/schemas/AssetStatus'
+        isCurrent:
+          type: boolean
+          description: 'Whether this is the current (latest) version.'
+        changeComment:
+          type: string
+          nullable: true
+          description: 'Optional change note provided at upload time.'
+    AssetVersionList:
+      type: object
+      required: [id, total, versions]
+      properties:
+        id:
+          type: string
+          description: 'The asset IRI.'
+        total:
+          type: integer
+          description: 'Total number of versions.'
+        versions:
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetVersion'
+          description: 'Descending list (newest first) for the requested page.'
     SchemaVersion:
       type: object
       properties:
@@ -835,6 +873,13 @@ paths:
             http:
               summary: HTTP IRI
               value: 'https://example.org/asset/123'
+        - name: version
+          in: query
+          description: Optional 1-based version ordinal. If provided, returns the asset content at that specific version.
+          required: false
+          schema:
+            type: integer
+            minimum: 1
       security:
         - jwt: []
       responses:
@@ -853,6 +898,156 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    put:
+      tags:
+        - Assets
+      summary: Update an asset in-place (versioned).
+      description: >
+        Updates an existing asset identified by its IRI. The update is applied in-place;
+        Envers records the previous state as a new revision in assets_aud automatically.
+        If no asset exists for the given IRI, the asset is created as version 1.
+        Required permission: ASSET_UPDATE or ADMIN_ALL
+      operationId: updateAsset
+      parameters:
+        - name: id
+          in: path
+          description: IRI identifier of the asset
+          required: true
+          schema:
+            type: string
+        - name: changeComment
+          in: query
+          description: Optional human-readable note for this version.
+          required: false
+          schema:
+            type: string
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/ld+json:
+            schema:
+              type: string
+          application/json:
+            schema:
+              type: string
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Asset'
+        '400':
+          $ref: '#/components/responses/ClientError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /assets/{id}/versions:
+    get:
+      tags:
+        - Assets
+      summary: Get version history for an asset.
+      description: >
+        Returns a paginated list of all versions of the asset, ordered descending (newest first).
+        Required permission: ASSET_READ or ADMIN_ALL
+      operationId: readAssetVersions
+      parameters:
+        - name: id
+          in: path
+          description: IRI identifier of the asset
+          required: true
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: 0-based page index.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: size
+          in: query
+          description: Page size (1–100).
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      security:
+        - jwt: []
+      responses:
+        '200':
+          description: The version history of the asset.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetVersionList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /assets/{id}/versions/{version}/revoke:
+    post:
+      tags:
+        - Assets
+      summary: Revoke a specific version of an asset.
+      description: >
+        Revokes the specified version of the asset. Only the current (latest) version can be revoked.
+        Attempting to revoke a historical version returns 409 Conflict, because Envers snapshots are immutable.
+        Required permission: ASSET_UPDATE or ADMIN_ALL
+      operationId: revokeAssetVersion
+      parameters:
+        - name: id
+          in: path
+          description: IRI identifier of the asset
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: path
+          description: 1-based version ordinal to revoke.
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+      security:
+        - jwt: []
+      responses:
+        '200':
+          description: Revoked
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetVersion'
+        '400':
+          $ref: '#/components/responses/ClientError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
   /assets/{asset_hash}:

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <embedded.postgres.test.version>2.4.0</embedded.postgres.test.version>
         <jose4j.version>0.9.6</jose4j.version>
         <nimbus-jose-jwt.version>10.0.2</nimbus-jose-jwt.version>
+        <tink.version>1.20.0</tink.version>
         <okhttp.version>5.3.0</okhttp.version>
         <!-- plugins -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -306,7 +307,7 @@
             <dependency>
                 <groupId>com.google.crypto.tink</groupId>
                 <artifactId>tink</artifactId>
-                <version>1.20.0</version>
+                <version>${tink.version}</version>
             </dependency>
 
             <!-- Test dependencies -->


### PR DESCRIPTION
## 🚀 Summary

Replaces the multi-row DEPRECATED pattern with in-place UPDATE + Envers audit
history, consistent with the existing schema versioning approach.

Key changes:

- AssetJpaDao.insert() updates the live row in-place on re-upload; Envers records the prior state automatically in assets_aud
- AssetAuditRepository: new class (mirrors SchemaAuditRepository) querying
- Envers revision history; computes version ordinals and DEPRECATED status at query time
- AssetStore/AssetStoreImpl: getVersionHistoryPage, getByIdAndVersion, getVersionCount
- AssetMetadata: changeComment field propagated via storeCredential
- Liquibase 009: adds change_comment column to assets + assets_aud
- OpenAPI: PUT /assets/{id}, GET /assets/{id}/versions, POST /assets/{id}/versions/{version}/revoke, ?version=X on GET /assets/{id}
- SecurityConfig: ASSET_UPDATE/ASSET_READ guards for new endpoints

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnit tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style
