### PR TITLE
Enhancement CAT-FR-LM-04 asset lifecycle (#44)

### DIFF
--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -28,7 +28,7 @@ import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
 import eu.xfsc.fc.core.service.validation.ValidationResultGraphWriter;
 import eu.xfsc.fc.core.service.validation.ValidationResultHasher;
-import eu.xfsc.fc.core.service.validation.ValidationResultStoreImpl;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
 import eu.xfsc.fc.core.service.verification.DanubeTechFormatMatcher;
 import eu.xfsc.fc.core.service.verification.FormatDetector;
@@ -52,6 +52,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -64,10 +65,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import static eu.xfsc.fc.core.util.TestUtil.assertThatAssetHasTheSameData;
 import static eu.xfsc.fc.core.util.TestUtil.getAccessor;
@@ -114,7 +119,6 @@ import static eu.xfsc.fc.core.util.TestUtil.getAccessor;
         ValidatorCacheJpaDao.class,
         ValidationResultGraphWriter.class,
         ValidationResultHasher.class,
-        ValidationResultStoreImpl.class,
         Vc2Processor.class,
         VerificationServiceImpl.class
 })
@@ -133,6 +137,9 @@ public class AssetStoreCompositeTest {
 
     @MockitoBean
     private ProvenanceService provenanceService;
+
+    @MockitoBean
+    private ValidationResultStore validationResultStore;
 
     @Autowired
     private VerificationServiceImpl verificationService;
@@ -154,6 +161,11 @@ public class AssetStoreCompositeTest {
 
     @Autowired
     private GraphRebuilder graphRebuilder;
+
+    @BeforeEach
+    void stubValidationResultStore() {
+        when(validationResultStore.findAll(any())).thenReturn(Page.empty());
+    }
 
     @AfterEach
     public void storageSelfCleaning() {

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
@@ -25,6 +25,7 @@ import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.util.HashUtils;
 import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
 import eu.xfsc.fc.graphdb.service.Neo4jGraphStore;
@@ -79,6 +80,9 @@ public class AssetStoreTest {
 
   @MockitoBean
   private ProvenanceService provenanceService;
+
+  @MockitoBean
+  private ValidationResultStore validationResultStore;
 
   @Autowired
   private AssetStore assetStorePublisher;

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
@@ -35,6 +35,7 @@ import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
 import eu.xfsc.fc.core.service.verification.claims.JenaAllTriplesExtractor;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
 import eu.xfsc.fc.graphdb.config.GraphDbConfig;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
@@ -98,6 +99,8 @@ public class Neo4jGraphStoreAccuracyTest {
   
   @MockitoBean
   private ProvenanceService provenanceService;
+  @MockitoBean
+  private ValidationResultStore validationResultStore;
 
   @Autowired
   private Neo4j embeddedDatabaseServer;

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/config/AssetStoreConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/config/AssetStoreConfig.java
@@ -15,6 +15,7 @@ import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -30,14 +31,15 @@ public class AssetStoreConfig {
       IriGenerator iriGenerator, AssetRepository assetRepository,
       ProtectedNamespaceProperties namespaceProperties,
       ProvenanceService provenanceService,
+      ValidationResultStore validationResultStore,
       AssetPublisher assetPublisher) {
     AssetStore assetStore;
     if ("none".equals(pubImpl)) {
       assetStore = new AssetStoreImpl(dao, graphDb, fileStore, iriGenerator, assetRepository,
-          namespaceProperties, provenanceService);
+          namespaceProperties, provenanceService, validationResultStore);
     } else {
       assetStore = new PublishingAssetStore(dao, graphDb, fileStore, iriGenerator, assetRepository,
-          namespaceProperties, provenanceService, assetPublisher);
+          namespaceProperties, provenanceService, validationResultStore, assetPublisher);
     }
     log.debug("getAssetStore; returning {} for impl {}", assetStore, pubImpl);
     return assetStore;

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/OutdatedReason.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/OutdatedReason.java
@@ -1,0 +1,11 @@
+package eu.xfsc.fc.core.dao.validation;
+
+/** Reason a {@link ValidationResult} was marked outdated. */
+public enum OutdatedReason {
+
+  /** The asset's content was updated, superseding previous validation results. */
+  ASSET_UPDATED,
+
+  /** The asset was revoked or reached end-of-life, invalidating prior results. */
+  ASSET_REVOKED
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResult.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResult.java
@@ -103,4 +103,13 @@ public class ValidationResult {
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt;
 
+  /** True when the asset was updated or revoked after this result was produced. */
+  @Column(name = "outdated", nullable = false)
+  private boolean outdated;
+
+  /** Why this result was marked outdated; null when {@code outdated} is false. */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "outdated_reason", length = 50)
+  private OutdatedReason outdatedReason;
+
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepository.java
@@ -3,9 +3,9 @@ package eu.xfsc.fc.core.dao.validation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 /** Spring Data JPA repository for {@link ValidationResult} entities. */
 public interface ValidationResultRepository extends JpaRepository<ValidationResult, Long> {
 
@@ -19,5 +19,19 @@ public interface ValidationResultRepository extends JpaRepository<ValidationResu
       countQuery = "SELECT COUNT(*) FROM validation_result WHERE :assetId = ANY(asset_ids)",
       nativeQuery = true)
   Page<ValidationResult> findByAssetId(@Param("assetId") String assetId, Pageable pageable);
+
+  /**
+   * Marks all validation results that reference the given asset ID as outdated with the supplied reason.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(value = "UPDATE validation_result SET outdated = true, outdated_reason = :reason "
+      + "WHERE :assetId = ANY(asset_ids)", nativeQuery = true)
+  void markOutdatedByAssetId(@Param("assetId") String assetId, @Param("reason") String reason);
+
+  /** Deletes all validation results that reference the given asset ID. */
+  @Modifying
+  @Query(value = "DELETE FROM validation_result WHERE :assetId = ANY(asset_ids)",
+      nativeQuery = true)
+  void deleteByAssetId(@Param("assetId") String assetId);
 
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
@@ -63,6 +63,7 @@ public interface AssetStore {
 
   /**
    * Remove the asset with the given hash from the store.
+   * If the asset has a linked human-readable representation, it is also deleted.
    *
    * @param hash The hash of the asset to work on.
    */

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
@@ -18,6 +18,8 @@ import eu.xfsc.fc.core.pojo.PaginatedResults;
 import eu.xfsc.fc.core.pojo.Validator;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.core.dao.validation.OutdatedReason;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -54,6 +56,7 @@ public class AssetStoreImpl implements AssetStore {
   private final AssetRepository assetRepository;
   private final ProtectedNamespaceProperties namespaceProperties;
   private final ProvenanceService provenanceService;
+  private final ValidationResultStore validationResultStore;
 
   @Override
   public ContentAccessor getFileByHash(final String hash) {
@@ -127,6 +130,9 @@ public class AssetStoreImpl implements AssetStore {
     }
     if (subjectHash != null && subjectHash.subjectId() != null) {
       graphDb.deleteClaims(subjectHash.subjectId());
+      validationResultStore.markOutdatedByAssetId(subjectHash.subjectId(), OutdatedReason.ASSET_UPDATED);
+      // deleteClaims wipes all triples for the asset, including MR-HR link triples; re-write them
+      tryRewriteLinkTriples(assetMetadata.getId());
     }
     graphDb.addClaims(verificationResult.getClaims(), assetMetadata.getId());
     return subjectHash;
@@ -186,15 +192,18 @@ public class AssetStoreImpl implements AssetStore {
     	hash, AssetStatus.ACTIVE, ssr.getAssetStatus()));
     }
     graphDb.deleteClaims(ssr.subjectId());
+    validationResultStore.markOutdatedByAssetId(ssr.subjectId(), OutdatedReason.ASSET_REVOKED);
   }
 
   @Override
   public void deleteAsset(final String hash) {
+    deleteAsset(hash, false);
+  }
+
+  private void deleteAsset(final String hash, final boolean cascading) {
     final Optional<Asset> assetOpt = assetRepository.findByAssetHashWithLinkedAsset(hash);
-    final String hrHashToCascade = assetOpt
-        .filter(a -> a.getAssetType() == AssetType.MACHINE_READABLE && a.getLinkedAsset() != null)
-        .map(a -> a.getLinkedAsset().getAssetHash())
-        .orElse(null);
+    // Only cascade from MR → HR once; a cascading call never triggers a further cascade.
+    final String hrHashToCascade = cascading ? null : assetOpt.map(this::findHumanReadableAssetHash).orElse(null);
 
     assetOpt.filter(a -> a.getLinkedAsset() != null).ifPresent(a -> {
       final Asset peer = a.getLinkedAsset();
@@ -210,6 +219,7 @@ public class AssetStoreImpl implements AssetStore {
     }
 
     provenanceService.deleteByAssetId(ssr.subjectId());
+    validationResultStore.deleteByAssetId(ssr.subjectId());
 
     if (ssr.getAssetStatus() == AssetStatus.ACTIVE) {
       graphDb.deleteClaims(ssr.subjectId());
@@ -222,7 +232,7 @@ public class AssetStoreImpl implements AssetStore {
 
     if (hrHashToCascade != null) {
       try {
-        deleteAsset(hrHashToCascade);
+        deleteAsset(hrHashToCascade, true);
       } catch (NotFoundException ex) {
         log.debug("deleteAsset; HR asset already gone, skipping cascade");
       }
@@ -327,6 +337,23 @@ public class AssetStoreImpl implements AssetStore {
   @Override
   public void writeAssetLinkTriples(String mrIri, String hrIri) {
     writeLinkTriples(mrIri, hrIri);
+  }
+
+  private void tryRewriteLinkTriples(String assetId) {
+    try {
+      assetRepository.findBySubjectIdWithLinkedAsset(assetId)
+          .filter(a -> a.getLinkedAsset() != null && a.getAssetType() == AssetType.MACHINE_READABLE)
+          .ifPresent(a -> writeAssetLinkTriples(assetId, a.getLinkedAsset().getSubjectId()));
+    } catch (Exception ex) {
+      log.warn("tryRewriteLinkTriples; failed to restore link triples after graph rebuild for asset {}", assetId, ex);
+    }
+  }
+
+  private String findHumanReadableAssetHash(Asset asset) {
+    if (asset.getAssetType() != AssetType.MACHINE_READABLE || asset.getLinkedAsset() == null) {
+      return null;
+    }
+    return asset.getLinkedAsset().getAssetHash();
   }
 
   private void writeLinkTriples(String mrIri, String hrIri) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/PublishingAssetStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/PublishingAssetStore.java
@@ -11,6 +11,7 @@ import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher.AssetEvent;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 
 public class PublishingAssetStore extends AssetStoreImpl {
 
@@ -20,9 +21,10 @@ public class PublishingAssetStore extends AssetStoreImpl {
       IriGenerator iriGenerator, AssetRepository assetRepository,
       ProtectedNamespaceProperties namespaceProperties,
       ProvenanceService provenanceService,
+      ValidationResultStore validationResultStore,
       AssetPublisher assetPublisher) {
     super(dao, graphDb, fileStore, iriGenerator, assetRepository, namespaceProperties,
-        provenanceService);
+        provenanceService, validationResultStore);
     this.assetPublisher = assetPublisher;
   }
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStore.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.core.service.validation;
 
+import eu.xfsc.fc.core.dao.validation.OutdatedReason;
 import eu.xfsc.fc.core.dao.validation.ValidationResult;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import java.util.Optional;
@@ -43,4 +44,19 @@ public interface ValidationResultStore {
    * Used during graph rebuild to restore triples from PostgreSQL state.
    */
   void syncToGraph(ValidationResult result, GraphStore graphStore);
+
+  /**
+   * Marks all validation results for the given asset ID as outdated.
+   *
+   * @param assetId the asset IRI whose results to mark outdated
+   * @param reason why the results are being invalidated
+   */
+  void markOutdatedByAssetId(String assetId, OutdatedReason reason);
+
+  /**
+   * Delete all validation results for the given asset ID.
+   *
+   * @param assetId the asset IRI to delete results for
+   */
+  void deleteByAssetId(String assetId);
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImpl.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.service.validation;
 
 import eu.xfsc.fc.core.dao.validation.GraphSyncStatus;
+import eu.xfsc.fc.core.dao.validation.OutdatedReason;
 import eu.xfsc.fc.core.dao.validation.ValidationResult;
 import eu.xfsc.fc.core.dao.validation.ValidationResultRepository;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
@@ -84,6 +85,20 @@ public class ValidationResultStoreImpl implements ValidationResultStore {
       result.setGraphSyncStatus(GraphSyncStatus.FAILED);
       repository.saveAndFlush(result);
     }
+  }
+
+  @Override
+  @Transactional
+  public void markOutdatedByAssetId(String assetId, OutdatedReason reason) {
+    repository.markOutdatedByAssetId(assetId, reason.name());
+    log.debug("markOutdatedByAssetId; marked outdated assetId={}, reason={}", assetId, reason.name());
+  }
+
+  @Override
+  @Transactional
+  public void deleteByAssetId(String assetId) {
+    repository.deleteByAssetId(assetId);
+    log.debug("deleteByAssetId; deleted validation results assetId={}", assetId);
   }
 
   private ValidationResult buildEntity(ValidationResultRecord record) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/CredentialSubjectClaimExtractor.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/CredentialSubjectClaimExtractor.java
@@ -21,6 +21,7 @@ import org.apache.jena.rdf.model.Statement;
 
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.RdfClaim;
+import eu.xfsc.fc.core.util.CredentialConstants;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
@@ -33,10 +34,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class CredentialSubjectClaimExtractor implements ClaimExtractor {
 
-  private static final String CREDENTIAL_SUBJECT_URI =
-      "https://www.w3.org/2018/credentials#credentialSubject";
-  private static final String VERIFIABLE_CREDENTIAL_URI =
-      "https://www.w3.org/2018/credentials#verifiableCredential";
+  private static final String CREDENTIAL_SUBJECT_URI = CredentialConstants.CREDENTIAL_SUBJECT_URI;
+  private static final String VERIFIABLE_CREDENTIAL_URI = CredentialConstants.VERIFIABLE_CREDENTIAL_URI;
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
@@ -226,7 +226,7 @@ public class ClaimValidator {
       return ModelPrinter.get().print(reportResource.getModel());
     }   
     
-    private static final String CREDENTIAL_SUBJECT = "https://www.w3.org/2018/credentials#credentialSubject";
+    private static final String CREDENTIAL_SUBJECT = CredentialConstants.CREDENTIAL_SUBJECT_URI;
     
     public static TrustFrameworkBaseClass getSubjectType(ContentAccessor ontology, StreamManager sm, String subject,
         Map<TrustFrameworkBaseClass, List<String>> classUris) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/CredentialConstants.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/CredentialConstants.java
@@ -1,0 +1,16 @@
+package eu.xfsc.fc.core.util;
+
+/**
+ * W3C Verifiable Credentials vocabulary URIs shared across the codebase.
+ */
+public final class CredentialConstants {
+
+  public static final String CREDENTIAL_SUBJECT_URI =
+      "https://www.w3.org/2018/credentials#credentialSubject";
+
+  public static final String VERIFIABLE_CREDENTIAL_URI =
+      "https://www.w3.org/2018/credentials#verifiableCredential";
+
+  private CredentialConstants() {
+  }
+}

--- a/fc-service-core/src/main/resources/liquibase/changesets/015-validation-result-outdated.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/015-validation-result-outdated.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+  <changeSet id="015-validation-result-outdated" author="saackef">
+    <addColumn tableName="validation_result">
+      <column name="outdated" type="boolean" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+    <addColumn tableName="validation_result">
+      <column name="outdated_reason" type="VARCHAR(50)"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -18,4 +18,5 @@
     <include file="changesets/012-asset-links.xml" relativeToChangelogFile="true" />
     <include file="changesets/013-validation-result.xml" relativeToChangelogFile="true" />
     <include file="changesets/014-provenance-credentials.xml" relativeToChangelogFile="true" />
+    <include file="changesets/015-validation-result-outdated.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepositoryTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepositoryTest.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.core.dao.validation;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,6 +13,7 @@ import java.time.Instant;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -150,6 +152,62 @@ class ValidationResultRepositoryTest {
     Page<ValidationResult> page3 = repository.findAll(PageRequest.of(2, 2));
     assertEquals(1, page3.getNumberOfElements(), "Last page should have 1 element");
     assertTrue(!page3.hasNext(), "Last page should not have next");
+  }
+
+  @Test
+  @Transactional
+  void markOutdatedByAssetId_existingResults_marksAllOutdatedWithReason() {
+    final String assetId = "https://example.org/asset/mark-1";
+
+    repository.save(buildResult(
+        new String[]{assetId}, new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+    repository.save(buildResult(
+        new String[]{assetId, "https://example.org/asset/other"}, new String[]{"ref/2"},
+        true, GraphSyncStatus.SYNCED));
+
+    repository.markOutdatedByAssetId(assetId, OutdatedReason.ASSET_UPDATED.name());
+
+    Page<ValidationResult> page = repository.findByAssetId(assetId, PageRequest.of(0, 10));
+    assertEquals(2, page.getTotalElements());
+    page.getContent().forEach(r -> {
+      assertTrue(r.isOutdated(), "Result must be marked outdated");
+      assertEquals(OutdatedReason.ASSET_UPDATED, r.getOutdatedReason());
+    });
+  }
+
+  @Test
+  @Transactional
+  void markOutdatedByAssetId_alreadyOutdated_isIdempotent() {
+    final String assetId = "https://example.org/asset/idem-1";
+    repository.save(buildResult(new String[]{assetId}, new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+
+    repository.markOutdatedByAssetId(assetId, OutdatedReason.ASSET_REVOKED.name());
+    repository.markOutdatedByAssetId(assetId, OutdatedReason.ASSET_REVOKED.name());
+
+    Page<ValidationResult> page = repository.findByAssetId(assetId, PageRequest.of(0, 10));
+    assertEquals(1, page.getTotalElements());
+    assertTrue(page.getContent().getFirst().isOutdated());
+    assertEquals(OutdatedReason.ASSET_REVOKED, page.getContent().getFirst().getOutdatedReason());
+  }
+
+  @Test
+  @Transactional
+  void deleteByAssetId_existingResults_deletesAll() {
+    final String assetId = "https://example.org/asset/delete-1";
+
+    repository.save(buildResult(new String[]{assetId}, new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+    repository.save(buildResult(new String[]{assetId}, new String[]{"ref/2"}, false, GraphSyncStatus.FAILED));
+
+    repository.deleteByAssetId(assetId);
+
+    Page<ValidationResult> page = repository.findByAssetId(assetId, PageRequest.of(0, 10));
+    assertEquals(0, page.getTotalElements(), "All results for the asset must be deleted");
+  }
+
+  @Test
+  @Transactional
+  void deleteByAssetId_noMatchingResults_noError() {
+    assertDoesNotThrow(() -> repository.deleteByAssetId("https://example.org/asset/none"));
   }
 
   @Test

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCascadeDeleteTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCascadeDeleteTest.java
@@ -12,9 +12,12 @@ import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.AssetType;
 import eu.xfsc.fc.core.pojo.ContentAccessorBinary;
+import eu.xfsc.fc.core.dao.validation.OutdatedReason;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.service.graphdb.DummyGraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.util.HashUtils;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
@@ -31,10 +34,12 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 
 /**
  * Integration tests for cascade-delete behaviour in {@link AssetStoreImpl}.
@@ -62,6 +67,9 @@ class AssetStoreCascadeDeleteTest {
 
   @MockitoBean
   private ProvenanceService provenanceService;
+
+  @MockitoBean
+  private ValidationResultStore validationResultStore;
 
   @Autowired
   private AssetStore assetStore;
@@ -121,7 +129,44 @@ class AssetStoreCascadeDeleteTest {
     assertThrows(NotFoundException.class, () -> assetStore.getByHash(meta.getAssetHash()));
   }
 
-  // ===== helpers =====
+  @Test
+  void deleteAsset_callsValidationResultDeleteForSingleAsset() {
+    final var meta = storeNonRdfAsset(null, "validate-cleanup-single");
+
+    assetStore.deleteAsset(meta.getAssetHash());
+
+    verify(validationResultStore).deleteByAssetId(meta.getId());
+  }
+
+  @Test
+  void storeCredential_existingAssetId_marksValidationResultsOutdated() {
+    storeNonRdfAsset(MR_ID, "update-test-v1");
+
+    final byte[] contentV2 = "update-test-v2".getBytes(StandardCharsets.UTF_8);
+    final Instant now = Instant.now();
+    final AssetMetadata meta = new AssetMetadata(
+        HashUtils.calculateSha256AsHex(contentV2), MR_ID, AssetStatus.ACTIVE,
+        TEST_ISSUER, null, now, now, new ContentAccessorBinary(contentV2));
+    meta.setContentType("application/ld+json");
+    meta.setFileSize((long) contentV2.length);
+
+    assetStore.storeCredential(meta, new CredentialVerificationResult(
+        now, "active", TEST_ISSUER, now, MR_ID, List.of(), null));
+
+    verify(validationResultStore).markOutdatedByAssetId(MR_ID, OutdatedReason.ASSET_UPDATED);
+  }
+
+  @Test
+  void deleteAsset_cascadeDelete_callsValidationResultDeleteForBothAssets() {
+    final var mrMeta = storeNonRdfAsset(MR_ID, "mr for validation verify");
+    final var hrMeta = storeNonRdfAsset(null, "hr for validation verify");
+    linkAssets(mrMeta.getId(), hrMeta.getId());
+
+    assetStore.deleteAsset(mrMeta.getAssetHash());
+
+    verify(validationResultStore).deleteByAssetId(mrMeta.getId());
+    verify(validationResultStore).deleteByAssetId(hrMeta.getId());
+  }
 
   private void linkAssets(String mrId, String hrId) {
     Asset mrEntity = assetRepository.findBySubjectIdWithLinkedAsset(mrId).orElseThrow();
@@ -142,6 +187,6 @@ class AssetStoreCascadeDeleteTest {
     meta.setContentType("application/octet-stream");
     meta.setFileSize((long) content.length);
 
-    return assetStore.storeUnverified(meta, contentText.replaceAll(" ", "_") + ".bin");
+    return assetStore.storeUnverified(meta, contentText.replace(" ", "_") + ".bin");
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreTest.java
@@ -28,6 +28,7 @@ import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 import eu.xfsc.fc.core.util.HashUtils;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
@@ -99,6 +100,9 @@ public class AssetStoreTest {
 
     @MockitoBean
     private ProvenanceService provenanceService;
+
+    @MockitoBean
+    private ValidationResultStore validationResultStore;
 
     @Autowired
     private AssetStore assetStorePublisher;

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
@@ -32,6 +32,7 @@ import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
 import eu.xfsc.fc.core.service.verification.DanubeTechFormatMatcher;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
@@ -144,6 +145,9 @@ public class CesCompositePublisherTest {
 
     @MockitoBean
     private ProvenanceService provenanceService;
+
+    @MockitoBean
+    private ValidationResultStore validationResultStore;
 
     private MockWebServer mockCesService;
     private MockWebServer mockCompService;

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
@@ -27,6 +27,7 @@ import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStore;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 import eu.xfsc.fc.core.service.assetstore.IriGenerator;
 import eu.xfsc.fc.core.service.assetstore.IriValidator;
@@ -102,6 +103,9 @@ public class RevalidationServiceTest {
 
   @MockitoBean
   private ProvenanceService provenanceService;
+
+  @MockitoBean
+  private ValidationResultStore validationResultStore;
 
   //@Autowired
   //private Neo4j embeddedDatabaseServer;

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/AssetLinkPreservationOnUpdateTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/AssetLinkPreservationOnUpdateTest.java
@@ -5,6 +5,7 @@ import static eu.xfsc.fc.server.util.TestCommonConstants.ASSET_UPDATE_WITH_PREFI
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import com.c4_soft.springaddons.security.oauth2.test.annotations.Claims;
 import com.c4_soft.springaddons.security.oauth2.test.annotations.OpenIdClaims;
@@ -22,12 +24,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import eu.xfsc.fc.api.generated.model.Asset;
 import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.api.generated.model.QueryLanguage;
 import eu.xfsc.fc.core.dao.assets.AssetRepository;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
+import eu.xfsc.fc.core.pojo.GraphQuery;
+import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
 import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.core.util.CredentialConstants;
 import eu.xfsc.fc.core.util.HashUtils;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
@@ -72,6 +79,10 @@ public class AssetLinkPreservationOnUpdateTest {
   private AssetStore assetStore;
   @Autowired
   private AssetRepository assetRepository;
+  @Autowired
+  private GraphStore graphStore;
+  @Autowired
+  private ProtectedNamespaceProperties namespaceProperties;
 
   @BeforeAll
   void setup() {
@@ -81,6 +92,19 @@ public class AssetLinkPreservationOnUpdateTest {
   @AfterEach
   void cleanUp() {
     assetStore.clear();
+  }
+
+  @Test
+  void uploadHumanReadable_withoutAuthentication_returnsUnauthorized() throws Exception {
+    final var file = new MockMultipartFile("file", "test.txt", "text/plain",
+        "content".getBytes(StandardCharsets.UTF_8));
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .multipart("/assets/" + URLEncoder.encode(MR_IRI, StandardCharsets.UTF_8) + "/human-readable")
+            .file(file)
+            .with(csrf())
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test
@@ -134,6 +158,32 @@ public class AssetLinkPreservationOnUpdateTest {
         "Link must point to HR v2, not the deleted HR v1");
 
     deleteAssetQuietly(hrV2.getAssetHash());
+  }
+
+  @Test
+  @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX, ASSET_UPDATE_WITH_PREFIX},
+      claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+          @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+  void updateMachineReadableAsset_hasHumanReadableTripleRemainsQueryableAfterUpdate() throws Exception {
+    storeMrVersion("MR v1 for SPARQL check");
+    final var hrAsset = uploadHumanReadable(MR_IRI, "HR for SPARQL check", "text/plain", "hr-sparql.txt");
+
+    storeMrVersion("MR v2 for SPARQL check");
+
+    final var sparql = """
+        SELECT ?s ?p ?o WHERE {
+          <<(?s ?p ?o)>> <%s> <%s> .
+          FILTER(?s = <%s> && ?p = <%s>)
+        }
+        """.formatted(CredentialConstants.CREDENTIAL_SUBJECT_URI, MR_IRI, MR_IRI,
+            namespaceProperties.getNamespace() + "hasHumanReadable");
+    final var results = graphStore.queryData(
+        new GraphQuery(sparql, Map.of(), QueryLanguage.SPARQL, GraphQuery.QUERY_TIMEOUT, false));
+
+    assertTrue(results.getTotalCount() > 0,
+        "fcmeta:hasHumanReadable triple must remain queryable after MR asset update");
+
+    deleteAssetQuietly(hrAsset.getAssetHash());
   }
 
   private void storeMrVersion(String content) {

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -754,6 +754,14 @@ components:
           type: string
           format: date-time
           description: Timestamp of record creation in the database
+        outdated:
+          type: boolean
+          description: True if the result has been superseded by a newer validation run or asset lifecycle event
+        outdatedReason:
+          type: string
+          enum: [ASSET_UPDATED, ASSET_REVOKED]
+          nullable: true
+          description: Reason the result was marked outdated; null when outdated is false
 
     ProvenanceCredential:
       type: object


### PR DESCRIPTION
## 🚀 Summary

Implements CAT-FR-LM-04 — asset lifecycle scope management.

What changed:

- ValidationResult entity extended with outdated + outdated_reason columns (Liquibase 015)
- ValidationResultStore / ValidationResultStoreImpl added: marks results OUTDATED on asset update/revoke, deletes them on asset delete
- AssetStoreImpl.deleteAsset cascades deletion to linked HR asset (MR → HR, one level only)
- AssetStoreImpl.storeCredentialInternal re-writes MR↔HR link triples after deleteClaims wipes them on update
- PublishingAssetStore delegates new lifecycle operations to the wrapped store

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnit tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style