### PR TITLE
Enhancement [CAT-FR-CO-05] On-Demand Validation (#43)

### DIFF
--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
@@ -54,6 +54,9 @@ public class SparqlGraphStore implements GraphStore {
      */
     protected final Pattern orderByRegex = Pattern.compile("ORDER\\sBY(?=(?:[^'\"`]*(['\"`])[^'\"`]*\1)*[^'\"`]*$)", Pattern.CASE_INSENSITIVE);
 
+    // Rejects characters that break the <iri> token in a SPARQL string context.
+    private static final Pattern SAFE_IRI_PATTERN = Pattern.compile("^[^<>\"\\\\\\s{}|^`\\[\\]]+$");
+
 
     private final ClaimValidator claimValidator;
 
@@ -159,6 +162,27 @@ public class SparqlGraphStore implements GraphStore {
         log.debug("deleteClaims.enter; got subject: {}", credentialSubject);
         final String deleteQuery = String.format("DELETE WHERE { ?s <%s> <%s> .}", PROP_CREDENTIAL_SUBJECT, credentialSubject);
         Txn.executeWrite(rdfConnection, () -> rdfConnection.update(deleteQuery));
+    }
+
+    @Override
+    public void deleteValidationResultClaims(String resultIri) {
+        log.debug("deleteValidationResultClaims.enter; resultIri={}", resultIri);
+        requireSafeIri(resultIri);
+        // Delete all RDF-star annotations where the embedded triple has resultIri as subject or object.
+        // Two operations: (1) result property triples <<(resultIri ?p ?o)>>, (2) hasValidationResult links <<(?s ?p resultIri)>>.
+        // Note: <<(?s ?p ?o)>> is the annotation-pattern syntax required by Jena SPARQL-star in WHERE/DELETE clauses.
+        final String query = String.format(
+            "DELETE WHERE { <<(<%1$s> ?p ?o)>> <%2$s> ?cs . } ;" +
+            "DELETE WHERE { <<(?s ?p <%1$s>)>> <%2$s> ?cs . }",
+            resultIri, PROP_CREDENTIAL_SUBJECT);
+        Txn.executeWrite(rdfConnection, () -> rdfConnection.update(query));
+        log.debug("deleteValidationResultClaims.exit");
+    }
+
+    private static void requireSafeIri(String iri) {
+        if (iri == null || !SAFE_IRI_PATTERN.matcher(iri).matches()) {
+            throw new ServerException("IRI contains characters unsafe for SPARQL interpolation: " + iri);
+        }
     }
 
     @Override

--- a/fc-graphdb-fuseki/src/test/java/eu/xfsc/fc/graphdb/service/SparqlGraphStoreTest.java
+++ b/fc-graphdb-fuseki/src/test/java/eu/xfsc/fc/graphdb/service/SparqlGraphStoreTest.java
@@ -390,6 +390,47 @@ public class SparqlGraphStoreTest {
     }
 
     @Test
+    void deleteValidationResultClaims_removesMatchingTriples_preservesUnrelated() {
+        String assetId1 = "http://example.org/asset/1";
+        String assetId2 = "http://example.org/asset/2";
+        String resultIri1 = "http://example.org/result/1";
+        String resultIri2 = "http://example.org/result/2";
+        String conformsPredicate = "http://example.org/conforms";
+
+        // Seed result1: property triple + link triple (assetId1 -> resultIri1)
+        graphStore.addClaims(List.of(
+            typeClaim(resultIri1, "http://example.org/ValidationResult"),
+            literalClaim(resultIri1, conformsPredicate, "true")
+        ), assetId1);
+        graphStore.addClaims(List.of(
+            new CredentialClaim("<" + assetId1 + ">", "<http://example.org/hasValidationResult>", "<" + resultIri1 + ">")
+        ), assetId1);
+
+        // Seed result2: same structure but different IRI — must survive the deletion
+        graphStore.addClaims(List.of(
+            typeClaim(resultIri2, "http://example.org/ValidationResult"),
+            literalClaim(resultIri2, conformsPredicate, "true")
+        ), assetId2);
+        graphStore.addClaims(List.of(
+            new CredentialClaim("<" + assetId2 + ">", "<http://example.org/hasValidationResult>", "<" + resultIri2 + ">")
+        ), assetId2);
+
+        long countBefore = queryAllClaimsByCredentialSubject().getResults().size();
+        assertTrue(countBefore > 0, "Precondition: claims must be present before deletion");
+
+        graphStore.deleteValidationResultClaims(resultIri1);
+
+        List<Map<String, Object>> remaining = queryAllClaimsByCredentialSubject().getResults();
+        boolean result1Gone = remaining.stream().noneMatch(r ->
+            resultIri1.equals(r.get("s")) || resultIri1.equals(r.get("o")));
+        assertTrue(result1Gone, "All triples referencing result1 IRI should be deleted");
+
+        boolean result2Intact = remaining.stream().anyMatch(r ->
+            resultIri2.equals(r.get("s")) || resultIri2.equals(r.get("o")));
+        assertTrue(result2Intact, "Triples for result2 should not be affected");
+    }
+
+    @Test
     void queryData_sparqlStarFilterBySpecificCredential_returnsOnlyThatCredential() {
         String credA = "http://example.org/credFilterA";
         String credB = "http://example.org/credFilterB";
@@ -410,7 +451,6 @@ public class SparqlGraphStoreTest {
             "Filter by credA should not return credB's claims");
     }
 
-    // --- Helpers ---
 
     private PaginatedResults<Map<String, Object>> querySparql(String sparql) {
         return graphStore.queryData(new GraphQuery(

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
@@ -123,9 +123,8 @@ public class Neo4jGraphStore implements GraphStore {
      */
     @Override
     public void addClaims(List<RdfClaim> claimList, String credentialSubject) {
-        log.debug("addClaims.enter; got claims: {}, subject: {}", claimList, credentialSubject);
         if (!claimList.isEmpty()) {
-            try (Session session = driver.session()) { 
+            try (Session session = driver.session()) {
                 Pair<String, Set<String>> props = claimValidator.resolveClaims(claimList, credentialSubject);
                 if (!props.getRight().isEmpty()) {
                     updateGraphConfig(session, props.getRight());
@@ -134,7 +133,6 @@ public class Neo4jGraphStore implements GraphStore {
                 log.debug("addClaims; inserted: {}", rs.consume());
             }
         }
-        log.debug("addClaims.exit");
     }
 
     /**
@@ -142,15 +140,27 @@ public class Neo4jGraphStore implements GraphStore {
      */
     @Override
     public void deleteClaims(String credentialSubject) {
-        log.debug("deleteClaims.enter; got subject: {}", credentialSubject);
         Map<String, Object> params = Map.of("uri", credentialSubject);
         try (Session session = driver.session()) {
-            Result rsDelelte = session.run(queryDelete, params);
-            log.debug("deleteClaims; deleted: {}", rsDelelte.consume());
+            Result rsDelete = session.run(queryDelete, params);
+            log.debug("deleteClaims; deleted: {}", rsDelete.consume());
             Result rsUpdate = session.run(queryUpdate, params);
             log.debug("deleteClaims; updated: {}", rsUpdate.consume());
         }
-        log.debug("deleteClaims.exit");
+    }
+
+    /**
+     * Deletes all graph claims linked to a validation result IRI.
+     *
+     * <p>The IRI is passed as a bound Cypher parameter ({@code $uri}), so query injection is
+     * prevented by the Neo4j driver and no string interpolation validation is required here.</p>
+     */
+    @Override
+    public void deleteValidationResultClaims(String resultIri) {
+        try (Session session = driver.session()) {
+            Result rs = session.run("MATCH (n {uri: $uri}) DETACH DELETE n", Map.of("uri", resultIri));
+            log.debug("deleteValidationResultClaims; deleted: {}", rs.consume());
+        }
     }
 
     /**
@@ -193,7 +203,6 @@ public class Neo4jGraphStore implements GraphStore {
         while (result.hasNext()) {
             org.neo4j.driver.Record record = result.next();
             Map<String, Object> map = record.asMap();
-            log.debug("doQuery; record: {}", map);
             Map<String, Object> outputMap = new HashMap<>();
             totalCount = (Long) map.getOrDefault("totalCount", Long.valueOf(resultList.size()));
             for (var entry : map.entrySet()) {
@@ -224,7 +233,6 @@ public class Neo4jGraphStore implements GraphStore {
             Collections.shuffle(resultList);
         }
 
-        log.debug("doQuery.exit; returning: {}", resultList);
         return new PaginatedResults<>(totalCount, resultList);
     }
 
@@ -255,7 +263,6 @@ public class Neo4jGraphStore implements GraphStore {
 
     private String getDynamicallyAddedCountClauseQuery(GraphQuery query) {
         if (query.isWithTotalCount()) {
-            log.debug("getDynamicallyAddedCountClauseQuery.enter; actual query: {}", query.getQuery());
             /*get string before statements and append count clause*/
             String statement = "return";
 
@@ -280,7 +287,6 @@ public class Neo4jGraphStore implements GraphStore {
             }
             /*finally combine both string */
             String finalString = subStringOfCount.append(actualQuery).toString();
-            log.debug("getDynamicallyAddedCountClauseQuery.exit; count query appended : {}", finalString);
             return finalString;
         }
         return query.getQuery();

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -31,7 +31,7 @@ import eu.xfsc.fc.core.service.validation.ValidationResultHasher;
 import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
 import eu.xfsc.fc.core.service.verification.DanubeTechFormatMatcher;
-import eu.xfsc.fc.core.service.verification.FormatDetector;
+import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
 import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
 import eu.xfsc.fc.core.service.verification.LoireJwtParser;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
@@ -68,6 +68,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.data.domain.Page;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
+
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +100,7 @@ import static eu.xfsc.fc.core.util.TestUtil.getAccessor;
         DocumentLoaderConfig.class,
         DocumentLoaderProperties.class,
         FileStoreConfig.class,
-        FormatDetector.class,
+        CredentialFormatDetector.class,
         GraphRebuilder.class,
         HttpDocumentResolver.class,
         IriGenerator.class,
@@ -114,6 +117,8 @@ import static eu.xfsc.fc.core.util.TestUtil.getAccessor;
         SchemaJpaDao.class,
         SchemaModuleConfigService.class,
         SchemaStoreImpl.class,
+        RdfAssetParser.class,
+        ShaclValidationExecutor.class,
         SchemaValidationServiceImpl.class,
         SecurityAuditorAware.class,
         ValidatorCacheJpaDao.class,

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreAccuracyTest.java
@@ -6,7 +6,12 @@ import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
-import eu.xfsc.fc.core.pojo.*;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.pojo.CredentialClaim;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
+import eu.xfsc.fc.core.pojo.GraphQuery;
+import eu.xfsc.fc.core.pojo.RdfClaim;
 import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.dao.assets.AssetAuditRepository;
 import eu.xfsc.fc.core.dao.assets.AssetJpaDao;
@@ -22,7 +27,7 @@ import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
 import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
 import eu.xfsc.fc.core.service.verification.DanubeTechFormatMatcher;
-import eu.xfsc.fc.core.service.verification.FormatDetector;
+import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
 import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
 import eu.xfsc.fc.core.service.verification.LoireJwtParser;
 import eu.xfsc.fc.core.service.verification.LoireMatcher;
@@ -31,6 +36,8 @@ import eu.xfsc.fc.core.service.verification.SchemaModuleConfigService;
 import eu.xfsc.fc.core.service.verification.SchemaValidationServiceImpl;
 import eu.xfsc.fc.core.service.verification.Vc2Processor;
 import eu.xfsc.fc.core.service.verification.VerificationServiceImpl;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
 import eu.xfsc.fc.core.service.verification.claims.JenaAllTriplesExtractor;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
@@ -75,10 +82,11 @@ import java.util.Map;
 	VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, ValidatorCacheJpaDao.class,
 	DidResolverConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class, HttpDocumentResolver.class,
         CredentialVerificationStrategy.class, ClaimExtractionService.class, JenaAllTriplesExtractor.class,
-        SchemaValidationServiceImpl.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
+        RdfAssetParser.class, ShaclValidationExecutor.class, SchemaValidationServiceImpl.class,
+        ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
 	AdminConfigRepository.class, SchemaModuleConfigService.class, SecurityAuditorAware.class,
 	JwtContentPreprocessor.class, Vc2Processor.class, JwtSignatureVerifier.class, DidDocumentResolver.class,
-        FormatDetector.class, LoireJwtParser.class, LoireMatcher.class, DanubeTechFormatMatcher.class})
+        CredentialFormatDetector.class, LoireJwtParser.class, LoireMatcher.class, DanubeTechFormatMatcher.class})
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 @Import(EmbeddedNeo4JConfig.class)
 public class Neo4jGraphStoreAccuracyTest {

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStoreTest.java
@@ -435,6 +435,59 @@ public class Neo4jGraphStoreTest {
         graphGaia.deleteClaims(credentialSubject);
     }
 
+    @Test
+    void deleteValidationResultClaims_removesTargetNode_preservesUnrelatedNode() {
+        String resultIri1 = "https://example.org/result/del-1";
+        String resultIri2 = "https://example.org/result/del-2";
+
+        // Seed two nodes — n10s sets n.uri from the subject URI of imported N-Triples
+        graphGaia.addClaims(List.of(
+            new CredentialClaim(
+                "<" + resultIri1 + ">",
+                "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+                "<http://example.org/ValidationResult>"
+            )
+        ), resultIri1);
+        graphGaia.addClaims(List.of(
+            new CredentialClaim(
+                "<" + resultIri2 + ">",
+                "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+                "<http://example.org/ValidationResult>"
+            )
+        ), resultIri2);
+
+        // Precondition: both nodes must exist
+        GraphQuery findResult1Before = new GraphQuery(
+            "MATCH (n {uri: $uri}) RETURN n.uri AS found",
+            Map.of("uri", resultIri1), QueryLanguage.OPENCYPHER, GraphQuery.QUERY_TIMEOUT, false);
+        GraphQuery findResult2Before = new GraphQuery(
+            "MATCH (n {uri: $uri}) RETURN n.uri AS found",
+            Map.of("uri", resultIri2), QueryLanguage.OPENCYPHER, GraphQuery.QUERY_TIMEOUT, false);
+        Assertions.assertEquals(1, graphGaia.queryData(findResult1Before).getResults().size(),
+            "Precondition: result1 node must exist");
+        Assertions.assertEquals(1, graphGaia.queryData(findResult2Before).getResults().size(),
+            "Precondition: result2 node must exist");
+
+        graphGaia.deleteValidationResultClaims(resultIri1);
+
+        // result1 node must be gone
+        GraphQuery findResult1After = new GraphQuery(
+            "MATCH (n {uri: $uri}) RETURN n.uri AS found",
+            Map.of("uri", resultIri1), QueryLanguage.OPENCYPHER, GraphQuery.QUERY_TIMEOUT, false);
+        Assertions.assertTrue(graphGaia.queryData(findResult1After).getResults().isEmpty(),
+            "result1 node should be deleted");
+
+        // result2 node must still exist
+        GraphQuery findResult2After = new GraphQuery(
+            "MATCH (n {uri: $uri}) RETURN n.uri AS found",
+            Map.of("uri", resultIri2), QueryLanguage.OPENCYPHER, GraphQuery.QUERY_TIMEOUT, false);
+        Assertions.assertEquals(1, graphGaia.queryData(findResult2After).getResults().size(),
+            "result2 node should not be affected");
+
+        // cleanup
+        graphGaia.deleteValidationResultClaims(resultIri2);
+    }
+
     private List<RdfClaim> loadTestClaims(String path) throws Exception {
         try (InputStream is = new ClassPathResource(path).getInputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(is));

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/config/AssetStoreConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/config/AssetStoreConfig.java
@@ -13,9 +13,9 @@ import eu.xfsc.fc.core.service.assetstore.IriGenerator;
 import eu.xfsc.fc.core.service.assetstore.PublishingAssetStore;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
-import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher;
-import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
+import org.springframework.context.ApplicationEventPublisher;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -30,16 +30,28 @@ public class AssetStoreConfig {
       @Qualifier("assetFileStore") FileStore fileStore,
       IriGenerator iriGenerator, AssetRepository assetRepository,
       ProtectedNamespaceProperties namespaceProperties,
-      ProvenanceService provenanceService,
-      ValidationResultStore validationResultStore,
+      ApplicationEventPublisher eventPublisher,
       AssetPublisher assetPublisher) {
     AssetStore assetStore;
     if ("none".equals(pubImpl)) {
-      assetStore = new AssetStoreImpl(dao, graphDb, fileStore, iriGenerator, assetRepository,
-          namespaceProperties, provenanceService, validationResultStore);
+      assetStore = new AssetStoreImpl(
+          dao,
+          graphDb,
+          fileStore,
+          iriGenerator,
+          assetRepository,
+          namespaceProperties,
+          eventPublisher);
     } else {
-      assetStore = new PublishingAssetStore(dao, graphDb, fileStore, iriGenerator, assetRepository,
-          namespaceProperties, provenanceService, validationResultStore, assetPublisher);
+      assetStore = new PublishingAssetStore(
+          dao,
+          graphDb,
+          fileStore,
+          iriGenerator,
+          assetRepository,
+          namespaceProperties,
+          eventPublisher,
+          assetPublisher);
     }
     log.debug("getAssetStore; returning {} for impl {}", assetStore, pubImpl);
     return assetStore;

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/config/XmlSecurityConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/config/XmlSecurityConfig.java
@@ -1,0 +1,63 @@
+package eu.xfsc.fc.core.config;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.validation.SchemaFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.xml.sax.SAXException;
+
+/**
+ * Shared secure XML parser factory configuration.
+ *
+ * <p>Both factories are scoped {@code prototype} because {@link DocumentBuilderFactory} and
+ * {@link SchemaFactory} are documented as not thread-safe; consumers must inject via
+ * {@link org.springframework.beans.factory.ObjectProvider} and call {@code getObject()}
+ * for each parse to obtain a fresh instance.</p>
+ */
+@Configuration
+public class XmlSecurityConfig {
+
+  /**
+   * Hardened {@link DocumentBuilderFactory} that resists XXE, billion-laughs and external
+   * entity attacks. Mitigations follow the OWASP XML External Entity (XXE) Prevention
+   * Cheat Sheet — see comments on each setting.
+   */
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  public DocumentBuilderFactory secureDocumentBuilderFactory() throws ParserConfigurationException {
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setNamespaceAware(true);
+    // Primary XXE mitigation: reject any input containing a DOCTYPE declaration.
+    dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+    // Defense-in-depth for parsers that ignore disallow-doctype-decl: block external entity loading.
+    dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+    dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+    // Generic JAXP flag enabling secure-processing limits (e.g. caps entity expansion to mitigate
+    // billion-laughs / quadratic-blowup denial of service).
+    dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    // Belt-and-braces: even if an entity slips through, do not expand it inline.
+    dbf.setExpandEntityReferences(false);
+    return dbf;
+  }
+
+  /**
+   * Hardened {@link SchemaFactory} for W3C XML Schema 1.0. Blocks SSRF and external schema
+   * inclusion attacks via {@code xs:include} / {@code xs:import}.
+   */
+  @Bean
+  @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+  public SchemaFactory secureXmlSchemaFactory() throws SAXException {
+    SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    // Enables JAXP secure-processing limits inside the schema parser itself.
+    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+    // Block all URI-based DTD and schema loading — prevents SSRF via attacker-supplied schemas
+    // that reference internal endpoints or fetch payloads from the network.
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+    factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+    return factory;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/GraphSyncStatus.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/GraphSyncStatus.java
@@ -13,7 +13,7 @@ public enum GraphSyncStatus {
   SYNCED,
 
   /**
-   * The graph DB write failed. The PostgreSQL row is the source of truth.
+   * The graph write failed. The stored validation result row is the source of truth.
    * FAILED rows require manual intervention; no automatic retry is performed.
    */
   FAILED

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResult.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResult.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import java.time.Instant;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -61,8 +62,8 @@ public class ValidationResult {
   private String[] validatorIds;
 
   /**
-   * {@code SCHEMA} or {@code TRUST_FRAMEWORK} — distinguishes on-demand schema validation
-   * from external trust framework check results.
+   * Validator type — distinguishes schema validation ({@code SHACL}, {@code JSON_SCHEMA},
+   * {@code XML_SCHEMA}) from external trust framework checks ({@code TRUST_FRAMEWORK}).
    */
   @Enumerated(EnumType.STRING)
   @Column(name = "validator_type", length = 64, nullable = false)
@@ -77,11 +78,10 @@ public class ValidationResult {
   private Instant validatedAt;
 
   /**
-   * Serialised validation report (JSONB). Null for passing validations.
+   * Serialised validation report. Null for passing validations.
    * For SHACL: Turtle report. For JSON Schema: violation messages. For XML: error message.
    */
-  @JdbcTypeCode(SqlTypes.JSON)
-  @Column(name = "report", columnDefinition = "jsonb")
+  @Column(name = "report", columnDefinition = "text")
   private String report;
 
   /**
@@ -99,6 +99,7 @@ public class ValidationResult {
   @Column(name = "graph_sync_status", length = 16)
   private GraphSyncStatus graphSyncStatus;
 
+  @Setter(AccessLevel.NONE)
   @CreatedDate
   @Column(name = "created_at", nullable = false, updatable = false)
   private Instant createdAt;

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepository.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.core.dao.validation;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,6 +21,15 @@ public interface ValidationResultRepository extends JpaRepository<ValidationResu
       nativeQuery = true)
   Page<ValidationResult> findByAssetId(@Param("assetId") String assetId, Pageable pageable);
 
+  /** Returns all validation results referencing {@code assetId}, without pagination. */
+  @Query(value = "SELECT * FROM validation_result WHERE :assetId = ANY(asset_ids)", nativeQuery = true)
+  List<ValidationResult> findAllByAssetId(@Param("assetId") String assetId);
+
+  /** Deletes all validation results that reference {@code assetId} in their {@code asset_ids} array. */
+  @Modifying
+  @Query(value = "DELETE FROM validation_result WHERE :assetId = ANY(asset_ids)", nativeQuery = true)
+  void deleteAllByAssetId(@Param("assetId") String assetId);
+
   /**
    * Marks all validation results that reference the given asset ID as outdated with the supplied reason.
    */
@@ -27,11 +37,5 @@ public interface ValidationResultRepository extends JpaRepository<ValidationResu
   @Query(value = "UPDATE validation_result SET outdated = true, outdated_reason = :reason "
       + "WHERE :assetId = ANY(asset_ids)", nativeQuery = true)
   void markOutdatedByAssetId(@Param("assetId") String assetId, @Param("reason") String reason);
-
-  /** Deletes all validation results that reference the given asset ID. */
-  @Modifying
-  @Query(value = "DELETE FROM validation_result WHERE :assetId = ANY(asset_ids)",
-      nativeQuery = true)
-  void deleteByAssetId(@Param("assetId") String assetId);
 
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidatorType.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/validation/ValidatorType.java
@@ -5,9 +5,21 @@ package eu.xfsc.fc.core.dao.validation;
  */
 public enum ValidatorType {
 
-  /** On-demand schema validation (SHACL, JSON Schema, XML Schema). */
-  SCHEMA,
+  /** On-demand SHACL validation of RDF assets. */
+  SHACL,
 
-  /** External trust framework compliance check. */
+  /** On-demand JSON Schema validation of non-RDF JSON assets. */
+  JSON_SCHEMA,
+
+  /** On-demand XML Schema validation of non-RDF XML assets. */
+  XML_SCHEMA,
+
+  /**
+   * External trust framework compliance check.
+   *
+   * <p>No {@code ValidationStrategy} implementation exists yet; compliance evaluation is
+   * currently performed by the trust-framework orchestrator outside the on-demand validation
+   * pipeline.</p>
+   */
   TRUST_FRAMEWORK
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetDeletedEvent.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetDeletedEvent.java
@@ -1,0 +1,11 @@
+package eu.xfsc.fc.core.service.assetstore;
+
+/**
+ * Published by {@link AssetStoreImpl} when an asset row is successfully deleted.
+ * Listeners should use {@code @TransactionalEventListener(phase = BEFORE_COMMIT)}
+ * so cleanup runs inside the same transaction as the asset deletion.
+ *
+ * @param assetId the subject IRI of the deleted asset
+ */
+public record AssetDeletedEvent(String assetId) {
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStore.java
@@ -118,12 +118,12 @@ public interface AssetStore {
   AssetMetadata getById(String id);
 
   /**
-    * Check whether an active asset exists for the given IRI (subjectId).
+   * Check whether an active asset exists for the given IRI (subjectId).
    *
    * @param id The IRI that identifies the asset.
-    * @return true if an active asset exists, false otherwise.
+   * @return true if an active asset exists, false otherwise.
    */
-    boolean existsById(String id);
+  boolean existsById(String id);
 
   /**
    * Fetch an active asset's file content by its IRI (subjectId).
@@ -190,9 +190,8 @@ public interface AssetStore {
   Optional<LinkedAssetRef> findLink(String assetIri);
 
   /**
-   * Write {@code fcmeta:hasHumanReadable} and {@code fcmeta:hasMachineReadable} triples
+   * Writes {@code fcmeta:hasHumanReadable} and {@code fcmeta:hasMachineReadable} triples
    * to the graph store for the given MR–HR pair.
-   * Used during graph rebuilds to restore link triples from PostgreSQL state.
    *
    * @param mrIri IRI of the machine-readable asset
    * @param hrIri IRI of the human-readable asset

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/AssetStoreImpl.java
@@ -18,8 +18,7 @@ import eu.xfsc.fc.core.pojo.PaginatedResults;
 import eu.xfsc.fc.core.pojo.Validator;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
-import eu.xfsc.fc.core.dao.validation.OutdatedReason;
-import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+import org.springframework.context.ApplicationEventPublisher;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -55,8 +54,7 @@ public class AssetStoreImpl implements AssetStore {
   private final IriGenerator iriGenerator;
   private final AssetRepository assetRepository;
   private final ProtectedNamespaceProperties namespaceProperties;
-  private final ProvenanceService provenanceService;
-  private final ValidationResultStore validationResultStore;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   public ContentAccessor getFileByHash(final String hash) {
@@ -130,7 +128,6 @@ public class AssetStoreImpl implements AssetStore {
     }
     if (subjectHash != null && subjectHash.subjectId() != null) {
       graphDb.deleteClaims(subjectHash.subjectId());
-      validationResultStore.markOutdatedByAssetId(subjectHash.subjectId(), OutdatedReason.ASSET_UPDATED);
       // deleteClaims wipes all triples for the asset, including MR-HR link triples; re-write them
       tryRewriteLinkTriples(assetMetadata.getId());
     }
@@ -192,7 +189,6 @@ public class AssetStoreImpl implements AssetStore {
     	hash, AssetStatus.ACTIVE, ssr.getAssetStatus()));
     }
     graphDb.deleteClaims(ssr.subjectId());
-    validationResultStore.markOutdatedByAssetId(ssr.subjectId(), OutdatedReason.ASSET_REVOKED);
   }
 
   @Override
@@ -218,9 +214,7 @@ public class AssetStoreImpl implements AssetStore {
       throw new NotFoundException("no asset found for hash " + hash);
     }
 
-    provenanceService.deleteByAssetId(ssr.subjectId());
-    validationResultStore.deleteByAssetId(ssr.subjectId());
-
+    eventPublisher.publishEvent(new AssetDeletedEvent(ssr.subjectId()));
     if (ssr.getAssetStatus() == AssetStatus.ACTIVE) {
       graphDb.deleteClaims(ssr.subjectId());
     }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/PublishingAssetStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/assetstore/PublishingAssetStore.java
@@ -8,10 +8,9 @@ import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
-import eu.xfsc.fc.core.service.provenance.ProvenanceService;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher;
+import org.springframework.context.ApplicationEventPublisher;
 import eu.xfsc.fc.core.service.pubsub.AssetPublisher.AssetEvent;
-import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 
 public class PublishingAssetStore extends AssetStoreImpl {
 
@@ -19,12 +18,16 @@ public class PublishingAssetStore extends AssetStoreImpl {
 
   public PublishingAssetStore(AssetDao dao, GraphStore graphDb, FileStore fileStore,
       IriGenerator iriGenerator, AssetRepository assetRepository,
-      ProtectedNamespaceProperties namespaceProperties,
-      ProvenanceService provenanceService,
-      ValidationResultStore validationResultStore,
+      ProtectedNamespaceProperties namespaceProperties, ApplicationEventPublisher eventPublisher,
       AssetPublisher assetPublisher) {
-    super(dao, graphDb, fileStore, iriGenerator, assetRepository, namespaceProperties,
-        provenanceService, validationResultStore);
+    super(
+        dao,
+        graphDb,
+        fileStore,
+        iriGenerator,
+        assetRepository,
+        namespaceProperties,
+        eventPublisher);
     this.assetPublisher = assetPublisher;
   }
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/DummyGraphStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/DummyGraphStore.java
@@ -30,6 +30,11 @@ public class DummyGraphStore implements GraphStore {
     }
 
     @Override
+    public void deleteValidationResultClaims(String resultIri) {
+        // Dummy implementation
+    }
+
+    @Override
     public PaginatedResults<Map<String, Object>> queryData(GraphQuery query) {
         // Dummy implementation
         return new PaginatedResults<>(Collections.emptyList());

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/GraphStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/GraphStore.java
@@ -33,6 +33,17 @@ public interface GraphStore {
     void deleteClaims(String credentialSubject);
 
     /**
+     * Deletes all graph triples associated with a validation result.
+     *
+     * <p>Removes triples where {@code resultIri} appears as subject or object,
+     * including {@code fcmeta:hasValidationResult} links from asset nodes and
+     * all {@code fcmeta:*} properties on the result node itself.</p>
+     *
+     * @param resultIri the IRI of the validation result (e.g. {@code fcmeta:ValidationResult/123})
+     */
+    void deleteValidationResultClaims(String resultIri);
+
+    /**
      * Query the graph when Cypher query is passed in query object and this
      * returns list of Maps with key value pairs as a result.
      *

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreImpl.java
@@ -32,6 +32,7 @@ import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -77,6 +78,12 @@ public class SchemaStoreImpl implements SchemaStore {
 
   @Autowired
   private ProtectedNamespaceFilter protectedNamespaceFilter;
+
+  @Autowired
+  private ObjectProvider<DocumentBuilderFactory> secureDocumentBuilderFactoryProvider;
+
+  @Autowired
+  private ObjectProvider<SchemaFactory> secureXmlSchemaFactoryProvider;
 
   private static final Map<SchemaType, ContentAccessor> COMPOSITE_SCHEMAS = new ConcurrentHashMap<>();
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
@@ -302,17 +309,10 @@ public class SchemaStoreImpl implements SchemaStore {
   private SchemaAnalysisResult analyzeXmlSchema(ContentAccessor schema) {
     try {
       byte[] content = schema.getContentAsString().getBytes(StandardCharsets.UTF_8);
-      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-      dbf.setNamespaceAware(true);
-      // Disable DTDs entirely to prevent XXE attacks;
-      // uses a Xerces-specific feature URI as it's not part of standard XMLConstants.
-      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      DocumentBuilderFactory dbf = secureDocumentBuilderFactoryProvider.getObject();
       Document doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(content));
 
-      SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      SchemaFactory factory = secureXmlSchemaFactoryProvider.getObject();
       factory.newSchema(new DOMSource(doc));
 
       String targetNs = doc.getDocumentElement().getAttribute("targetNamespace");

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/AssetValidationService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/AssetValidationService.java
@@ -1,0 +1,29 @@
+package eu.xfsc.fc.core.service.validation;
+
+import eu.xfsc.fc.api.generated.model.ValidationRequest;
+import eu.xfsc.fc.api.generated.model.ValidationResponse;
+
+/**
+ * On-demand validation of stored assets against stored schemas.
+ *
+ * <p>Results are persisted via {@link ValidationResultStore} and retrievable
+ * through the GET /assets/{id}/validations endpoint.</p>
+ */
+public interface AssetValidationService {
+
+  /**
+   * Validates one or more stored assets against stored schemas.
+   *
+   * <p>If {@code assetIds} contains a single entry, the asset is dispatched through the
+   * full type-based pipeline (SHACL for RDF, JSON Schema for JSON, XML Schema for XML).
+   * If {@code assetIds} contains multiple entries, all assets are merged into a single
+   * data graph and validated via SHACL only.</p>
+   *
+   * @param request asset IRIs and schema selection (schemaIds or validateAgainstAllSchemas)
+   * @return validation response with result ID(s) and optional report
+   * @throws eu.xfsc.fc.core.exception.NotFoundException       if an asset or schema ID does not exist
+   * @throws eu.xfsc.fc.core.exception.VerificationException   if an asset type is not validatable
+   * @throws eu.xfsc.fc.core.exception.ClientException         if assetIds is empty or exceeds the maximum
+   */
+  ValidationResponse validateAssets(ValidationRequest request);
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/AssetValidationServiceImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/AssetValidationServiceImpl.java
@@ -1,0 +1,382 @@
+package eu.xfsc.fc.core.service.validation;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.api.generated.model.ValidationRequest;
+import eu.xfsc.fc.api.generated.model.ValidationResponse;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.exception.ServerException;
+import eu.xfsc.fc.core.exception.VerificationException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import eu.xfsc.fc.core.service.validation.strategy.ValidationStrategy;
+import eu.xfsc.fc.core.service.verification.SchemaModuleConfigService;
+import eu.xfsc.fc.core.service.verification.SchemaModuleType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link AssetValidationService}.
+ *
+ * <p>Orchestrates on-demand validation of stored assets against stored schemas.
+ * Dispatches to registered {@link ValidationStrategy} implementations based on schema type
+ * and asset format. Handles module toggles, schema resolution, and result storage via
+ * {@link ValidationResultStore}.</p>
+ *
+ * <p>Multi-asset requests are restricted to SHACL validation. Single-asset requests support
+ * all registered strategies (SHACL for RDF assets, JSON Schema for non-RDF JSON,
+ * XML Schema for non-RDF XML). Each applicable strategy stores an independent
+ * {@link eu.xfsc.fc.core.dao.validation.ValidationResult}.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class AssetValidationServiceImpl implements AssetValidationService {
+
+  // increase with caution: each extra asset adds a full SHACL merge pass
+  @Value("${federated-catalogue.validation.max-assets-per-request:20}")
+  private int maxAssetsPerRequest;
+
+  private final AssetStore assetStore;
+  private final SchemaStore schemaStore;
+  private final SchemaModuleConfigService moduleConfig;
+  private final List<ValidationStrategy> strategies;
+  private final ValidationResultStore validationResultStore;
+
+  @Override
+  @Transactional
+  public ValidationResponse validateAssets(ValidationRequest request) {
+    List<String> assetIds = request.getAssetIds();
+    if (assetIds == null || assetIds.isEmpty()) {
+      throw new ClientException("assetIds must contain at least one asset ID");
+    }
+    if (assetIds.size() > maxAssetsPerRequest) {
+      throw new ClientException(
+          "Too many assets in request: " + assetIds.size() + " (maximum: " + maxAssetsPerRequest + ")");
+    }
+
+    List<String> schemaIds = request.getSchemaIds();
+    Boolean validateAll = request.getValidateAgainstAllSchemas();
+    Instant validatedAt = Instant.now();
+
+    if (assetIds.size() > 1) {
+      return validateMultipleAssets(assetIds, schemaIds, validateAll, validatedAt);
+    }
+
+    return validateSingleAsset(assetIds.get(0), schemaIds, validateAll, validatedAt);
+  }
+
+  private ValidationResponse validateSingleAsset(
+      String assetId, List<String> schemaIds, Boolean validateAll, Instant validatedAt) {
+    AssetMetadata asset = assetStore.getById(assetId);
+
+    if (asset.getContentAccessor() == null) {
+      boolean anyApplies = strategies.stream().anyMatch(s -> s.appliesTo(asset));
+      if (!anyApplies) {
+        String ct = asset.getContentType();
+        if (ct == null) {
+          throw new VerificationException(
+              "Asset " + asset.getId() + " has no content type. Cannot determine validation schema type. "
+                  + "Validatable types: " + MediaType.APPLICATION_JSON_VALUE
+                  + ", " + MediaType.APPLICATION_XML_VALUE);
+        }
+        throw new VerificationException(
+            "Asset " + asset.getId() + " has unsupported content type for validation: " + ct
+                + ". Validatable types: " + MediaType.APPLICATION_JSON_VALUE
+                + ", " + MediaType.APPLICATION_XML_VALUE);
+      }
+    }
+
+    List<StrategyJob> jobs;
+    if (schemaIds != null && !schemaIds.isEmpty()) {
+      jobs = planExplicit(asset, schemaIds);
+    } else if (Boolean.TRUE.equals(validateAll)) {
+      jobs = planAllApplicable(asset);
+    } else {
+      throw new NotFoundException(
+          "No schemas specified for validation. Provide schemaIds or set validateAgainstAllSchemas=true.");
+    }
+
+    return execute(List.of(asset), jobs, validatedAt);
+  }
+
+  private ValidationResponse validateMultipleAssets(
+      List<String> assetIds, List<String> schemaIds, Boolean validateAll, Instant validatedAt) {
+    requireModuleEnabled(SchemaModuleType.SHACL);
+
+    List<AssetMetadata> assets = new ArrayList<>();
+    for (String id : assetIds) {
+      AssetMetadata asset = assetStore.getById(id);
+      if (asset.getContentAccessor() == null) {
+        throw new VerificationException(
+            "Asset " + id + " is not an RDF asset. Multi-asset validation only supports RDF assets for SHACL.");
+      }
+      assets.add(asset);
+    }
+
+    SchemaResolutionResult schemas = resolveShaclSchemas(schemaIds, validateAll);
+    ValidationStrategy shaclStrategy = strategies.stream()
+        .filter(s -> s.type() == ValidatorType.SHACL)
+        .findFirst()
+        .orElseThrow(() -> new ServerException("SHACL validation strategy not registered"));
+
+    ValidationReport report = shaclStrategy.validate(assets, schemas.schemaContents());
+    Long resultId = storeResult(assetIds, schemas.validatorIds(), ValidatorType.SHACL, report, validatedAt);
+
+    return buildResponse(assetIds, schemas.schemaIds(), report, List.of(resultId), validatedAt);
+  }
+
+  /**
+   * Plans validation jobs for a single asset against explicit schema IDs.
+   *
+   * <p>Schema IDs are grouped by the strategy that accepts them. Each group produces one
+   * {@link StrategyJob}. SHACL accepts multiple shapes per job; JSON and XML enforce exactly
+   * one schema.</p>
+   *
+   * @throws ClientException if no registered strategy accepts a schema type,
+   *     if a non-SHACL strategy receives more than one schema,
+   *     or if the matched strategy does not apply to the asset's format
+   * @throws VerificationException if the matched strategy's module is disabled
+   */
+  private List<StrategyJob> planExplicit(AssetMetadata asset, List<String> schemaIds) {
+    Map<ValidationStrategy, List<SchemaRecord>> byStrategy = new LinkedHashMap<>();
+    for (String id : schemaIds) {
+      SchemaRecord record = schemaStore.getSchemaRecord(id);
+      ValidationStrategy strategy = findStrategyFor(record);
+      byStrategy.computeIfAbsent(strategy, k -> new ArrayList<>()).add(record);
+    }
+
+    List<StrategyJob> jobs = new ArrayList<>();
+    for (Map.Entry<ValidationStrategy, List<SchemaRecord>> entry : byStrategy.entrySet()) {
+      ValidationStrategy strategy = entry.getKey();
+      List<SchemaRecord> records = entry.getValue();
+
+      if (strategy.type() != ValidatorType.SHACL && records.size() > 1) {
+        throw new ClientException(
+            strategy.type() + " validation supports exactly one schema per request, but "
+                + records.size() + " were provided.");
+      }
+      if (!strategy.appliesTo(asset)) {
+        throw new ClientException(
+            "Schema type " + records.get(0).type() + " is not applicable to asset " + asset.getId()
+                + ". RDF assets must be validated via SHACL (SHAPE schema type)."
+                + " Non-RDF assets use JSON or XML schemas.");
+      }
+      requireModuleEnabled(strategy.moduleType());
+
+      List<ContentAccessor> contents = records.stream()
+          .map(r -> schemaStore.getSchema(r.getId()))
+          .toList();
+      List<String> ids = records.stream().map(SchemaRecord::getId).toList();
+      jobs.add(new StrategyJob(strategy, contents, ids));
+    }
+    return jobs;
+  }
+
+  /**
+   * Plans validation jobs for a single asset against all applicable stored schemas.
+   *
+   * <p>Each enabled strategy that applies to the asset is checked for available schemas.
+   * Strategies with no stored schemas are silently skipped. Throws if no job can be planned.</p>
+   *
+   * @throws NotFoundException if at least one applicable, enabled strategy has no stored schemas
+   *     (applies to non-RDF assets with a single applicable schema type)
+   * @throws VerificationException if no strategy is both enabled and applicable
+   */
+  private List<StrategyJob> planAllApplicable(AssetMetadata asset) {
+    List<StrategyJob> jobs = new ArrayList<>();
+    boolean anyApplicableEnabled = false;
+    Map<SchemaType, List<String>> schemasByType = null;
+
+    for (ValidationStrategy strategy : strategies) {
+      if (!moduleConfig.isModuleEnabled(strategy.moduleType())) {
+        continue;
+      }
+      if (!strategy.appliesTo(asset)) {
+        continue;
+      }
+
+      anyApplicableEnabled = true;
+      SchemaType schemaType = resolveSchemaStoreType(strategy);
+      ContentAccessor content = resolveAllSchemasContent(strategy, schemaType);
+      if (content == null) {
+        continue;
+      }
+
+      if (schemasByType == null) {
+        schemasByType = schemaStore.getSchemaList();
+      }
+      List<String> ids = schemasByType.getOrDefault(schemaType, List.of());
+      jobs.add(new StrategyJob(strategy, List.of(content), ids));
+    }
+
+    if (jobs.isEmpty()) {
+      if (asset.getContentAccessor() == null && anyApplicableEnabled) {
+        throw new NotFoundException(
+            "No schema found for validation of asset " + asset.getId()
+                + ". Ensure schemas of the applicable type are stored.");
+      }
+      throw new VerificationException(
+          "No validation module is enabled or applicable for asset " + asset.getId()
+              + ". Enable at least one applicable module via admin settings (SHACL, "
+              + SchemaModuleType.JSON_SCHEMA + ", or " + SchemaModuleType.XML_SCHEMA + ").");
+    }
+    return jobs;
+  }
+
+  private ValidationResponse execute(
+      List<AssetMetadata> assets, List<StrategyJob> jobs, Instant validatedAt) {
+    List<String> assetIds = assets.stream().map(AssetMetadata::getId).toList();
+    List<String> allSchemaIds = new ArrayList<>();
+    List<Long> allResultIds = new ArrayList<>();
+    ValidationReport firstReport = null;
+    ValidationReport failingReport = null;
+
+    for (StrategyJob job : jobs) {
+      ValidationReport report = job.strategy().validate(assets, job.schemaContents());
+      allResultIds.add(storeResult(assetIds, job.schemaIds(), job.strategy().type(), report, validatedAt));
+      allSchemaIds.addAll(job.schemaIds());
+      if (firstReport == null) {
+        firstReport = report;
+      }
+      if (!report.getConforms() && failingReport == null) {
+        failingReport = report;
+      }
+    }
+
+    ValidationReport responseReport = failingReport != null ? failingReport : firstReport;
+    return buildResponse(assetIds, allSchemaIds, responseReport, allResultIds, validatedAt);
+  }
+
+  /**
+   * Resolves SHACL shapes into a merged list of ContentAccessors.
+   *
+   * <p>If explicit schemaIds are given, each is type-checked (must be SHAPE) and loaded.
+   * If validateAgainstAllSchemas=true, the composite schema (union of all stored shapes) is used.</p>
+   */
+  private SchemaResolutionResult resolveShaclSchemas(List<String> schemaIds, Boolean validateAll) {
+    if (schemaIds != null && !schemaIds.isEmpty()) {
+      List<ContentAccessor> contents = new ArrayList<>();
+      List<String> resolvedIds = new ArrayList<>();
+      for (String id : schemaIds) {
+        SchemaRecord record = schemaStore.getSchemaRecord(id);
+        if (record.type() != SchemaType.SHAPE) {
+          throw new ClientException(
+              "Schema " + id + " has type " + record.type()
+                  + " and cannot be used for SHACL validation. Only SHAPE schemas are accepted.");
+        }
+        contents.add(schemaStore.getSchema(id));
+        resolvedIds.add(id);
+      }
+      return new SchemaResolutionResult(contents, resolvedIds, resolvedIds);
+    }
+
+    if (Boolean.TRUE.equals(validateAll)) {
+      ContentAccessor composite = schemaStore.getCompositeSchema(SchemaType.SHAPE);
+      if (composite == null) {
+        throw new NotFoundException("No SHACL shapes found for validation");
+      }
+      List<String> allIds = schemaStore.getSchemaList().getOrDefault(SchemaType.SHAPE, List.of());
+      return new SchemaResolutionResult(List.of(composite), allIds, allIds);
+    }
+
+    throw new NotFoundException(
+        "No schemas specified for validation. Provide schemaIds or set validateAgainstAllSchemas=true.");
+  }
+
+  private ValidationStrategy findStrategyFor(SchemaRecord record) {
+    return strategies.stream()
+        .filter(s -> s.acceptsSchema(record))
+        .findFirst()
+        .orElseThrow(() -> new ClientException(
+            "Schema " + record.getId() + " has type " + record.type()
+                + " which is not supported for on-demand validation. Supported types: SHAPE, JSON, XML."));
+  }
+
+  private SchemaType resolveSchemaStoreType(ValidationStrategy strategy) {
+    return switch (strategy.type()) {
+      case SHACL -> SchemaType.SHAPE;
+      case JSON_SCHEMA -> SchemaType.JSON;
+      case XML_SCHEMA -> SchemaType.XML;
+      default -> throw new ServerException("Unknown validator type: " + strategy.type());
+    };
+  }
+
+  private ContentAccessor resolveAllSchemasContent(ValidationStrategy strategy, SchemaType schemaType) {
+    if (strategy.type() == ValidatorType.SHACL) {
+      return schemaStore.getCompositeSchema(schemaType);
+    }
+    return schemaStore.getLatestSchemaByType(schemaType);
+  }
+
+  private void requireModuleEnabled(String moduleType) {
+    if (!moduleConfig.isModuleEnabled(moduleType)) {
+      throw new VerificationException("Validation module " + moduleType + " is disabled");
+    }
+  }
+
+  private Long storeResult(List<String> assetIds, List<String> validatorIds,
+      ValidatorType validatorType, ValidationReport report, Instant validatedAt) {
+    String rawReport = report.getConforms() ? null : report.getRawReport();
+    return validationResultStore.store(new ValidationResultRecord(
+        assetIds,
+        validatorIds,
+        validatorType,
+        report.getConforms(),
+        validatedAt,
+        rawReport));
+  }
+
+
+  /**
+   * Builds the {@link ValidationResponse} for a completed validation run.
+   *
+   * <p>When multiple strategies ran (for example SHACL plus JSON Schema in a single request),
+   * the response report is the first <em>failing</em> report, or the first report overall
+   * if all strategies conformed. This means only one report is surfaced per response;
+   * all result IDs are included regardless. The report is omitted entirely when the
+   * overall result conforms.</p>
+   */
+  private ValidationResponse buildResponse(List<String> assetIds, List<String> schemaIds,
+      ValidationReport report, List<Long> validationResultIds, Instant validatedAt) {
+    ValidationResponse response = new ValidationResponse();
+    response.setAssetIds(assetIds);
+    response.setSchemaIds(schemaIds);
+    response.setConforms(report.getConforms());
+    response.setValidatedAt(validatedAt);
+    response.setValidationResultIds(validationResultIds);
+    if (!report.getConforms()) {
+      response.setReport(report);
+    }
+    return response;
+  }
+
+  /**
+   * Holds resolved SHACL schema ContentAccessors, schema IDs, and validator IDs for storage.
+   */
+  private record SchemaResolutionResult(
+      List<ContentAccessor> schemaContents, List<String> schemaIds, List<String> validatorIds) {
+  }
+
+  /**
+   * Binds a {@link ValidationStrategy} to the pre-resolved schema content and IDs for one dispatch.
+   */
+  private record StrategyJob(
+      ValidationStrategy strategy,
+      List<ContentAccessor> schemaContents,
+      List<String> schemaIds) {
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultCleanupListener.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultCleanupListener.java
@@ -1,0 +1,36 @@
+package eu.xfsc.fc.core.service.validation;
+
+import eu.xfsc.fc.core.service.assetstore.AssetDeletedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * Deletes validation results when an asset is deleted.
+ *
+ * <p>Runs inside the same transaction as the asset deletion ({@code BEFORE_COMMIT}) so that
+ * validation result cleanup is atomic with the asset row removal.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ValidationResultCleanupListener {
+
+  private final ValidationResultStore validationResultStore;
+
+  /**
+   * Deletes all validation results for the deleted asset.
+   *
+   * <p>Runs at {@link TransactionPhase#BEFORE_COMMIT}, inside the same transaction as the
+   * asset deletion. This guarantees atomicity: either both the asset row and its validation
+   * results are removed, or neither is. If this method throws, the exception propagates to
+   * the caller and the outer transaction is rolled back — the asset row is preserved.</p>
+   */
+  @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+  public void onAssetDeleted(AssetDeletedEvent event) {
+    log.debug("onAssetDeleted; cleaning up validation results for assetId={}", event.assetId());
+    validationResultStore.deleteByAssetId(event.assetId());
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriter.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriter.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
- * Writes validation result metadata to the graph DB as {@code fcmeta:} RDF triples.
+ * Writes validation result metadata to the graph store as {@code fcmeta:} RDF triples.
  *
  * <p>Calls {@link GraphStore#addClaims(List, String)} directly, bypassing
  * {@code ProtectedNamespaceFilter}. This is intentional: the filter only blocks
@@ -47,7 +47,7 @@ public class ValidationResultGraphWriter {
    */
   public void write(ValidationResult result, GraphStore graphStore) {
     String fcmeta = namespaceProperties.getNamespace();
-    String resultIri = buildResultIri(result.getId(), fcmeta);
+    String resultIri = resultIri(result.getId());
     List<RdfClaim> claims = new ArrayList<>();
 
     // Link each asset subject IRI → this validation result
@@ -74,8 +74,14 @@ public class ValidationResultGraphWriter {
     log.debug("write; wrote {} fcmeta triples for result id={}", claims.size(), result.getId());
   }
 
-  private static String buildResultIri(Long id, String fcmeta) {
-    return fcmeta + "ValidationResult/" + id;
+  /**
+   * Returns the IRI for a stored validation result, using the configured {@code fcmeta:} namespace.
+   *
+   * @param id the numeric ID of the stored {@link eu.xfsc.fc.core.dao.validation.ValidationResult}
+   * @return the full validation result IRI
+   */
+  public String resultIri(Long id) {
+    return namespaceProperties.getNamespace() + "ValidationResult/" + id;
   }
 
   private static CredentialClaim iriTriple(String subject, String predicate, String object) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStore.java
@@ -8,9 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 /**
- * Write and read boundary interface for validation results.
- *
- * <p>{@link ValidationResultStoreImpl} is the production implementation.</p>
+ * Write and read boundary interface for validation result records and their graph projection.
  */
 public interface ValidationResultStore {
 
@@ -41,7 +39,6 @@ public interface ValidationResultStore {
   /**
    * Writes {@code fcmeta:} triples for the given result to the graph store and updates
    * {@code graph_sync_status} to {@code SYNCED} on success or {@code FAILED} on error.
-   * Used during graph rebuild to restore triples from PostgreSQL state.
    */
   void syncToGraph(ValidationResult result, GraphStore graphStore);
 
@@ -49,14 +46,19 @@ public interface ValidationResultStore {
    * Marks all validation results for the given asset ID as outdated.
    *
    * @param assetId the asset IRI whose results to mark outdated
-   * @param reason why the results are being invalidated
+   * @param reason  why the results are being invalidated
    */
   void markOutdatedByAssetId(String assetId, OutdatedReason reason);
 
   /**
-   * Delete all validation results for the given asset ID.
+   * Deletes all validation results that reference the given asset ID, from both the relational DB
+   * and the graph store.
    *
-   * @param assetId the asset IRI to delete results for
+   * <p>Must be called before the asset itself is deleted so that graph triples can still
+   * be resolved by result ID. Deleting results for an asset that also appears in multi-asset
+   * validation batches removes the entire result row, not just the reference.</p>
+   *
+   * @param assetId the asset IRI as stored in {@code validation_result.asset_ids}
    */
   void deleteByAssetId(String assetId);
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImpl.java
@@ -5,6 +5,7 @@ import eu.xfsc.fc.core.dao.validation.OutdatedReason;
 import eu.xfsc.fc.core.dao.validation.ValidationResult;
 import eu.xfsc.fc.core.dao.validation.ValidationResultRepository;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,11 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
  * Implements {@link ValidationResultStore} and provides
  * validation result persistence with graph DB sync.
  *
- * <p>Write sequence: PostgreSQL INSERT + graph DB write both happen inside the {@code @Transactional}
- * boundary; PostgreSQL commits only when {@code store()} returns. If PostgreSQL fails to commit after a
- * successful graph write, graph triples will exist without a corresponding PostgreSQL row.
+ * <p>Write sequence: relational DB INSERT + graph DB write both happen inside the {@code @Transactional}
+ * boundary; the DB commits only when {@code store()} returns. If the DB fails to commit after a
+ * successful graph write, graph triples will exist without a corresponding DB row.
  * If the graph write itself fails, the row is marked
- * {@code FAILED} and no retry is attempted. PostgreSQL is the system of record.</p>
+ * {@code FAILED} and no retry is attempted. The relational DB is the system of record.</p>
  */
 @Slf4j
 @Service
@@ -36,8 +37,8 @@ public class ValidationResultStoreImpl implements ValidationResultStore {
   /**
    * {@inheritDoc}
    *
-   * <p>Persists the result to PostgreSQL (with tamper-proof hash), then attempts a
-   * graph DB write (best-effort). The PostgreSQL row is the source of truth; a failed graph
+   * <p>Persists the result to the relational DB (with tamper-proof hash), then attempts a
+   * graph DB write (best-effort). The DB row is the source of truth; a failed graph
    * write marks the row {@code FAILED} and is not retried.</p>
    */
   @Override
@@ -49,7 +50,7 @@ public class ValidationResultStoreImpl implements ValidationResultStore {
     log.debug("store; saved ValidationResult id={}, conforms={}", saved.getId(), saved.isConforms());
 
     // Note: the graph write happens while the @Transactional method is still open.
-    // PostgreSQL commits when store() returns. Best-effort: graph write failure marks row FAILED; no retry.
+    // The DB transaction commits when store() returns. Best-effort: graph write failure marks row FAILED; no retry.
     tryWriteToGraph(saved);
 
     return saved.getId();
@@ -75,6 +76,23 @@ public class ValidationResultStoreImpl implements ValidationResultStore {
 
   @Override
   @Transactional
+  public void deleteByAssetId(String assetId) {
+    List<ValidationResult> results = repository.findAllByAssetId(assetId);
+    log.debug("deleteByAssetId; found {} results for assetId={}", results.size(), assetId);
+    for (ValidationResult result : results) {
+      String iri = graphWriter.resultIri(result.getId());
+      try {
+        graphStore.deleteValidationResultClaims(iri);
+      } catch (Exception e) {
+        log.warn("deleteByAssetId; graph cleanup failed for result id={}: {}", result.getId(), e.getMessage());
+      }
+    }
+    repository.deleteAllByAssetId(assetId);
+    log.debug("deleteByAssetId; deleted {} DB rows for assetId={}", results.size(), assetId);
+  }
+
+  @Override
+  @Transactional
   public void syncToGraph(ValidationResult result, GraphStore graphStore) {
     try {
       graphWriter.write(result, graphStore);
@@ -92,13 +110,6 @@ public class ValidationResultStoreImpl implements ValidationResultStore {
   public void markOutdatedByAssetId(String assetId, OutdatedReason reason) {
     repository.markOutdatedByAssetId(assetId, reason.name());
     log.debug("markOutdatedByAssetId; marked outdated assetId={}, reason={}", assetId, reason.name());
-  }
-
-  @Override
-  @Transactional
-  public void deleteByAssetId(String assetId) {
-    repository.deleteByAssetId(assetId);
-    log.debug("deleteByAssetId; deleted validation results assetId={}", assetId);
   }
 
   private ValidationResult buildEntity(ValidationResultRecord record) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/rdf/RdfAssetParser.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/rdf/RdfAssetParser.java
@@ -1,0 +1,161 @@
+package eu.xfsc.fc.core.service.validation.rdf;
+
+import com.apicatalog.jsonld.loader.DocumentLoader;
+import com.apicatalog.jsonld.loader.SchemeRouter;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
+import eu.xfsc.fc.core.service.verification.VerificationConstants;
+import eu.xfsc.fc.core.service.verification.cache.CachingLocator;
+import eu.xfsc.fc.core.util.FormatDetectionConstants;
+import eu.xfsc.fc.core.util.RdfFormatDetector;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RiotException;
+import org.apache.jena.riot.system.stream.StreamManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+/**
+ * Parses RDF asset content and SHACL shapes into Jena {@link Model} instances.
+ *
+ * <p>This class is a Spring bean because it owns the application-scoped {@link StreamManager}
+ * lifecycle. The {@link StreamManager} is initialised once in {@link #init()} and shared across
+ * all parsing calls. {@link FileStore} is injected solely to back the {@link CachingLocator}
+ * registered with that {@link StreamManager}; it is not used in any parsing method directly.</p>
+ *
+ * <p>The {@link #parse(AssetMetadata)} method supports two runtime branches:</p>
+ * <ul>
+ *   <li>Loire JWT (starts with {@code "eyJ"}): unwrapped via {@link LoireJwtParser},
+ *       then parsed as JSON-LD 1.1.</li>
+ *   <li>All non-JWT RDF content (including JSON-LD): format detected via
+ *       {@link RdfFormatDetector}.</li>
+ * </ul>
+ *
+ * <p>The helper methods {@link #isJsonLd(AssetMetadata)} and {@link #isRdfXml(AssetMetadata)}
+ * are separate from parse-branching and are used only by validation strategies to determine
+ * applicability.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RdfAssetParser {
+
+  @Qualifier("contextCacheFileStore")
+  private final FileStore fileStore;
+  private final DocumentLoader documentLoader;
+  private final LoireJwtParser loireJwtParser;
+
+  private StreamManager streamManager;
+
+  @PostConstruct
+  void init() {
+    SchemeRouter loader = (SchemeRouter) SchemeRouter.defaultInstance();
+    loader.set("file", documentLoader);
+    loader.set("http", documentLoader);
+    loader.set("https", documentLoader);
+    StreamManager clone = StreamManager.get().clone();
+    clone.clearLocators();
+    clone.addLocator(new CachingLocator(fileStore));
+    streamManager = clone;
+  }
+
+  /**
+   * Parses an RDF asset into a Jena {@link Model}.
+   *
+    * <p>Runtime flow:</p>
+    * <ul>
+    *   <li>JWT branch: unwrap via {@link LoireJwtParser} and parse as JSON-LD 1.1.</li>
+    *   <li>Non-JWT branch: detect RDF syntax via {@link RdfFormatDetector}
+    *       (including JSON-LD), then parse using the detected Jena {@link Lang}.</li>
+    * </ul>
+   *
+   * @param asset asset with non-null {@link AssetMetadata#getContentAccessor()}
+   * @throws ClientException if the asset has no content or the RDF content is malformed
+   */
+  public Model parse(AssetMetadata asset) {
+    ContentAccessor content = asset.getContentAccessor();
+    if (content == null) {
+      throw new ClientException(
+          "Asset " + asset.getId() + " is not an RDF asset and cannot be validated with SHACL");
+    }
+    String rawContent = content.getContentAsString().strip();
+    if (rawContent.startsWith(VerificationConstants.JWT_PREFIX)) {
+      ContentAccessor unwrapped = loireJwtParser.unwrap(content);
+      return parseRdfContent(unwrapped, Lang.JSONLD11);
+    }
+    Lang lang = RdfFormatDetector.detect(asset.getContentType(), rawContent);
+    return parseRdfContent(content, lang);
+  }
+
+  /**
+   * Parses a SHACL shapes document (Turtle) into a Jena {@link Model}.
+   *
+   * @param shape ContentAccessor containing a valid SHACL Turtle document
+   * @throws ClientException if the Turtle content is malformed
+   */
+  public Model parseShape(ContentAccessor shape) {
+    try {
+      Model model = ModelFactory.createDefaultModel();
+      RDFParser.create()
+          .streamManager(streamManager)
+          .source(shape.getContentAsStream())
+          .lang(Lang.TURTLE)
+          .parse(model);
+      return model;
+    } catch (RiotException e) {
+      throw new ClientException("Invalid SHACL shape: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Returns {@code true} if the asset content is JSON-LD (content starts with '{').
+   * Falls back to content-type inspection for assets without a content accessor.
+   */
+  public boolean isJsonLd(AssetMetadata asset) {
+    ContentAccessor content = asset.getContentAccessor();
+    if (content != null) {
+      return content.getContentAsString().strip().startsWith(FormatDetectionConstants.JSON_LD_PREFIX);
+    }
+    String ct = asset.getContentType();
+    return ct != null && (ct.contains(VerificationConstants.MEDIA_TYPE_LD_JSON)
+      || ct.contains(VerificationConstants.MEDIA_TYPE_VC_LD_JSON)
+      || ct.contains(VerificationConstants.MEDIA_TYPE_VP_LD_JSON));
+  }
+
+  /**
+   * Returns {@code true} if the asset content is RDF/XML (content starts with {@code "<?xml"}
+   * or {@code "<rdf:RDF"}). Falls back to content-type inspection for assets without a content accessor.
+   */
+  public boolean isRdfXml(AssetMetadata asset) {
+    ContentAccessor content = asset.getContentAccessor();
+    if (content != null) {
+      String raw = content.getContentAsString().strip();
+      return raw.startsWith(FormatDetectionConstants.RDF_XML_PREFIX_1)
+          || raw.startsWith(FormatDetectionConstants.RDF_XML_PREFIX_2);
+    }
+    String ct = asset.getContentType();
+    return ct != null && ct.contains(VerificationConstants.MEDIA_TYPE_RDF_XML);
+  }
+
+  private Model parseRdfContent(ContentAccessor content, Lang lang) {
+    try {
+      Model model = ModelFactory.createDefaultModel();
+      RDFParser.create()
+          .streamManager(streamManager)
+          .source(content.getContentAsStream())
+          .lang(lang)
+          .parse(model);
+      return model;
+    } catch (RiotException e) {
+      throw new ClientException("Invalid RDF asset content: " + e.getMessage(), e);
+    }
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/report/ValidationReportFactory.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/report/ValidationReportFactory.java
@@ -1,0 +1,131 @@
+package eu.xfsc.fc.core.service.validation.report;
+
+import com.networknt.schema.Error;
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.api.generated.model.ValidationViolation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.topbraid.shacl.util.ModelPrinter;
+import org.topbraid.shacl.vocabulary.SH;
+import org.xml.sax.SAXException;
+
+/**
+ * Factory for assembling {@link ValidationReport} instances from raw validator output.
+ *
+ * <p>Centralises all report construction so that individual {@code ValidationStrategy}
+ * implementations contain no {@code new ValidationReport()} / {@code new ValidationViolation()}
+ * boilerplate.</p>
+ */
+@UtilityClass
+public class ValidationReportFactory {
+
+  private static final String SHACL_NS = "http://www.w3.org/ns/shacl#";
+  private static final Map<String, ValidationViolation.SeverityEnum> SHACL_SEVERITY_MAP = Map.of(
+      SHACL_NS + "Violation", ValidationViolation.SeverityEnum.VIOLATION,
+      SHACL_NS + "Warning", ValidationViolation.SeverityEnum.WARNING,
+      SHACL_NS + "Info", ValidationViolation.SeverityEnum.INFO
+  );
+
+  /** Returns a conforming report with an empty violations list. */
+  public static ValidationReport conforming() {
+    return new ValidationReport().conforms(true).violations(List.of());
+  }
+
+  /**
+   * Builds a report from a TopBraid SHACL {@code sh:ValidationReport} resource.
+   *
+   * @param reportResource the SHACL result resource produced by {@code ValidationUtil}
+   * @return report with conforms flag, violations, and raw Turtle report on failure
+   */
+  public static ValidationReport fromShacl(Resource reportResource) {
+    boolean conforms = reportResource.getProperty(SH.conforms).getBoolean();
+    if (conforms) {
+      return conforming();
+    }
+
+    List<ValidationViolation> violations = new ArrayList<>();
+    StmtIterator results = reportResource.getModel().listStatements(null, SH.result, (RDFNode) null);
+    while (results.hasNext()) {
+      Resource result = results.next().getObject().asResource();
+      ValidationViolation violation = new ValidationViolation();
+      violation.setFocusNode(getStringProperty(result, SH.focusNode));
+      violation.setResultPath(getStringProperty(result, SH.resultPath));
+      violation.setMessage(getStringProperty(result, SH.resultMessage));
+      String severityUri = getStringProperty(result, SH.resultSeverity);
+      violation.setSeverity(
+          SHACL_SEVERITY_MAP.getOrDefault(severityUri, ValidationViolation.SeverityEnum.VIOLATION));
+      violation.setSourceShape(getStringProperty(result, SH.sourceShape));
+      violations.add(violation);
+    }
+    return new ValidationReport()
+      .conforms(false)
+      .violations(violations)
+      .rawReport(ModelPrinter.get().print(reportResource.getModel()));
+  }
+
+  /**
+   * Builds a report from a list of networknt JSON Schema {@link Error} objects.
+   *
+   * @param errors validation errors; empty list produces a conforming report
+   * @return report with conforms flag, violations, and newline-joined raw report on failure
+   */
+  public static ValidationReport fromJsonErrors(List<Error> errors) {
+    if (errors.isEmpty()) {
+      return conforming();
+    }
+    return new ValidationReport()
+        .conforms(false)
+        .violations(errors.stream().map(ValidationReportFactory::toJsonViolation).toList())
+        .rawReport(errors.stream()
+            .map(Error::getMessage)
+            .reduce((a, b) -> a + "\n" + b)
+            .orElse(null));
+  }
+
+  /**
+   * Builds a non-conforming report from a single SAX validation exception.
+   *
+   * @param e the SAX exception thrown by the XML {@code Validator}
+   * @return report with conforms=false, one violation, and the exception message as raw report
+   */
+  public static ValidationReport fromSaxException(SAXException e) {
+    return new ValidationReport()
+      .conforms(false)
+      .violations(List.of(new ValidationViolation()
+        .message(e.getMessage())
+        .severity(ValidationViolation.SeverityEnum.VIOLATION)))
+      .rawReport(e.getMessage());
+  }
+
+  private static ValidationViolation toJsonViolation(Error error) {
+    ValidationViolation violation = new ValidationViolation();
+    violation.setFocusNode(
+        error.getInstanceLocation() != null ? error.getInstanceLocation().toString() : null);
+    violation.setMessage(error.getMessage());
+    violation.setSeverity(ValidationViolation.SeverityEnum.VIOLATION);
+    violation.setSourceShape(
+        error.getSchemaLocation() != null ? error.getSchemaLocation().toString() : null);
+    return violation;
+  }
+
+  private static String getStringProperty(Resource resource, Property property) {
+    var stmt = resource.getProperty(property);
+    if (stmt == null) {
+      return null;
+    }
+    RDFNode node = stmt.getObject();
+    if (node.isLiteral()) {
+      return node.asLiteral().getString();
+    }
+    if (node.isResource()) {
+      return node.asResource().getURI();
+    }
+    return null;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/JsonSchemaValidationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/JsonSchemaValidationStrategy.java
@@ -1,0 +1,154 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.Error;
+import com.networknt.schema.Schema;
+import com.networknt.schema.SchemaException;
+import com.networknt.schema.SchemaRegistry;
+import com.networknt.schema.SpecificationVersion;
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.service.validation.report.ValidationReportFactory;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import eu.xfsc.fc.core.service.verification.SchemaModuleType;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+/**
+ * {@link ValidationStrategy} implementation for JSON Schema (Draft 2020-12) validation.
+ *
+ * <p>Applies to non-RDF JSON assets ({@code application/json}, {@code application/schema+json})
+ * and to JSON-LD serialized RDF assets. Enforces exactly one asset and one schema per call.</p>
+ *
+ * <p>Uses the networknt json-schema-validator 2.x API with {@link SchemaRegistry}.
+ * External {@code $ref} URIs using {@code file://}, {@code http://}, {@code gopher://}, or
+ * {@code ftp://} are rejected to prevent SSRF attacks.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class JsonSchemaValidationStrategy implements ValidationStrategy {
+
+  @Qualifier("assetFileStore")
+  private final FileStore fileStore;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public ValidatorType type() {
+    return ValidatorType.JSON_SCHEMA;
+  }
+
+  @Override
+  public String moduleType() {
+    return SchemaModuleType.JSON_SCHEMA;
+  }
+
+  /**
+   * Returns {@code true} for non-RDF JSON assets only.
+   * RDF assets (including JSON-LD) should use SHACL validation.
+   */
+  @Override
+  public boolean appliesTo(AssetMetadata asset) {
+    ContentAccessor content = asset.getContentAccessor();
+
+    // A non-null ContentAccessor marks an RDF asset (the content is held as a pre-parsed object).
+    // RDF assets - including JSON-LD - must be validated via SHACL, not JSON Schema.
+    // Non-RDF JSON assets have no ContentAccessor; their type is identified by content-type below.
+    if (content != null) {
+      return false;
+    }
+    String ct = asset.getContentType();
+    return ct != null
+        && (ct.contains(MediaType.APPLICATION_JSON_VALUE)
+            || ct.contains(SchemaStore.MEDIA_TYPE_JSON_SCHEMA));
+  }
+
+  @Override
+  public boolean acceptsSchema(SchemaRecord record) {
+    return record.type() == SchemaType.JSON;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Requires exactly one asset and one schema. For non-RDF assets without a content accessor,
+   * asset content is loaded from the file store using the asset hash.</p>
+   *
+   * @throws ClientException if the asset count or schema count is not exactly one,
+   *     if JSON content is malformed, or if the schema contains a forbidden {@code $ref}
+   */
+  @Override
+  public ValidationReport validate(List<AssetMetadata> assets, List<ContentAccessor> schemas) {
+    if (assets.size() != 1) {
+      throw new ClientException(
+          "JSON Schema validation requires exactly one asset, but " + assets.size() + " were provided.");
+    }
+    if (schemas.size() != 1) {
+      throw new ClientException(
+          "JSON Schema validation requires exactly one schema, but " + schemas.size() + " were provided.");
+    }
+    ContentAccessor assetContent = resolveContent(assets.get(0));
+    return validateContent(assetContent, schemas.get(0));
+  }
+
+  private ContentAccessor resolveContent(AssetMetadata asset) {
+    if (asset.getContentAccessor() != null) {
+      return asset.getContentAccessor();
+    }
+    try {
+      return fileStore.readFile(asset.getAssetHash());
+    } catch (IOException e) {
+      throw new ClientException(
+          "Cannot load asset content for " + asset.getId() + ": " + e.getMessage(), e);
+    }
+  }
+
+  private ValidationReport validateContent(ContentAccessor assetContent, ContentAccessor schemaContent) {
+    try {
+      JsonNode schemaNode = objectMapper.readTree(schemaContent.getContentAsString());
+      validateNoExternalRefs(schemaNode);
+      JsonNode contentNode = objectMapper.readTree(assetContent.getContentAsStream());
+      SchemaRegistry registry = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12);
+      Schema schema = registry.getSchema(schemaNode);
+      List<Error> errors = schema.validate(contentNode);
+      return ValidationReportFactory.fromJsonErrors(errors);
+    } catch (IOException e) {
+      throw new ClientException("Invalid JSON schema or asset content: " + e.getMessage(), e);
+    } catch (SchemaException e) {
+      throw new ClientException("Schema could not be loaded: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Rejects schemas containing $ref URIs that enable SSRF — file://, http://, gopher://, ftp://.
+   * https:// is permitted as it is standard JSON Schema practice for referencing public schemas.
+   */
+  private void validateNoExternalRefs(JsonNode node) {
+    if (node.isObject()) {
+      JsonNode ref = node.get("$ref");
+      if (ref != null && ref.isTextual()) {
+        String value = ref.asText();
+        if (value.startsWith("file://") || value.startsWith("http://")
+            || value.startsWith("gopher://") || value.startsWith("ftp://")) {
+          throw new ClientException("Schema contains $ref '" + value + "' which is not permitted");
+        }
+      }
+      node.fields().forEachRemaining(entry -> validateNoExternalRefs(entry.getValue()));
+    } else if (node.isArray()) {
+      node.elements().forEachRemaining(this::validateNoExternalRefs);
+    }
+  }
+
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationExecutor.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationExecutor.java
@@ -1,0 +1,78 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import eu.xfsc.fc.core.exception.ServerException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.topbraid.shacl.validation.ValidationUtil;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executes TopBraid SHACL validation with a configurable timeout.
+ *
+ * <p>Owns an application-scoped thread pool to isolate SHACL execution from the calling
+ * thread and enforce a hard timeout via {@link Future#get(long, TimeUnit)}.</p>
+ */
+@Slf4j
+@Service
+public class ShaclValidationExecutor {
+
+  @Value("${federated-catalogue.validation.shacl.timeout-seconds:10}")
+  private int shaclTimeoutSeconds;
+
+  @Value("${federated-catalogue.validation.shacl.pool-size:4}")
+  private int shaclPoolSize;
+
+  // Application-scoped pool — avoids per-call thread creation; threads are reused across requests.
+  private ExecutorService executorService;
+
+  @PostConstruct
+  void init() {
+    executorService = Executors.newFixedThreadPool(shaclPoolSize);
+  }
+
+  @PreDestroy
+  void shutdown() throws InterruptedException {
+    executorService.shutdown();
+    if (!executorService.awaitTermination(shaclTimeoutSeconds + 5L, TimeUnit.SECONDS)) {
+      executorService.shutdownNow();
+    }
+  }
+
+  /**
+   * Validates {@code dataModel} against {@code shapesModel} using TopBraid SHACL.
+   *
+   * @param dataModel   the RDF data graph to validate
+   * @param shapesModel the SHACL shapes graph
+   * @return the {@code sh:ValidationReport} resource
+   * @throws TimeoutException if validation exceeds the configured timeout
+   * @throws ServerException  on execution failure or thread interruption
+   */
+  public Resource validate(Model dataModel, Model shapesModel) {
+    Future<Resource> future = executorService.submit(
+        () -> ValidationUtil.validateModel(dataModel, shapesModel, true));
+    try {
+      return future.get(shaclTimeoutSeconds, TimeUnit.SECONDS);
+    } catch (java.util.concurrent.TimeoutException e) {
+      future.cancel(true);
+      throw new TimeoutException(
+          "SHACL validation timed out after " + shaclTimeoutSeconds + " seconds");
+    } catch (ExecutionException e) {
+      throw new ServerException(
+          "SHACL validation failed: " + e.getCause().getMessage(), e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new ServerException("SHACL validation interrupted", e);
+    }
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationStrategy.java
@@ -1,0 +1,92 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.service.validation.report.ValidationReportFactory;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.verification.SchemaModuleType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * {@link ValidationStrategy} implementation for SHACL validation of RDF assets.
+ *
+ * <p>Supports all RDF serializations — Turtle, N-Triples, JSON-LD, RDF/XML — including
+ * Loire JWT-wrapped credentials. For multi-asset requests, all asset models are merged
+ * before validation. All shape models are also merged when multiple schemas are provided.</p>
+ *
+ * <p>Parsing is delegated to {@link RdfAssetParser}; this strategy owns only the
+ * TopBraid SHACL execution and result mapping.</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ShaclValidationStrategy implements ValidationStrategy {
+
+  private final RdfAssetParser rdfAssetParser;
+  private final ShaclValidationExecutor shaclValidationExecutor;
+
+  @Override
+  public ValidatorType type() {
+    return ValidatorType.SHACL;
+  }
+
+  @Override
+  public String moduleType() {
+    return SchemaModuleType.SHACL;
+  }
+
+  /** Returns {@code true} for any asset that has RDF content (content accessor is non-null). */
+  @Override
+  public boolean appliesTo(AssetMetadata asset) {
+    return asset.getContentAccessor() != null;
+  }
+
+  @Override
+  public boolean acceptsSchema(SchemaRecord record) {
+    return record.type() == SchemaType.SHAPE;
+  }
+
+  /**
+   * Validates one or more RDF assets against one or more SHACL shape graphs.
+   *
+   * <p>All asset models are merged into a single data graph before validation.
+   * All schema ContentAccessors are parsed and merged into a single shapes graph.</p>
+   *
+   * @param assets   RDF assets; each must have a non-null content accessor
+   * @param schemas  SHACL shape documents (Turtle); must not be empty
+   * @return validation report with conforms flag, violations, and raw Turtle report
+   */
+  @Override
+  public ValidationReport validate(List<AssetMetadata> assets, List<ContentAccessor> schemas) {
+    Model shapesModel = buildMergedShapesModel(schemas);
+    Model dataModel = buildMergedDataModel(assets);
+    return ValidationReportFactory.fromShacl(shaclValidationExecutor.validate(dataModel, shapesModel));
+  }
+
+  private Model buildMergedShapesModel(List<ContentAccessor> schemas) {
+    Model merged = ModelFactory.createDefaultModel();
+    for (ContentAccessor schema : schemas) {
+      merged.add(rdfAssetParser.parseShape(schema));
+    }
+    return merged;
+  }
+
+  private Model buildMergedDataModel(List<AssetMetadata> assets) {
+    Model merged = ModelFactory.createDefaultModel();
+    for (AssetMetadata asset : assets) {
+      merged.add(rdfAssetParser.parse(asset));
+    }
+    return merged;
+  }
+
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ValidationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/ValidationStrategy.java
@@ -1,0 +1,64 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+
+import java.util.List;
+
+/**
+ * SPI for a single-paradigm asset validator.
+ *
+ * <p>Each strategy is a Spring {@code @Service} bean. The orchestrator
+ * ({@link eu.xfsc.fc.core.service.validation.AssetValidationServiceImpl}) collects all
+ * strategies via {@code List<ValidationStrategy>} constructor injection and dispatches to
+ * applicable ones based on {@link #appliesTo} and {@link #acceptsSchema}.</p>
+ *
+ * <p>Cardinality contract:
+ * <ul>
+ *   <li>SHACL accepts N assets + N schemas (all asset models merged; all shapes merged).</li>
+ *   <li>JSON Schema and XML Schema accept exactly 1 asset + 1 schema; implementations
+ *       throw {@link eu.xfsc.fc.core.exception.ClientException} with accepted values
+ *       if called with more.</li>
+ * </ul></p>
+ *
+ * <p>The {@link ValidatorType#TRUST_FRAMEWORK} case has no strategy implementation yet;
+ * compliance evaluation is currently performed by the trust-framework orchestrator.</p>
+ */
+public interface ValidationStrategy {
+
+  /**
+   * Stable identifier persisted in {@code ValidationResult.validatorType}.
+   */
+  ValidatorType type();
+
+  /**
+   * Module gating key used to check whether this validator is enabled in admin config.
+   * Values are constants from {@link eu.xfsc.fc.core.service.verification.SchemaModuleType}.
+   */
+  String moduleType();
+
+  /**
+   * Returns {@code true} when this strategy can validate the given asset based on its
+   * content type and content shape.
+   */
+  boolean appliesTo(AssetMetadata asset);
+
+  /**
+   * Returns {@code true} when the given schema record is consumable by this strategy.
+   */
+  boolean acceptsSchema(SchemaRecord record);
+
+  /**
+   * Validates one or more assets against one or more schemas.
+   *
+   * @param assets   assets to validate; must not be empty
+   * @param schemas  pre-loaded schema content accessors; must not be empty
+   * @return validation report with conforms flag, violations, and optional raw report
+   * @throws eu.xfsc.fc.core.exception.ClientException if cardinality or content-type
+   *     constraints are violated
+   */
+  ValidationReport validate(List<AssetMetadata> assets, List<ContentAccessor> schemas);
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/XmlSchemaValidationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/strategy/XmlSchemaValidationStrategy.java
@@ -1,0 +1,157 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.ServerException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import eu.xfsc.fc.core.service.validation.report.ValidationReportFactory;
+import eu.xfsc.fc.core.service.verification.SchemaModuleType;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+/**
+ * {@link ValidationStrategy} implementation for XML Schema (XSD 1.0) validation.
+ *
+ * <p>Applies to non-RDF XML assets ({@code application/xml}, {@code text/xml}) and to
+ * RDF/XML serialized RDF assets. Enforces exactly one asset and one schema per call.</p>
+ *
+ * <p>Uses {@code javax.xml.validation}. The {@link SchemaFactory} and
+ * {@link Validator} are hardened against XXE attacks by disabling external DTD and
+ * schema access ({@link XMLConstants#ACCESS_EXTERNAL_DTD},
+ * {@link XMLConstants#ACCESS_EXTERNAL_SCHEMA}).</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class XmlSchemaValidationStrategy implements ValidationStrategy {
+
+  @Qualifier("assetFileStore")
+  private final FileStore fileStore;
+  private final ObjectProvider<DocumentBuilderFactory> secureDocumentBuilderFactoryProvider;
+  private final ObjectProvider<SchemaFactory> secureXmlSchemaFactoryProvider;
+
+  @Override
+  public ValidatorType type() {
+    return ValidatorType.XML_SCHEMA;
+  }
+
+  @Override
+  public String moduleType() {
+    return SchemaModuleType.XML_SCHEMA;
+  }
+
+  /**
+   * Returns {@code true} for non-RDF XML assets only.
+   * RDF assets (including RDF/XML) should use SHACL validation.
+   */
+  @Override
+  public boolean appliesTo(AssetMetadata asset) {
+    ContentAccessor content = asset.getContentAccessor();
+
+    // A non-null ContentAccessor marks an RDF asset (the content is held as a pre-parsed object).
+    // RDF assets - including RDF/XML - must be validated via SHACL, not XML Schema.
+    // Non-RDF XML assets have no ContentAccessor; their type is identified by content-type below.
+    if (content != null) {
+      return false;
+    }
+    String ct = asset.getContentType();
+    return ct != null
+        && (ct.contains(MediaType.APPLICATION_XML_VALUE)
+            || ct.contains(MediaType.TEXT_XML_VALUE));
+  }
+
+  @Override
+  public boolean acceptsSchema(SchemaRecord record) {
+    return record.type() == SchemaType.XML;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Requires exactly one asset and one schema. For non-RDF assets without a content accessor,
+   * asset content is loaded from the file store using the asset hash.</p>
+   *
+   * @throws ClientException if the asset count or schema count is not exactly one,
+   *     if XML content is malformed, or if the schema is invalid
+   */
+  @Override
+  public ValidationReport validate(List<AssetMetadata> assets, List<ContentAccessor> schemas) {
+    if (assets.size() != 1) {
+      throw new ClientException(
+          "XML Schema validation requires exactly one asset, but " + assets.size() + " were provided.");
+    }
+    if (schemas.size() != 1) {
+      throw new ClientException(
+          "XML Schema validation requires exactly one schema, but " + schemas.size() + " were provided.");
+    }
+    ContentAccessor assetContent = resolveContent(assets.get(0));
+    return validateContent(assetContent, schemas.get(0));
+  }
+
+  private ContentAccessor resolveContent(AssetMetadata asset) {
+    if (asset.getContentAccessor() != null) {
+      return asset.getContentAccessor();
+    }
+    try {
+      return fileStore.readFile(asset.getAssetHash());
+    } catch (IOException e) {
+      throw new ClientException(
+          "Cannot load asset content for " + asset.getId() + ": " + e.getMessage(), e);
+    }
+  }
+
+  private ValidationReport validateContent(ContentAccessor assetContent, ContentAccessor schemaContent) {
+    try {
+      Schema xsdSchema = loadXsdSchema(schemaContent);
+      // A new Validator instance per call: Validator is not thread-safe
+      Validator validator = xsdSchema.newValidator();
+      // XXE prevention on the content validator
+      validator.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      validator.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+
+      try (InputStream contentStream = assetContent.getContentAsStream()) {
+        validator.validate(new StreamSource(contentStream));
+        return ValidationReportFactory.conforming();
+      } catch (SAXException e) {
+        return ValidationReportFactory.fromSaxException(e);
+      }
+    } catch (ParserConfigurationException e) {
+      throw new ServerException("XML parser configuration error: " + e.getMessage(), e);
+    } catch (SAXException | IOException e) {
+      throw new ClientException("Invalid XML schema or asset content: " + e.getMessage(), e);
+    }
+  }
+
+  private Schema loadXsdSchema(ContentAccessor schemaContent)
+      throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory dbf = secureDocumentBuilderFactoryProvider.getObject();
+    Document schemaDoc;
+    try (InputStream schemaStream = schemaContent.getContentAsStream()) {
+      schemaDoc = dbf.newDocumentBuilder().parse(schemaStream);
+    }
+    SchemaFactory factory = secureXmlSchemaFactoryProvider.getObject();
+    return factory.newSchema(new DOMSource(schemaDoc));
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetector.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetector.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class FormatDetector {
+public class CredentialFormatDetector {
 
     private final ObjectMapper objectMapper;
     private final List<FormatMatcher> matchers;

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
@@ -157,7 +157,7 @@ public class CredentialVerificationStrategy implements VerificationStrategy {
     private final DocumentLoader documentLoader;
     private final Vc2Processor vc2Processor;
     private final JwtSignatureVerifier jwtSignatureVerifier;
-    private final FormatDetector formatDetector;
+    private final CredentialFormatDetector formatDetector;
     private final LoireJwtParser loireJwtParser;
     private final ClaimExtractionService claimExtractionService;
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/DetectionContext.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/DetectionContext.java
@@ -5,7 +5,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.springframework.lang.Nullable;
 
 /**
- * Pre-parsed credential payload, built once by {@link FormatDetector} and passed to each
+ * Pre-parsed credential payload, built once by {@link CredentialFormatDetector} and passed to each
  * {@link FormatMatcher}. Avoids reparsing the JWT or body JSON per matcher.
  *
  * <p>{@code parsedJson} holds:

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/FormatMatcher.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/FormatMatcher.java
@@ -9,7 +9,7 @@ import java.util.stream.StreamSupport;
 /**
  * Strategy interface for credential format detection.
  *
- * <p>Implementations are Spring beans collected by {@link FormatDetector}. Each matcher
+ * <p>Implementations are Spring beans collected by {@link CredentialFormatDetector}. Each matcher
  * inspects a {@link DetectionContext} and returns the format it recognises, or
  * {@link Optional#empty()} to pass to the next matcher.
  *

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceImpl.java
@@ -1,31 +1,38 @@
 package eu.xfsc.fc.core.service.verification;
 
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.apache.jena.rdf.model.ResourceFactory.createStatement;
+import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
+
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.jena.riot.system.stream.StreamManager;
-import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.jena.datatypes.RDFDatatype;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
 import org.springframework.stereotype.Component;
-
-import com.apicatalog.jsonld.loader.DocumentLoader;
-import com.apicatalog.jsonld.loader.SchemeRouter;
-import jakarta.annotation.PostConstruct;
+import org.topbraid.shacl.util.ModelPrinter;
+import org.topbraid.shacl.vocabulary.SH;
 
 import eu.xfsc.fc.core.pojo.RdfClaim;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.SchemaValidationResult;
-import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.schemastore.SchemaStore;
-import eu.xfsc.fc.core.service.verification.cache.CachingLocator;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
-import eu.xfsc.fc.core.util.ClaimValidator;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Default implementation of {@link SchemaValidationService}.
  *
- * <p>Performs SHACL validation by extracting RDF claims from a credential payload
- * and validating them against SHACL shape graphs using {@link ClaimValidator}.</p>
+ * <p>Performs SHACL validation by extracting RDF claims from a credential payload,
+ * building a Jena data model, parsing the shape via {@link RdfAssetParser}, and
+ * executing SHACL via the shared {@link ShaclValidationExecutor}.</p>
  *
  * @see SchemaValidationService
  */
@@ -36,80 +43,86 @@ public class SchemaValidationServiceImpl implements SchemaValidationService {
 
   private final ClaimExtractionService claimExtractionService;
   private final SchemaStore schemaStore;
-    @Qualifier("contextCacheFileStore")
-    private final FileStore fileStore;
-  private final DocumentLoader documentLoader;
+  private final RdfAssetParser rdfAssetParser;
+  private final ShaclValidationExecutor shaclValidationExecutor;
 
-    private StreamManager streamManager;
+  /** {@inheritDoc} Delegates to {@link #validateCredentialAgainstSchema} with a {@code null} schema. */
+  @Override
+  public SchemaValidationResult validateCredentialAgainstCompositeSchema(ContentAccessor payload) {
+    return validateCredentialAgainstSchema(payload, null);
+  }
 
-    /** {@inheritDoc} Delegates to {@link #validateCredentialAgainstSchema} with a {@code null} schema. */
-    @Override
-    public SchemaValidationResult validateCredentialAgainstCompositeSchema(ContentAccessor payload) {
-        return validateCredentialAgainstSchema(payload, null);
+  /** {@inheritDoc} */
+  @Override
+  public SchemaValidationResult validateCredentialAgainstSchema(ContentAccessor payload, ContentAccessor schema) {
+    log.debug("validateCredentialAgainstSchema.enter;");
+    SchemaValidationResult result = null;
+    try {
+      if (schema == null) {
+        schema = schemaStore.getCompositeSchema(SchemaStore.SchemaType.SHAPE);
+      }
+      List<RdfClaim> claims = extractClaims(payload);
+      result = validateClaimsAgainstSchema(claims, schema);
+    } catch (Exception exc) {
+      log.info("validateCredentialAgainstSchema.error: {}", exc.getMessage());
     }
+    boolean conforms = result != null && result.isConforming();
+    log.debug("validateCredentialAgainstSchema.exit; conforms: {}", conforms);
+    return result;
+  }
 
-    /** {@inheritDoc} */
-    @Override
-    public SchemaValidationResult validateCredentialAgainstSchema(ContentAccessor payload, ContentAccessor schema) {
-        log.debug("validateCredentialAgainstSchema.enter;");
-        SchemaValidationResult result = null;
-        try {
-            if (schema == null) {
-                schema = schemaStore.getCompositeSchema(SchemaStore.SchemaType.SHAPE);
-            }
-            List<RdfClaim> claims = extractClaims(payload);
-            result = validateClaimsAgainstSchema(claims, schema);
-        } catch (Exception exc) {
-            log.info("validateCredentialAgainstSchema.error: {}", exc.getMessage());
-        }
-        boolean conforms = result != null && result.isConforming();
-        log.debug("validateCredentialAgainstSchema.exit; conforms: {}", conforms);
-        return result;
+  /** {@inheritDoc} */
+  @Override
+  public SchemaValidationResult validateClaimsAgainstCompositeSchema(List<RdfClaim> claims) {
+    log.debug("validateClaimsAgainstCompositeSchema.enter;");
+    SchemaValidationResult result = null;
+    try {
+      ContentAccessor shaclShape = schemaStore.getCompositeSchema(SchemaStore.SchemaType.SHAPE);
+      result = validateClaimsAgainstSchema(claims, shaclShape);
+    } catch (Exception exc) {
+      log.info("validateClaimsAgainstCompositeSchema.error: {}", exc.getMessage());
     }
+    boolean conforms = result != null && result.isConforming();
+    log.debug("validateClaimsAgainstCompositeSchema.exit; conforms: {}", conforms);
+    return result;
+  }
 
-    /** {@inheritDoc} */
-    @Override
-    public SchemaValidationResult validateClaimsAgainstCompositeSchema(List<RdfClaim> claims) {
-        log.debug("validateClaimsAgainstCompositeSchema.enter;");
-        SchemaValidationResult result = null;
-        try {
-            ContentAccessor shaclShape = schemaStore.getCompositeSchema(SchemaStore.SchemaType.SHAPE);
-            result = validateClaimsAgainstSchema(claims, shaclShape);
-        } catch (Exception exc) {
-            log.info("validateClaimsAgainstCompositeSchema.error: {}", exc.getMessage());
-        }
-        boolean conforms = result != null && result.isConforming();
-        log.debug("validateClaimsAgainstCompositeSchema.exit; conforms: {}", conforms);
-        return result;
+  /** {@inheritDoc} */
+  @Override
+  public SchemaValidationResult validateClaimsAgainstSchema(List<RdfClaim> claims, ContentAccessor schema) {
+    Model shapesModel = rdfAssetParser.parseShape(schema);
+    Model dataModel = buildDataModel(claims);
+    Resource reportResource = shaclValidationExecutor.validate(dataModel, shapesModel);
+    boolean conforms = reportResource.getProperty(SH.conforms).getBoolean();
+    String rawReport = conforms ? null : ModelPrinter.get().print(reportResource.getModel());
+    return new SchemaValidationResult(conforms, rawReport);
+  }
+
+  private List<RdfClaim> extractClaims(ContentAccessor payload) {
+    return claimExtractionService.extractCredentialClaims(payload);
+  }
+
+  private Model buildDataModel(List<RdfClaim> claims) {
+    Model data = ModelFactory.createDefaultModel();
+    for (RdfClaim claim : claims) {
+      log.trace("buildDataModel; {}", claim);
+      Statement triple = claim.getTriple();
+      if (triple != null) {
+        data.add(triple);
+        continue;
+      }
+      RDFNode node;
+      String objectStr = claim.getObjectString();
+      if (objectStr != null && objectStr.startsWith("\"")) {
+        node = createTypedLiteral(claim.getObjectValue(), (RDFDatatype) null);
+      } else {
+        node = createResource(claim.getObjectValue());
+      }
+      data.add(createStatement(
+          createResource(claim.getSubjectValue()),
+          createProperty(claim.getPredicateValue()),
+          node));
     }
-
-    /** {@inheritDoc} */
-    @Override
-    public SchemaValidationResult validateClaimsAgainstSchema(List<RdfClaim> claims, ContentAccessor schema) {
-        String report = ClaimValidator.validateClaimsBySchema(claims, schema, streamManager);
-        return new SchemaValidationResult(report == null, report);
-    }
-
-    /**
-     * Initialises the JSON-LD {@link SchemeRouter} and Jena {@link StreamManager}
-     * once after dependency injection, ensuring thread-safe setup.
-     */
-    @PostConstruct
-    private void init() {
-        log.debug("init; Setting up SchemeRouter");
-        SchemeRouter loader = (SchemeRouter) SchemeRouter.defaultInstance();
-        loader.set("file", documentLoader);
-        loader.set("http", documentLoader);
-        loader.set("https", documentLoader);
-
-        log.debug("init; Setting up Jena caching Locator");
-        StreamManager clone = StreamManager.get().clone();
-        clone.clearLocators();
-        clone.addLocator(new CachingLocator(fileStore));
-        streamManager = clone;
-    }
-
-    private List<RdfClaim> extractClaims(ContentAccessor payload) {
-        return claimExtractionService.extractCredentialClaims(payload);
-    }
+    return data;
+  }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
@@ -31,6 +31,7 @@ public final class VerificationConstants {
   public static final String MEDIA_TYPE_VP_JWT = "application/vp+jwt";
   public static final String MEDIA_TYPE_VC_LD_JSON = "application/vc+ld+json";
   public static final String MEDIA_TYPE_VP_LD_JSON = "application/vp+ld+json";
+  public static final String MEDIA_TYPE_LD_JSON = "application/ld+json";
 
     // RDF format media types
     public static final String MEDIA_TYPE_TURTLE = "text/turtle";

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/JenaAllTriplesExtractor.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/claims/JenaAllTriplesExtractor.java
@@ -3,7 +3,7 @@ package eu.xfsc.fc.core.service.verification.claims;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.RdfClaim;
-import eu.xfsc.fc.core.service.verification.VerificationConstants;
+import eu.xfsc.fc.core.util.RdfFormatDetector;
 import eu.xfsc.fc.core.util.RdfNodeMapper;
 
 import java.util.ArrayList;
@@ -44,7 +44,7 @@ public class JenaAllTriplesExtractor implements ClaimExtractor {
   @Override
   public List<RdfClaim> extractClaims(ContentAccessor content) {
     String body = content.getContentAsString();
-    Lang lang = detectLang(content.getContentType());
+    Lang lang = RdfFormatDetector.detect(content.getContentType(), body);
     Model model = parseWithFallback(body, lang);
     List<RdfClaim> claims = new ArrayList<>();
     StmtIterator it = model.listStatements();
@@ -91,22 +91,6 @@ public class JenaAllTriplesExtractor implements ClaimExtractor {
     if (lang == Lang.RDFXML && body.contains("<!DOCTYPE")) {
       throw new RiotException("RDF/XML input must not contain DOCTYPE declarations");
     }
-  }
-
-  /**
-   * Maps a MIME content type to a Jena {@link Lang}.
-   * Falls back to {@link Lang#JSONLD} for absent or unrecognized content types.
-   */
-  static Lang detectLang(String contentType) {
-    if (contentType == null) {
-      return Lang.JSONLD;
-    }
-    return switch (contentType.strip().toLowerCase()) {
-      case VerificationConstants.MEDIA_TYPE_TURTLE -> Lang.TURTLE;
-      case VerificationConstants.MEDIA_TYPE_NTRIPLES -> Lang.NTRIPLES;
-      case VerificationConstants.MEDIA_TYPE_RDF_XML -> Lang.RDFXML;
-      default -> Lang.JSONLD;
-    };
   }
 
   private RdfClaim toRdfClaim(Statement stmt) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
@@ -1,10 +1,5 @@
 package eu.xfsc.fc.core.util;
 
-import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
-import static org.apache.jena.rdf.model.ResourceFactory.createStatement;
-import static org.apache.jena.rdf.model.ResourceFactory.createTypedLiteral;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -19,7 +14,6 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.jena.datatypes.DatatypeFormatException;
-import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.ontology.OntModel;
@@ -33,18 +27,13 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.RiotException;
 import org.apache.jena.riot.system.stream.StreamManager;
+import org.apache.jena.shared.impl.JenaParameters;
 import org.apache.jena.vocabulary.RDF;
-import org.topbraid.shacl.util.ModelPrinter;
-import org.topbraid.shacl.validation.ValidationUtil;
-import org.topbraid.shacl.vocabulary.SH;
-
 
 import eu.xfsc.fc.core.exception.QueryException;
 import eu.xfsc.fc.core.pojo.RdfClaim;
@@ -64,19 +53,19 @@ public class ClaimValidator {
         // save the actual settings to not interfere with other modules which
         // rely on other settings
         eagerJenaLiteralValidation =
-                org.apache.jena.shared.impl.JenaParameters.enableEagerLiteralValidation;
+                JenaParameters.enableEagerLiteralValidation;
         jenaAcceptanceOfUnknownLiteralDatatypes =
-                org.apache.jena.shared.impl.JenaParameters.enableSilentAcceptanceOfUnknownDatatypes;
+                JenaParameters.enableSilentAcceptanceOfUnknownDatatypes;
 
         // Now switch to picky mode
-        org.apache.jena.shared.impl.JenaParameters.enableEagerLiteralValidation = true;
-        org.apache.jena.shared.impl.JenaParameters.enableSilentAcceptanceOfUnknownDatatypes = false;
+        JenaParameters.enableEagerLiteralValidation = true;
+        JenaParameters.enableSilentAcceptanceOfUnknownDatatypes = false;
     }
 
     private void resetJenaLiteralValidation() {
-        org.apache.jena.shared.impl.JenaParameters.enableEagerLiteralValidation =
+        JenaParameters.enableEagerLiteralValidation =
                 eagerJenaLiteralValidation;
-        org.apache.jena.shared.impl.JenaParameters.enableSilentAcceptanceOfUnknownDatatypes =
+        JenaParameters.enableSilentAcceptanceOfUnknownDatatypes =
                 jenaAcceptanceOfUnknownLiteralDatatypes;
     }
 
@@ -178,53 +167,6 @@ public class ClaimValidator {
         return Pair.of(added, props);
     }
     
-    
-    /**
-     * Method that validates a dataGraph against shaclShape
-     * @param claims the claims to be validated
-     * @param schema the shacl shape to be used for validation
-     * @param sm StreamManager to be used for parsing the schema
-     * @return SchemaValidationResult object
-     */
-    public static String validateClaimsBySchema(List<RdfClaim> claims, ContentAccessor schema, StreamManager sm) {
-      Model data = ModelFactory.createDefaultModel();
-      Model shape = ModelFactory.createDefaultModel();
-      RDFParser.create()
-              .streamManager(sm)
-              .source(schema.getContentAsStream())
-              .lang(Lang.TURTLE)
-              .parse(shape);
-
-      for (RdfClaim claim: claims) {
-        log.trace("validateClaimsBySchema; {}", claim);
-        Statement triple = claim.getTriple();
-        if (triple != null) {
-          // Statement-based claim: add directly to preserve blank node identity and datatypes
-          data.add(triple);
-          continue;
-        }
-        // String-based claim fallback: derive type from formatted object string
-        RDFNode node;
-        String objectStr = claim.getObjectString();
-        if (objectStr != null && objectStr.startsWith("\"")) {
-          node = createTypedLiteral(claim.getObjectValue(), (RDFDatatype) null);
-        } else {
-          node = createResource(claim.getObjectValue());
-        }
-        Statement s = createStatement(createResource(claim.getSubjectValue()), createProperty(claim.getPredicateValue()), node);
-        data.add(s);
-      }
-      
-      Resource reportResource = ValidationUtil.validateModel(data, shape, true);
-      log.debug("validateClaimsBySchema; got result: {}", reportResource);
-      data.close();
-      shape.close();
-
-      if (reportResource.getProperty(SH.conforms).getBoolean()) {
-    	  return null;
-      }
-      return ModelPrinter.get().print(reportResource.getModel());
-    }   
     
     private static final String CREDENTIAL_SUBJECT = CredentialConstants.CREDENTIAL_SUBJECT_URI;
     

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/FormatDetectionConstants.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/FormatDetectionConstants.java
@@ -1,0 +1,21 @@
+package eu.xfsc.fc.core.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Shared string prefixes used by content-based format detection heuristics.
+ *
+ * <p>For JWT detection use {@code VerificationConstants.JWT_PREFIX} directly — JWT is a
+ * credential-envelope concern, not an RDF format heuristic, and lives in the verification
+ * package as the single source of truth.</p>
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FormatDetectionConstants {
+
+  public static final String JSON_LD_PREFIX = "{";
+  public static final String RDF_XML_PREFIX_1 = "<?xml";
+  public static final String RDF_XML_PREFIX_2 = "<rdf:RDF";
+  public static final String TURTLE_PREFIX_1 = "@prefix";
+  public static final String TURTLE_PREFIX_2 = "@base";
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -27,7 +27,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 /**
- * A set of tools to rebuild the graph db.
+ * A set of tools to rebuild the graph store.
  */
 @Slf4j
 @AllArgsConstructor
@@ -118,7 +118,7 @@ public class GraphRebuilder {
 
     ProcessorUtils.shutdownProcessors(executorService, taskQueue, 10, TimeUnit.MINUTES);
 
-    // Separate pass: restore link triples from PostgreSQL.
+    // Separate pass: restore link triples from persisted asset metadata records.
     // This must NOT be merged into addAssetToGraph() because non-RDF (human-readable) assets
     // have contentAccessor = null; calling extractClaims(null) would throw a NullPointerException.
     rebuildLinkTriples();
@@ -131,7 +131,7 @@ public class GraphRebuilder {
 
   /**
    * Restores {@code fcmeta:hasHumanReadable} and {@code fcmeta:hasMachineReadable} triples
-   * from the {@code assets} PostgreSQL table.
+   * from stored asset metadata records.
    *
    * <p>Only machine-readable assets with a linked asset are fetched. One row is sufficient to
    * reconstruct both directions because {@link #writeLinkTriples} writes both triples.</p>
@@ -183,7 +183,7 @@ public class GraphRebuilder {
     }
 
   /**
-   * Rebuilds validation result triples in the graph DB from PostgreSQL records.
+   * Rebuilds validation result triples in the graph store from stored validation result records.
    *
    * <p>Iterates through all {@link ValidationResult} entities and re-projects their
    * {@code fcmeta:} triples to the graph store. Updates {@code graph_sync_status} to

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/RdfFormatDetector.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/RdfFormatDetector.java
@@ -1,0 +1,67 @@
+package eu.xfsc.fc.core.util;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.service.verification.VerificationConstants;
+import lombok.experimental.UtilityClass;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFLanguages;
+import org.springframework.http.MediaType;
+
+/**
+ * Detects the RDF serialization format from an HTTP Content-Type header and/or content inspection.
+ *
+ * <p>Content-type is checked first using Jena's built-in media-type mapper.
+ * If the content type is absent or unrecognised, the raw content string is inspected by prefix.
+ * Throws {@link eu.xfsc.fc.core.exception.ClientException} when neither check produces a match.</p>
+ *
+ * <p>Also exposes content prefix constants shared with {@link eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser}.</p>
+ */
+@UtilityClass
+public class RdfFormatDetector {
+
+  /**
+   * Detects the RDF format from content-type and optional content inspection.
+   *
+   * @param contentType HTTP Content-Type value, or {@code null}
+   * @param rawContent  raw content string for fallback inspection; {@code null} skips inspection
+   * @return the detected {@link Lang}
+   * @throws ClientException if the format cannot be determined from either the content-type or the content
+   */
+  public static Lang detect(String contentType, String rawContent) {
+    if (contentType != null) {
+      Lang mappedLang = RDFLanguages.contentTypeToLang(contentType);
+      if (mappedLang != null) {
+        // Keep detector output stable across Jena mappings for ld+json.
+        return mappedLang == Lang.JSONLD ? Lang.JSONLD11 : mappedLang;
+      }
+      // VC/VP-specific JSON-LD media types are not registered with Jena's mapper.
+      if (contentType.contains(VerificationConstants.MEDIA_TYPE_VC_LD_JSON)
+          || contentType.contains(VerificationConstants.MEDIA_TYPE_VP_LD_JSON)
+          || contentType.contains(VerificationConstants.MEDIA_TYPE_LD_JSON)
+          || contentType.contains(MediaType.APPLICATION_JSON_VALUE)) {
+        return Lang.JSONLD11;
+      }
+    }
+    if (rawContent != null) {
+      if (rawContent.startsWith(FormatDetectionConstants.JSON_LD_PREFIX)) {
+        return Lang.JSONLD11;
+      }
+      if (rawContent.startsWith(FormatDetectionConstants.TURTLE_PREFIX_1)
+          || rawContent.startsWith(FormatDetectionConstants.TURTLE_PREFIX_2)) {
+        return Lang.TURTLE;
+      }
+      if (rawContent.startsWith(FormatDetectionConstants.RDF_XML_PREFIX_1)
+          || rawContent.startsWith(FormatDetectionConstants.RDF_XML_PREFIX_2)) {
+        return Lang.RDFXML;
+      }
+      // N-Triples have no keyword prefix. IRI subjects start with '<' (RDF/XML is already matched above),
+      // blank-node subjects start with '_:', and comment lines start with '#'.
+      if (rawContent.startsWith("<") || rawContent.startsWith("_:") || rawContent.startsWith("#")) {
+        return Lang.NT;
+      }
+    }
+    throw new ClientException(
+        "Cannot determine RDF format: unrecognised content-type '" + contentType
+        + "' and content does not match any known RDF serialization");
+  }
+}

--- a/fc-service-core/src/main/resources/liquibase/changesets/013-validation-result.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/013-validation-result.xml
@@ -24,7 +24,7 @@
       <column name="validated_at" type="TIMESTAMP WITH TIME ZONE">
         <constraints nullable="false"/>
       </column>
-      <column name="report" type="JSONB"/>
+      <column name="report" type="TEXT"/>
       <column name="content_hash" type="VARCHAR(64)">
         <constraints nullable="false"/>
       </column>
@@ -41,6 +41,7 @@
          enabling efficient = ANY(asset_ids) queries on TEXT[] array columns -->
     <sql>CREATE INDEX idx_validation_result_asset_ids
          ON validation_result USING GIN (asset_ids);</sql>
+    <rollback>DROP INDEX IF EXISTS idx_validation_result_asset_ids;</rollback>
 
   </changeSet>
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/assets/AssetDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/assets/AssetDaoTest.java
@@ -65,7 +65,6 @@ class AssetDaoTest {
     assetDao.deleteAll();
   }
 
-  // --- Helper ---
 
   private static AssetRecord buildRecord(String hash, String subjectId, String issuer,
       Instant uploadTime, Instant statusTime, Instant expirationTime,

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/cestracker/CesTrackerDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/cestracker/CesTrackerDaoTest.java
@@ -46,7 +46,6 @@ class CesTrackerDaoTest {
     jdbcTemplate.update("DELETE FROM ces_tracker");
   }
 
-  // --- Helper ---
 
   private static CesTracking buildTracking(String cesId, String event, Instant createdAt,
       int credProcessed, String credId, String error) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunksDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/revalidator/RevalidatorChunksDaoTest.java
@@ -56,7 +56,6 @@ class RevalidatorChunksDaoTest {
     schemaFileRepository.deleteAll();
   }
 
-  // --- Helpers ---
 
   private void insertChunk(int chunkId, Instant lastcheck) {
     jdbc.update("INSERT INTO revalidatorchunks(chunkid, lastcheck) VALUES (?, ?)", chunkId, java.sql.Timestamp.from(lastcheck));

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaDaoTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/schemas/SchemaDaoTest.java
@@ -61,7 +61,6 @@ class SchemaDaoTest {
     schemaDao.deleteAll();
   }
 
-  // --- Helper ---
 
   private static SchemaRecord buildRecord(String schemaId, String nameHash, SchemaType type,
       Instant uploadTime, Instant updateTime, String content, Set<String> terms) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepositoryTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/dao/validation/ValidationResultRepositoryTest.java
@@ -10,6 +10,7 @@ import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -22,6 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.annotation.Transactional;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest
@@ -42,21 +44,6 @@ class ValidationResultRepositoryTest {
   @AfterEach
   void cleanUp() {
     repository.deleteAll();
-  }
-
-  // --- helper ---
-
-  private ValidationResult buildResult(String[] assetIds, String[] schemaIds,
-      boolean conforms, GraphSyncStatus syncStatus) {
-    ValidationResult r = new ValidationResult();
-    r.setAssetIds(assetIds);
-    r.setValidatorIds(schemaIds);
-    r.setValidatorType(ValidatorType.SCHEMA);
-    r.setConforms(conforms);
-    r.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
-    r.setContentHash("aabbccdd".repeat(8));
-    r.setGraphSyncStatus(syncStatus);
-    return r;
   }
 
   // ===== findByAssetId =====
@@ -113,6 +100,70 @@ class ValidationResultRepositoryTest {
         new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
 
     assertNotNull(saved.getCreatedAt(), "createdAt must be set by @CreatedDate");
+  }
+
+  // ===== findAllByAssetId =====
+
+  @Test
+  void findAllByAssetId_matchingEntry_returnsAllResults() {
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/1"},
+        new String[]{"https://example.org/schema/1"},
+        true, GraphSyncStatus.SYNCED));
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/1"},
+        new String[]{"https://example.org/schema/2"},
+        false, GraphSyncStatus.FAILED));
+
+    List<ValidationResult> results = repository.findAllByAssetId("https://example.org/asset/1");
+
+    assertEquals(2, results.size());
+  }
+
+  @Test
+  void findAllByAssetId_noMatch_returnsEmpty() {
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/OTHER"},
+        new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+
+    List<ValidationResult> results = repository.findAllByAssetId("https://example.org/asset/NONE");
+
+    assertTrue(results.isEmpty());
+  }
+
+  // ===== deleteAllByAssetId =====
+
+  @Test
+  @Transactional
+  void deleteAllByAssetId_matchingRows_removesOnlyTargetAsset() {
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/1"},
+        new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/1"},
+        new String[]{"ref/2"}, false, GraphSyncStatus.SYNCED));
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/2"},
+        new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+
+    repository.deleteAllByAssetId("https://example.org/asset/1");
+
+    assertEquals(0, repository.findAllByAssetId("https://example.org/asset/1").size(),
+        "All rows for asset/1 must be removed");
+    assertEquals(1, repository.findAllByAssetId("https://example.org/asset/2").size(),
+        "Row for asset/2 must remain");
+  }
+
+  @Test
+  @Transactional
+  void deleteAllByAssetId_noMatch_performsNoop() {
+    repository.save(buildResult(
+        new String[]{"https://example.org/asset/OTHER"},
+        new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
+
+    repository.deleteAllByAssetId("https://example.org/asset/NONE");
+
+    assertEquals(1, repository.count(), "Unrelated row must remain");
   }
 
   // ===== findAll (used by GraphRebuilder) =====
@@ -198,7 +249,7 @@ class ValidationResultRepositoryTest {
     repository.save(buildResult(new String[]{assetId}, new String[]{"ref/1"}, true, GraphSyncStatus.SYNCED));
     repository.save(buildResult(new String[]{assetId}, new String[]{"ref/2"}, false, GraphSyncStatus.FAILED));
 
-    repository.deleteByAssetId(assetId);
+    repository.deleteAllByAssetId(assetId);
 
     Page<ValidationResult> page = repository.findByAssetId(assetId, PageRequest.of(0, 10));
     assertEquals(0, page.getTotalElements(), "All results for the asset must be deleted");
@@ -207,7 +258,7 @@ class ValidationResultRepositoryTest {
   @Test
   @Transactional
   void deleteByAssetId_noMatchingResults_noError() {
-    assertDoesNotThrow(() -> repository.deleteByAssetId("https://example.org/asset/none"));
+    assertDoesNotThrow(() -> repository.deleteAllByAssetId("https://example.org/asset/none"));
   }
 
   @Test
@@ -229,5 +280,19 @@ class ValidationResultRepositoryTest {
         .filter(r -> r.getGraphSyncStatus() == GraphSyncStatus.FAILED)
         .count();
     assertEquals(1, failedCount, "Should include FAILED results for rebuild processing");
+  }
+
+
+  private ValidationResult buildResult(String[] assetIds, String[] schemaIds,
+      boolean conforms, GraphSyncStatus syncStatus) {
+    ValidationResult r = new ValidationResult();
+    r.setAssetIds(assetIds);
+    r.setValidatorIds(schemaIds);
+    r.setValidatorType(ValidatorType.SHACL);
+    r.setConforms(conforms);
+    r.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
+    r.setContentHash("aabbccdd".repeat(8));
+    r.setGraphSyncStatus(syncStatus);
+    return r;
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCascadeDeleteTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCascadeDeleteTest.java
@@ -12,13 +12,12 @@ import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.AssetType;
 import eu.xfsc.fc.core.pojo.ContentAccessorBinary;
-import eu.xfsc.fc.core.dao.validation.OutdatedReason;
-import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.service.graphdb.DummyGraphStore;
 import eu.xfsc.fc.core.service.provenance.ProvenanceService;
-import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.util.HashUtils;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 import org.junit.jupiter.api.AfterEach;
@@ -32,14 +31,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
 
 /**
  * Integration tests for cascade-delete behaviour in {@link AssetStoreImpl}.
@@ -67,9 +61,6 @@ class AssetStoreCascadeDeleteTest {
 
   @MockitoBean
   private ProvenanceService provenanceService;
-
-  @MockitoBean
-  private ValidationResultStore validationResultStore;
 
   @Autowired
   private AssetStore assetStore;
@@ -127,45 +118,6 @@ class AssetStoreCascadeDeleteTest {
     assetStore.deleteAsset(meta.getAssetHash());
 
     assertThrows(NotFoundException.class, () -> assetStore.getByHash(meta.getAssetHash()));
-  }
-
-  @Test
-  void deleteAsset_callsValidationResultDeleteForSingleAsset() {
-    final var meta = storeNonRdfAsset(null, "validate-cleanup-single");
-
-    assetStore.deleteAsset(meta.getAssetHash());
-
-    verify(validationResultStore).deleteByAssetId(meta.getId());
-  }
-
-  @Test
-  void storeCredential_existingAssetId_marksValidationResultsOutdated() {
-    storeNonRdfAsset(MR_ID, "update-test-v1");
-
-    final byte[] contentV2 = "update-test-v2".getBytes(StandardCharsets.UTF_8);
-    final Instant now = Instant.now();
-    final AssetMetadata meta = new AssetMetadata(
-        HashUtils.calculateSha256AsHex(contentV2), MR_ID, AssetStatus.ACTIVE,
-        TEST_ISSUER, null, now, now, new ContentAccessorBinary(contentV2));
-    meta.setContentType("application/ld+json");
-    meta.setFileSize((long) contentV2.length);
-
-    assetStore.storeCredential(meta, new CredentialVerificationResult(
-        now, "active", TEST_ISSUER, now, MR_ID, List.of(), null));
-
-    verify(validationResultStore).markOutdatedByAssetId(MR_ID, OutdatedReason.ASSET_UPDATED);
-  }
-
-  @Test
-  void deleteAsset_cascadeDelete_callsValidationResultDeleteForBothAssets() {
-    final var mrMeta = storeNonRdfAsset(MR_ID, "mr for validation verify");
-    final var hrMeta = storeNonRdfAsset(null, "hr for validation verify");
-    linkAssets(mrMeta.getId(), hrMeta.getId());
-
-    assetStore.deleteAsset(mrMeta.getAssetHash());
-
-    verify(validationResultStore).deleteByAssetId(mrMeta.getId());
-    verify(validationResultStore).deleteByAssetId(hrMeta.getId());
   }
 
   private void linkAssets(String mrId, String hrId) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/pubsub/CesCompositePublisherTest.java
@@ -37,9 +37,11 @@ import eu.xfsc.fc.core.service.verification.CredentialVerificationStrategy;
 import eu.xfsc.fc.core.service.verification.DanubeTechFormatMatcher;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
 import eu.xfsc.fc.core.service.verification.claims.JenaAllTriplesExtractor;
-import eu.xfsc.fc.core.service.verification.FormatDetector;
+import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
 import eu.xfsc.fc.core.service.verification.LoireMatcher;
 import eu.xfsc.fc.core.service.verification.JwtContentPreprocessor;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.verification.LoireJwtParser;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
 import eu.xfsc.fc.core.service.verification.SchemaModuleConfigService;
@@ -96,7 +98,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
         DocumentLoaderProperties.class,
         DocumentLoaderConfig.class,
         DummyGraphStore.class, SchemaAuditRepository.class, FileStoreConfig.class,
-        FormatDetector.class,
+        CredentialFormatDetector.class,
         HttpDocumentResolver.class,
         IriGenerator.class,
         IriValidator.class,
@@ -113,6 +115,8 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
         SchemaJpaDao.class,
         SchemaModuleConfigService.class,
         SchemaStoreImpl.class,
+        RdfAssetParser.class,
+        ShaclValidationExecutor.class,
         SchemaValidationServiceImpl.class,
         ValidatorCacheJpaDao.class,
         Vc2Processor.class,

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/schemastore/SchemaStoreTest.java
@@ -55,6 +55,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import eu.xfsc.fc.core.config.DatabaseConfig;
+import eu.xfsc.fc.core.config.XmlSecurityConfig;
 import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.config.FileStoreConfig;
 import eu.xfsc.fc.core.config.ProtectedNamespaceProperties;
@@ -78,7 +79,8 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SchemaStoreTest.TestApplication.class, FileStoreConfig.class,
   SchemaStoreTest.class, SchemaStoreImpl.class, DatabaseConfig.class, SchemaJpaDao.class, SchemaAuditRepository.class,
-  ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class})
+  ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class,
+  XmlSecurityConfig.class})
 @Transactional
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 public class SchemaStoreTest {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/AssetValidationServiceImplTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/AssetValidationServiceImplTest.java
@@ -1,0 +1,1228 @@
+package eu.xfsc.fc.core.service.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.api.generated.model.ValidationRequest;
+import eu.xfsc.fc.api.generated.model.ValidationResponse;
+import eu.xfsc.fc.api.generated.model.ValidationViolation;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.exception.VerificationException;
+import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaRecord;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore;
+import eu.xfsc.fc.core.service.schemastore.SchemaStore.SchemaType;
+import eu.xfsc.fc.core.service.validation.strategy.ValidationStrategy;
+import eu.xfsc.fc.core.service.verification.SchemaModuleConfigService;
+import eu.xfsc.fc.core.service.verification.SchemaModuleType;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.SchemaFactory;
+import eu.xfsc.fc.core.service.validation.strategy.JsonSchemaValidationStrategy;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationStrategy;
+import eu.xfsc.fc.core.service.validation.strategy.XmlSchemaValidationStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+class AssetValidationServiceImplTest {
+
+  @Mock
+  private AssetStore assetStore;
+  @Mock
+  private SchemaStore schemaStore;
+  @Mock
+  private SchemaModuleConfigService moduleConfigService;
+  @Mock
+  private ShaclValidationStrategy shaclValidationStrategy;
+  @Mock
+  private JsonSchemaValidationStrategy jsonSchemaValidationStrategy;
+  @Mock
+  private XmlSchemaValidationStrategy xmlSchemaValidationStrategy;
+  @Mock
+  private ValidationResultStore validationResultStore;
+  @Mock
+  private List<ValidationStrategy> strategies;
+
+  @InjectMocks
+  private AssetValidationServiceImpl service;
+
+
+  @BeforeEach
+  void setUpStrategies() {
+    ReflectionTestUtils.setField(service, "maxAssetsPerRequest", 20);
+  }
+
+  @SuppressWarnings("unchecked") // Mockito can only mock raw Class literals; cast is safe for test providers.
+  private static <T> ObjectProvider<T> createProviderMock() {
+    return (ObjectProvider<T>) mock(ObjectProvider.class);
+  }
+
+
+  private static final String ASSET_ID = "https://example.org/asset/1";
+  private static final String ASSET_ID_2 = "https://example.org/asset/2";
+  private static final String SCHEMA_ID = "https://example.org/schema/shape/1";
+  private static final String JSON_SCHEMA_ID = "https://example.org/schema/json/1";
+  private static final String XML_SCHEMA_ID = "https://example.org/schema/xml/1";
+  private static final String ISSUER_DID = "did:web:example.org";
+  private static final String RDF_HASH = "hash-rdf";
+  private static final String RDFXML_HASH = "hash-rdfxml";
+  private static final String TURTLE_HASH = "hash-turtle";
+  private static final String NONRDF_HASH = "hash-nonrdf";
+
+  private static final ValidationReport CONFORMING_REPORT = new ValidationReport()
+      .conforms(true).violations(List.of());
+
+  private static final ValidationReport NON_CONFORMING_REPORT = new ValidationReport()
+      .conforms(false)
+      .violations(List.of(new ValidationViolation()
+          .message("constraint violation")
+          .severity(ValidationViolation.SeverityEnum.VIOLATION)))
+      .rawReport("constraint violation");
+
+  // === validateAsset — RDF (SHACL) path ===
+
+  @Test
+  void validateAsset_rdfAsset_explicitShapeSchema_returnsConformingResponse() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(1L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertEquals(List.of(ASSET_ID), response.getAssetIds());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(1L), response.getValidationResultIds());
+    assertNull(response.getReport());
+  }
+
+  @Test
+  void validateAsset_rdfAsset_nonConforming_reportIncludedInResponse() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("shape content");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(NON_CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(2L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertFalse(response.getConforms());
+    assertNotNull(response.getReport());
+    assertEquals(1, response.getReport().getViolations().size());
+    assertEquals("constraint violation", response.getReport().getViolations().get(0).getMessage());
+  }
+
+  @Test
+  void validateAsset_rdfAsset_validateAll_usesCompositeSchema() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor composite = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(3L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+  }
+
+  @Test
+  void validateAsset_rdfAsset_shaclModuleDisabled_throwsVerificationException() {
+    registerStrategyList();
+    registerShaclStrategy();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.SHACL)).thenReturn(false);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonLdRdfAsset_withExplicitJsonSchema_jsonModuleDisabled_throwsClientException() {
+    registerStrategyList();
+    registerJsonStrategy();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.JSON_SCHEMA)).thenReturn(false);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    // RDF assets (JSON-LD) are not applicable to JSON Schema validation - throws ClientException before module check
+    ClientException ex = assertThrows(ClientException.class, () -> service.validateAssets(request));
+    assertTrue(ex.getMessage().contains("not applicable"), "Exception should explain why: " + ex.getMessage());
+  }
+
+  @Test
+  void validateAsset_rdfXmlAsset_withExplicitXmlSchema_xmlModuleDisabled_throwsClientException() {
+    registerStrategyList();
+    registerXmlStrategy();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfXmlAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.XML_SCHEMA)).thenReturn(false);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    // RDF assets (RDF/XML) are not applicable to XML Schema validation - throws ClientException before module check
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_rdfAsset_noSchemasNoValidateAll_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+
+    assertThrows(NotFoundException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_rdfAsset_schemaTypeNotShape_throwsClientException() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    // Schema exists but is ONTOLOGY type — not supported for on-demand validation
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(
+        new SchemaRecord(SCHEMA_ID, SCHEMA_ID, SchemaType.ONTOLOGY, "ontology content", null));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_rdfAsset_validateAll_shaclEnabledNoShapesAndNoOtherModule_throwsVerificationException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(null);
+    // JSON_SCHEMA not enabled (default false) — nothing runs
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  // === validateAsset — RDF validateAll C-2: skip disabled modules ===
+
+  @Test
+  void validateAsset_rdfAsset_validateAll_allModulesDisabled_throwsVerificationException() {
+    registerStrategyList();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    // no module mocked → all return false
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  // === Positive tests for RDF serializations + SHACL ===
+
+  @Test
+  void validateAsset_rdfXmlAsset_withShapeSchema_returnsConformingResponse() {
+    AssetMetadata asset = buildRdfXmlAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(50L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertEquals(List.of(ASSET_ID), response.getAssetIds());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(50L), response.getValidationResultIds());
+    assertNull(response.getReport());
+  }
+
+  @Test
+  void validateAsset_rdfXmlAsset_validateAll_runsShaclOnly() {
+    AssetMetadata asset = buildRdfXmlAsset(ASSET_ID);
+    ContentAccessor composite = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(51L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(51L), response.getValidationResultIds());
+  }
+
+  @Test
+  void validateAsset_jsonLdRdfAsset_withShapeSchema_returnsConformingResponse() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(52L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertEquals(List.of(ASSET_ID), response.getAssetIds());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(52L), response.getValidationResultIds());
+    assertNull(response.getReport());
+  }
+
+  @Test
+  void validateAsset_jsonLdRdfAsset_validateAll_runsShaclOnly() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor composite = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(53L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(53L), response.getValidationResultIds());
+  }
+
+  // === Negative tests for RDF serializations + non-SHACL schemas ===
+
+  @Test
+  void validateAsset_rdfXmlAsset_withJsonSchema_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfXmlAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonLdRdfAsset_withXmlSchema_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonLdRdfAsset_multipleExplicitJsonSchemas_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(schemaStore.getSchemaRecord("https://example.org/schema/json/2"))
+        .thenReturn(buildJsonRecord("https://example.org/schema/json/2"));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID, "https://example.org/schema/json/2"));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_rdfXmlAsset_multipleExplicitXmlSchemas_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfXmlAsset(ASSET_ID));
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(schemaStore.getSchemaRecord("https://example.org/schema/xml/2"))
+        .thenReturn(buildXmlRecord("https://example.org/schema/xml/2"));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID, "https://example.org/schema/xml/2"));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_turtleRdfAsset_validateAll_runsShaclOnly() {
+    AssetMetadata asset = buildTurtleRdfAsset(ASSET_ID);
+    ContentAccessor composite = new ContentAccessorDirect("shape composite");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(34L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(34L), response.getValidationResultIds());
+    verify(validationResultStore, times(1)).store(any());
+  }
+
+  // === validateAsset — non-RDF JSON path ===
+
+  @Test
+  void validateAsset_jsonAsset_explicitJsonSchema_returnsConformingResponse() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/json");
+    ContentAccessor schemaContent = new ContentAccessorDirect("{\"$schema\":\"...\"}");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenJsonModuleEnabled();
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(schemaStore.getSchema(JSON_SCHEMA_ID)).thenReturn(schemaContent);
+    when(jsonSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(4L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(ASSET_ID), response.getAssetIds());
+    assertEquals(List.of(JSON_SCHEMA_ID), response.getSchemaIds());
+  }
+
+  @Test
+  void validateAsset_jsonAsset_jsonModuleDisabled_throwsVerificationException() {
+    registerStrategyList();
+    registerJsonStrategy();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/json"));
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.JSON_SCHEMA)).thenReturn(false);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonAsset_schemaTypeNotJson_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/json"));
+    givenJsonModuleEnabled();
+    // Caller provided a SHAPE schema for a JSON asset — must be rejected
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonAsset_multipleExplicitSchemas_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/json"));
+    givenJsonModuleEnabled();
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(schemaStore.getSchemaRecord("https://example.org/schema/json/2"))
+        .thenReturn(buildJsonRecord("https://example.org/schema/json/2"));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID, "https://example.org/schema/json/2"));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_jsonAsset_validateAll_usesLatestSchema() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/json");
+    ContentAccessor schemaContent = new ContentAccessorDirect("{\"$schema\":\"...\"}");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenJsonModuleEnabled();
+    when(schemaStore.getLatestSchemaByType(SchemaType.JSON)).thenReturn(schemaContent);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.JSON, List.of(JSON_SCHEMA_ID)));
+    when(jsonSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(5L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(JSON_SCHEMA_ID), response.getSchemaIds());
+  }
+
+  @Test
+  void validateAsset_jsonAsset_noSchemasNoValidateAll_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/json"));
+    givenJsonModuleEnabled();
+
+    assertThrows(NotFoundException.class,
+        () -> service.validateAssets(new ValidationRequest().assetIds(List.of(ASSET_ID))));
+  }
+
+  @Test
+  void validateAsset_jsonAsset_validateAll_noSchemaFound_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/json"));
+    givenJsonModuleEnabled();
+    when(schemaStore.getLatestSchemaByType(SchemaType.JSON)).thenReturn(null);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    assertThrows(NotFoundException.class, () -> service.validateAssets(request));
+  }
+
+  // === validateAsset — non-RDF XML path ===
+
+  @Test
+  void validateAsset_xmlAsset_explicitXmlSchema_returnsConformingResponse() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/xml");
+    ContentAccessor schemaContent = new ContentAccessorDirect("<xs:schema/>");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenXmlModuleEnabled();
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(schemaStore.getSchema(XML_SCHEMA_ID)).thenReturn(schemaContent);
+    when(xmlSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(6L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(ASSET_ID), response.getAssetIds());
+    assertEquals(List.of(XML_SCHEMA_ID), response.getSchemaIds());
+  }
+
+  @Test
+  void validateAsset_xmlAsset_xmlModuleDisabled_throwsVerificationException() {
+    registerStrategyList();
+    registerXmlStrategy();
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/xml"));
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.XML_SCHEMA)).thenReturn(false);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_xmlAsset_schemaTypeNotXml_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/xml"));
+    givenXmlModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_xmlAsset_multipleExplicitSchemas_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/xml"));
+    givenXmlModuleEnabled();
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(schemaStore.getSchemaRecord("https://example.org/schema/xml/2"))
+        .thenReturn(buildXmlRecord("https://example.org/schema/xml/2"));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID, "https://example.org/schema/xml/2"));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_xmlAsset_noSchemasNoValidateAll_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/xml"));
+    givenXmlModuleEnabled();
+
+    assertThrows(NotFoundException.class,
+        () -> service.validateAssets(new ValidationRequest().assetIds(List.of(ASSET_ID))));
+  }
+
+  @Test
+  void validateAsset_xmlAsset_validateAll_noSchemaFound_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/xml"));
+    givenXmlModuleEnabled();
+    when(schemaStore.getLatestSchemaByType(SchemaType.XML)).thenReturn(null);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setValidateAgainstAllSchemas(true);
+
+    assertThrows(NotFoundException.class, () -> service.validateAssets(request));
+  }
+
+  // === validateAsset — unsupported asset type path ===
+
+  @Test
+  void validateAsset_unsupportedContentType_throwsVerificationException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildNonRdfAssetWithContentType(ASSET_ID, "application/pdf"));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAsset_nonRdfAsset_nullContentType_throwsVerificationException() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, null);
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  // === validateAssets — multi-asset SHACL ===
+
+  @Test
+  void validateAssets_multipleRdfAssets_mergedValidation_returnsConformingResponse() {
+    ContentAccessor shapeContent = new ContentAccessorDirect("shape ttl");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(7L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(ASSET_ID, ASSET_ID_2), response.getAssetIds());
+    assertEquals(List.of(SCHEMA_ID), response.getSchemaIds());
+    assertEquals(List.of(7L), response.getValidationResultIds());
+
+    @SuppressWarnings("unchecked") // ArgumentCaptor raw type for parameterized List
+    ArgumentCaptor<List<AssetMetadata>> assetsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(shaclValidationStrategy).validate(assetsCaptor.capture(), anyList());
+    assertEquals(2, assetsCaptor.getValue().size());
+    assertEquals(ASSET_ID, assetsCaptor.getValue().get(0).getId());
+    assertEquals(ASSET_ID_2, assetsCaptor.getValue().get(1).getId());
+  }
+
+  @Test
+  void validateAssets_multipleRdfAssets_nonConformingResult_returnsViolations() {
+    ContentAccessor shapeContent = new ContentAccessorDirect("shape ttl");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(NON_CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(9L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertFalse(response.getConforms());
+    assertEquals(List.of(9L), response.getValidationResultIds());
+    assertNotNull(response.getReport());
+    assertFalse(response.getReport().getViolations().isEmpty());
+  }
+
+  @Test
+  void validateAssets_multipleRdfAssets_validateAll_compositeShapeFound_returnsConforming() {
+    ContentAccessor composite = new ContentAccessorDirect("composite shape");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(10L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setValidateAgainstAllSchemas(true);
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(10L), response.getValidationResultIds());
+    assertEquals(List.of(ASSET_ID, ASSET_ID_2), response.getAssetIds());
+    assertTrue(response.getSchemaIds().contains(SCHEMA_ID));
+  }
+
+  @Test
+  void validateAssets_emptyAssetIds_throwsClientException() {
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of());
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_nullAssetIds_throwsClientException() {
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(null);
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_tooManyAssetIds_throwsClientException() {
+    List<String> ids = java.util.stream.IntStream.rangeClosed(1, 21)
+        .mapToObj(i -> "https://example.org/asset/" + i)
+        .toList();
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(ids);
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_nonRdfAsset_throwsVerificationException() {
+    AssetMetadata nonRdf = buildNonRdfAssetWithContentType("https://example.org/asset/pdf", "application/pdf");
+
+    when(assetStore.getById(nonRdf.getId())).thenReturn(nonRdf);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(nonRdf.getId()));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_shaclModuleDisabled_throwsVerificationException() {
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.SHACL)).thenReturn(false);
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    assertThrows(VerificationException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_multipleShapeSchemas_verifyBothShapesParsedAndReturnsConforming() {
+    String schemaId2 = "https://example.org/schema/shape/2";
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shape1 = new ContentAccessorDirect("shape1");
+    ContentAccessor shape2 = new ContentAccessorDirect("shape2");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchemaRecord(schemaId2)).thenReturn(buildShapeRecord(schemaId2));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shape1);
+    when(schemaStore.getSchema(schemaId2)).thenReturn(shape2);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(8L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID, schemaId2));
+
+    ValidationResponse response = service.validateAssets(request);
+
+    assertTrue(response.getConforms());
+    assertNull(response.getReport());
+    assertEquals(List.of(SCHEMA_ID, schemaId2), response.getSchemaIds());
+    // Both shape ContentAccessors are passed together to validate for merging inside the strategy
+    @SuppressWarnings("unchecked") // ArgumentCaptor raw type for parameterized List
+    ArgumentCaptor<List<ContentAccessor>> schemasCaptor = ArgumentCaptor.forClass(List.class);
+    verify(shaclValidationStrategy).validate(anyList(), schemasCaptor.capture());
+    assertEquals(2, schemasCaptor.getValue().size());
+  }
+
+  @Test
+  void validateAssets_noSchemasNoValidateAll_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    givenShaclModuleEnabled();
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+
+    assertThrows(NotFoundException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_schemaTypeNotShape_throwsClientException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    assertThrows(ClientException.class, () -> service.validateAssets(request));
+  }
+
+  @Test
+  void validateAssets_validateAll_noShapesFound_throwsNotFoundException() {
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(null);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setValidateAgainstAllSchemas(true);
+
+    assertThrows(NotFoundException.class, () -> service.validateAssets(request));
+  }
+
+  // === storeResult — result content ===
+
+  @Test
+  void validateAsset_storesResultWithCorrectValidatorIds() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("shape");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(9L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    ArgumentCaptor<ValidationResultRecord> captor =
+        ArgumentCaptor.forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+
+    ValidationResultRecord stored = captor.getValue();
+    assertEquals(List.of(ASSET_ID), stored.assetIds());
+    assertEquals(List.of(SCHEMA_ID), stored.validatorIds());
+    assertEquals(ValidatorType.SHACL, stored.validatorType());
+    assertTrue(stored.conforms());
+    assertNotNull(stored.validatedAt());
+    assertNull(stored.report());
+  }
+
+  @Test
+  void validateAsset_jsonAsset_storesResultWithJsonSchemaValidatorType() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/json");
+    ContentAccessor schemaContent = new ContentAccessorDirect("{\"$schema\":\"...\"}");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenJsonModuleEnabled();
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(schemaStore.getSchema(JSON_SCHEMA_ID)).thenReturn(schemaContent);
+    when(jsonSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(10L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    ArgumentCaptor<ValidationResultRecord> captor = ArgumentCaptor.forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+
+    ValidationResultRecord stored = captor.getValue();
+    assertEquals(List.of(ASSET_ID), stored.assetIds());
+    assertEquals(List.of(JSON_SCHEMA_ID), stored.validatorIds());
+    assertEquals(ValidatorType.JSON_SCHEMA, stored.validatorType());
+    assertTrue(stored.conforms());
+    assertNotNull(stored.validatedAt());
+  }
+
+  @Test
+  void validateAsset_xmlAsset_storesResultWithXmlSchemaValidatorType() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/xml");
+    ContentAccessor schemaContent = new ContentAccessorDirect("<xs:schema/>");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenXmlModuleEnabled();
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(schemaStore.getSchema(XML_SCHEMA_ID)).thenReturn(schemaContent);
+    when(xmlSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(11L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    ArgumentCaptor<ValidationResultRecord> captor = ArgumentCaptor.forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+
+    ValidationResultRecord stored = captor.getValue();
+    assertEquals(List.of(ASSET_ID), stored.assetIds());
+    assertEquals(List.of(XML_SCHEMA_ID), stored.validatorIds());
+    assertEquals(ValidatorType.XML_SCHEMA, stored.validatorType());
+    assertTrue(stored.conforms());
+    assertNotNull(stored.validatedAt());
+  }
+
+  @Test
+  void validateAsset_nonConforming_storesRawReport() {
+    AssetMetadata asset = buildRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("shape");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(NON_CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(10L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    ArgumentCaptor<ValidationResultRecord> captor =
+        ArgumentCaptor.forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+
+    ValidationResultRecord stored = captor.getValue();
+    assertFalse(stored.conforms());
+    assertNotNull(stored.validatedAt());
+    assertEquals("constraint violation", stored.report());
+  }
+
+  // === strategy dispatch isolation ===
+
+  @Test
+  void validateAssets_turtleRdfAsset_explicitShape_dispatchesToShaclStrategyOnly() {
+    AssetMetadata asset = buildTurtleRdfAsset(ASSET_ID);
+    ContentAccessor shapeContent = new ContentAccessorDirect("@prefix sh: <http://www.w3.org/ns/shacl#> .");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenShaclModuleEnabled();
+    when(schemaStore.getSchemaRecord(SCHEMA_ID)).thenReturn(buildShapeRecord(SCHEMA_ID));
+    when(schemaStore.getSchema(SCHEMA_ID)).thenReturn(shapeContent);
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(50L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    verify(shaclValidationStrategy).validate(anyList(), anyList());
+    verify(jsonSchemaValidationStrategy, never()).validate(anyList(), anyList());
+    verify(xmlSchemaValidationStrategy, never()).validate(anyList(), anyList());
+  }
+
+  @Test
+  void validateAssets_jsonAsset_explicitJsonSchema_dispatchesToJsonStrategyOnly() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/json");
+    ContentAccessor schemaContent = new ContentAccessorDirect("{\"$schema\":\"...\"}");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenJsonModuleEnabled();
+    when(schemaStore.getSchemaRecord(JSON_SCHEMA_ID)).thenReturn(buildJsonRecord(JSON_SCHEMA_ID));
+    when(schemaStore.getSchema(JSON_SCHEMA_ID)).thenReturn(schemaContent);
+    when(jsonSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(51L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(JSON_SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    verify(jsonSchemaValidationStrategy).validate(anyList(), anyList());
+    verify(shaclValidationStrategy, never()).validate(anyList(), anyList());
+    verify(xmlSchemaValidationStrategy, never()).validate(anyList(), anyList());
+  }
+
+  @Test
+  void validateAssets_xmlAsset_explicitXmlSchema_dispatchesToXmlStrategyOnly() {
+    AssetMetadata asset = buildNonRdfAssetWithContentType(ASSET_ID, "application/xml");
+    ContentAccessor schemaContent = new ContentAccessorDirect("<xs:schema/>");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(asset);
+    givenXmlModuleEnabled();
+    when(schemaStore.getSchemaRecord(XML_SCHEMA_ID)).thenReturn(buildXmlRecord(XML_SCHEMA_ID));
+    when(schemaStore.getSchema(XML_SCHEMA_ID)).thenReturn(schemaContent);
+    when(xmlSchemaValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(52L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID));
+    request.setSchemaIds(List.of(XML_SCHEMA_ID));
+
+    service.validateAssets(request);
+
+    verify(xmlSchemaValidationStrategy).validate(anyList(), anyList());
+    verify(shaclValidationStrategy, never()).validate(anyList(), anyList());
+    verify(jsonSchemaValidationStrategy, never()).validate(anyList(), anyList());
+  }
+
+  @Test
+  void validateAssets_twoRdfAssets_validateAll_onlyShaclStrategyDispatched() {
+    ContentAccessor composite = new ContentAccessorDirect("composite shape");
+
+    when(assetStore.getById(ASSET_ID)).thenReturn(buildRdfAsset(ASSET_ID));
+    when(assetStore.getById(ASSET_ID_2)).thenReturn(buildRdfAsset(ASSET_ID_2));
+    givenShaclModuleEnabled();
+    when(schemaStore.getCompositeSchema(SchemaType.SHAPE)).thenReturn(composite);
+    when(schemaStore.getSchemaList()).thenReturn(Map.of(SchemaType.SHAPE, List.of(SCHEMA_ID)));
+    when(shaclValidationStrategy.validate(anyList(), anyList())).thenReturn(CONFORMING_REPORT);
+    when(validationResultStore.store(any())).thenReturn(53L);
+
+    ValidationRequest request = new ValidationRequest();
+    request.setAssetIds(List.of(ASSET_ID, ASSET_ID_2));
+    request.setValidateAgainstAllSchemas(true);
+
+    service.validateAssets(request);
+
+    verify(shaclValidationStrategy).validate(anyList(), anyList());
+    verify(jsonSchemaValidationStrategy, never()).validate(anyList(), anyList());
+    verify(xmlSchemaValidationStrategy, never()).validate(anyList(), anyList());
+  }
+
+
+  private static AssetMetadata buildRdfAsset(String id) {
+    return new AssetMetadata(RDF_HASH, id, AssetStatus.ACTIVE,
+        ISSUER_DID, List.of(), Instant.now(), Instant.now(),
+        new ContentAccessorDirect("{\"@context\":{}}"));
+  }
+
+  private static AssetMetadata buildRdfXmlAsset(String id) {
+    return new AssetMetadata(RDFXML_HASH, id, AssetStatus.ACTIVE,
+        ISSUER_DID, List.of(), Instant.now(), Instant.now(),
+        new ContentAccessorDirect("<?xml version=\"1.0\"?><rdf:RDF/>"));
+  }
+
+  private static AssetMetadata buildTurtleRdfAsset(String id) {
+    return new AssetMetadata(TURTLE_HASH, id, AssetStatus.ACTIVE,
+        ISSUER_DID, List.of(), Instant.now(), Instant.now(),
+        new ContentAccessorDirect("@prefix ex: <https://example.org/> ."));
+  }
+
+  private static AssetMetadata buildNonRdfAssetWithContentType(String id, String contentType) {
+    AssetMetadata asset = new AssetMetadata(NONRDF_HASH, id, AssetStatus.ACTIVE,
+        ISSUER_DID, List.of(), Instant.now(), Instant.now(), null);
+    asset.setContentType(contentType);
+    return asset;
+  }
+
+  private static SchemaRecord buildShapeRecord(String id) {
+    return new SchemaRecord(id, id, SchemaType.SHAPE, "@prefix sh: <http://www.w3.org/ns/shacl#> .", null);
+  }
+
+  private static SchemaRecord buildJsonRecord(String id) {
+    return new SchemaRecord(id, id, SchemaType.JSON, "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\"}",
+        null);
+  }
+
+  private static SchemaRecord buildXmlRecord(String id) {
+    return new SchemaRecord(id, id, SchemaType.XML, "<xs:schema/>", null);
+  }
+
+  private void registerStrategyList() {
+    when(strategies.iterator()).thenAnswer(inv ->
+        List.of(shaclValidationStrategy, jsonSchemaValidationStrategy, xmlSchemaValidationStrategy).iterator());
+    when(strategies.stream()).thenAnswer(inv ->
+        Stream.of(shaclValidationStrategy, jsonSchemaValidationStrategy, xmlSchemaValidationStrategy));
+  }
+
+  private void registerShaclStrategy() {
+    when(shaclValidationStrategy.type()).thenReturn(ValidatorType.SHACL);
+    when(shaclValidationStrategy.moduleType()).thenReturn(SchemaModuleType.SHACL);
+    when(shaclValidationStrategy.acceptsSchema(any())).thenAnswer(
+        inv -> ((SchemaRecord) inv.getArgument(0)).type() == SchemaType.SHAPE);
+    when(shaclValidationStrategy.appliesTo(any())).thenAnswer(
+        inv -> ((AssetMetadata) inv.getArgument(0)).getContentAccessor() != null);
+  }
+
+  private void registerJsonStrategy() {
+    JsonSchemaValidationStrategy jsonApplicabilityDelegate =
+        new JsonSchemaValidationStrategy(mock(FileStore.class),
+            new ObjectMapper());
+
+    when(jsonSchemaValidationStrategy.type()).thenReturn(ValidatorType.JSON_SCHEMA);
+    when(jsonSchemaValidationStrategy.moduleType()).thenReturn(SchemaModuleType.JSON_SCHEMA);
+    when(jsonSchemaValidationStrategy.acceptsSchema(any())).thenAnswer(
+        inv -> ((SchemaRecord) inv.getArgument(0)).type() == SchemaType.JSON);
+    when(jsonSchemaValidationStrategy.appliesTo(any())).thenAnswer(
+        inv -> jsonApplicabilityDelegate.appliesTo((AssetMetadata) inv.getArgument(0)));
+  }
+
+  private void registerXmlStrategy() {
+    ObjectProvider<DocumentBuilderFactory> documentBuilderFactoryProvider = createProviderMock();
+    ObjectProvider<SchemaFactory> schemaFactoryProvider = createProviderMock();
+    XmlSchemaValidationStrategy xmlApplicabilityDelegate =
+      new XmlSchemaValidationStrategy(
+        mock(FileStore.class),
+        documentBuilderFactoryProvider,
+        schemaFactoryProvider);
+
+    when(xmlSchemaValidationStrategy.type()).thenReturn(ValidatorType.XML_SCHEMA);
+    when(xmlSchemaValidationStrategy.moduleType()).thenReturn(SchemaModuleType.XML_SCHEMA);
+    when(xmlSchemaValidationStrategy.acceptsSchema(any())).thenAnswer(
+      inv -> ((SchemaRecord) inv.getArgument(0)).type() == SchemaType.XML);
+    when(xmlSchemaValidationStrategy.appliesTo(any())).thenAnswer(
+      inv -> xmlApplicabilityDelegate.appliesTo((AssetMetadata) inv.getArgument(0)));
+  }
+
+  private void givenShaclModuleEnabled() {
+    registerStrategyList();
+    registerShaclStrategy();
+    when(moduleConfigService.isModuleEnabled(any())).thenReturn(false);
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.SHACL)).thenReturn(true);
+  }
+
+  private void givenJsonModuleEnabled() {
+    registerStrategyList();
+    registerJsonStrategy();
+    when(moduleConfigService.isModuleEnabled(any())).thenReturn(false);
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.JSON_SCHEMA)).thenReturn(true);
+  }
+
+  private void givenXmlModuleEnabled() {
+    registerStrategyList();
+    registerXmlStrategy();
+    when(moduleConfigService.isModuleEnabled(any())).thenReturn(false);
+    when(moduleConfigService.isModuleEnabled(SchemaModuleType.XML_SCHEMA)).thenReturn(true);
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultCleanupListenerTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultCleanupListenerTest.java
@@ -1,0 +1,40 @@
+package eu.xfsc.fc.core.service.validation;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import eu.xfsc.fc.core.service.assetstore.AssetDeletedEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ValidationResultCleanupListenerTest {
+
+  @Mock
+  private ValidationResultStore validationResultStore;
+
+  @InjectMocks
+  private ValidationResultCleanupListener listener;
+
+  @Test
+  void onAssetDeleted_validEvent_callsDeleteByAssetId() {
+    AssetDeletedEvent event = new AssetDeletedEvent("https://example.org/asset/deleted-1");
+
+    listener.onAssetDeleted(event);
+
+    verify(validationResultStore).deleteByAssetId("https://example.org/asset/deleted-1");
+  }
+
+  @Test
+  void onAssetDeleted_storeThrows_propagatesException() {
+    AssetDeletedEvent event = new AssetDeletedEvent("https://example.org/asset/deleted-2");
+    doThrow(new RuntimeException("db unavailable"))
+        .when(validationResultStore).deleteByAssetId("https://example.org/asset/deleted-2");
+
+    assertThrows(RuntimeException.class, () -> listener.onAssetDeleted(event));
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriterTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriterTest.java
@@ -1,9 +1,11 @@
 package eu.xfsc.fc.core.service.validation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -32,19 +34,6 @@ class ValidationResultGraphWriterTest {
     graphStore = mock(GraphStore.class);
   }
 
-  // --- helper ---
-
-  private static ValidationResult buildResult(long id, String[] assetIds) {
-    ValidationResult r = new ValidationResult();
-    r.setAssetIds(assetIds);
-    r.setValidatorIds(new String[]{"https://example.org/schema/1"});
-    r.setValidatorType(ValidatorType.SCHEMA);
-    r.setConforms(true);
-    r.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
-    r.setId(id);
-    return r;
-  }
-
   // ===== write — single asset =====
 
   @Test
@@ -70,7 +59,7 @@ class ValidationResultGraphWriterTest {
     writer.write(result, graphStore);
 
     ArgumentCaptor<List<RdfClaim>> claimsCaptor = forClass(List.class);
-    verify(graphStore).addClaims(claimsCaptor.capture(), org.mockito.ArgumentMatchers.any());
+    verify(graphStore).addClaims(claimsCaptor.capture(), any());
 
     List<RdfClaim> claims = claimsCaptor.getValue();
     String expectedSubject = "<https://example.org/asset/1>";
@@ -94,7 +83,7 @@ class ValidationResultGraphWriterTest {
     writer.write(result, graphStore);
 
     ArgumentCaptor<List<RdfClaim>> claimsCaptor = forClass(List.class);
-    verify(graphStore).addClaims(claimsCaptor.capture(), org.mockito.ArgumentMatchers.any());
+    verify(graphStore).addClaims(claimsCaptor.capture(), any());
 
     List<RdfClaim> claims = claimsCaptor.getValue();
     assertEquals(6, claims.size(), "Two assets + 1 validatorId: 2 hasValidationResult + 1 validatorId + 3 property triples = 6");
@@ -111,7 +100,7 @@ class ValidationResultGraphWriterTest {
     writer.write(result, graphStore);
 
     ArgumentCaptor<String> subjectCaptor = forClass(String.class);
-    verify(graphStore).addClaims(org.mockito.ArgumentMatchers.any(), subjectCaptor.capture());
+    verify(graphStore).addClaims(any(), subjectCaptor.capture());
 
     assertEquals("https://example.org/asset/FIRST", subjectCaptor.getValue());
   }
@@ -126,7 +115,7 @@ class ValidationResultGraphWriterTest {
     writer.write(result, graphStore);
 
     ArgumentCaptor<List<RdfClaim>> claimsCaptor = forClass(List.class);
-    verify(graphStore).addClaims(claimsCaptor.capture(), org.mockito.ArgumentMatchers.any());
+    verify(graphStore).addClaims(claimsCaptor.capture(), any());
 
     String expectedPredicate = "<" + FCMETA + "validatorId>";
     String expectedObject = "<https://example.org/schema/1>";
@@ -148,7 +137,7 @@ class ValidationResultGraphWriterTest {
     writer.write(result, graphStore);
 
     ArgumentCaptor<List<RdfClaim>> claimsCaptor = forClass(List.class);
-    verify(graphStore).addClaims(claimsCaptor.capture(), org.mockito.ArgumentMatchers.any());
+    verify(graphStore).addClaims(claimsCaptor.capture(), any());
 
     // 1 hasValidationResult + 2 validatorId + 3 property triples = 6
     assertEquals(6, claimsCaptor.getValue().size());
@@ -165,15 +154,25 @@ class ValidationResultGraphWriterTest {
   void write_graphStoreThrowsException_propagatesException() {
     ValidationResult result = buildResult(1L, new String[]{"https://example.org/asset/1"});
     GraphStore failingStore = mock(GraphStore.class);
-    org.mockito.Mockito.doThrow(new RuntimeException("Graph DB connection failed"))
+    doThrow(new RuntimeException("Graph DB connection failed"))
         .when(failingStore).addClaims(any(), any());
 
-    try {
-      writer.write(result, failingStore);
-      org.junit.jupiter.api.Assertions.fail("Expected RuntimeException to be thrown");
-    } catch (RuntimeException e) {
-      assertEquals("Graph DB connection failed", e.getMessage());
-      verify(failingStore).addClaims(any(), any());
-    }
+    RuntimeException ex = assertThrows(RuntimeException.class,
+        () -> writer.write(result, failingStore));
+
+    assertEquals("Graph DB connection failed", ex.getMessage());
+    verify(failingStore).addClaims(any(), any());
+  }
+
+
+  private static ValidationResult buildResult(long id, String[] assetIds) {
+    ValidationResult r = new ValidationResult();
+    r.setAssetIds(assetIds);
+    r.setValidatorIds(new String[]{"https://example.org/schema/1"});
+    r.setValidatorType(ValidatorType.SHACL);
+    r.setConforms(true);
+    r.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
+    r.setId(id);
+    return r;
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultHasherTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultHasherTest.java
@@ -21,7 +21,6 @@ class ValidationResultHasherTest {
     hasher = new ValidationResultHasher(new ObjectMapper());
   }
 
-  // --- helper ---
 
   private static ValidationResult buildResult(String[] assetIds, String[] validatorIds,
       ValidatorType validatorType, boolean conforms, Instant validatedAt) {
@@ -41,7 +40,7 @@ class ValidationResultHasherTest {
     ValidationResult result = buildResult(
         new String[]{"https://example.org/asset/1"},
         new String[]{"https://example.org/schema/1"},
-        ValidatorType.SCHEMA,
+        ValidatorType.SHACL,
         true,
         Instant.parse("2024-06-01T12:00:00Z"));
 
@@ -55,9 +54,9 @@ class ValidationResultHasherTest {
   void hash_sameInput_returnsSameHash() {
     Instant ts = Instant.parse("2024-06-01T12:00:00Z");
     ValidationResult r1 = buildResult(new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, true, ts);
     ValidationResult r2 = buildResult(new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, true, ts);
 
     assertEquals(hasher.hash(r1), hasher.hash(r2));
   }
@@ -66,9 +65,9 @@ class ValidationResultHasherTest {
   void hash_differentConforms_returnsDifferentHash() {
     Instant ts = Instant.parse("2024-06-01T12:00:00Z");
     ValidationResult passing = buildResult(new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, true, ts);
     ValidationResult failing = buildResult(new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, false, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, false, ts);
 
     assertNotEquals(hasher.hash(passing), hasher.hash(failing));
   }
@@ -77,9 +76,9 @@ class ValidationResultHasherTest {
   void hash_differentAssetIds_returnsDifferentHash() {
     Instant ts = Instant.parse("2024-06-01T12:00:00Z");
     ValidationResult r1 = buildResult(new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, true, ts);
     ValidationResult r2 = buildResult(new String[]{"https://example.org/asset/2"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true, ts);
+        new String[]{"ref/1"}, ValidatorType.SHACL, true, ts);
 
     assertNotEquals(hasher.hash(r1), hasher.hash(r2));
   }
@@ -90,7 +89,7 @@ class ValidationResultHasherTest {
   void verify_correctHash_returnsTrue() {
     ValidationResult result = buildResult(
         new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true,
+        new String[]{"ref/1"}, ValidatorType.SHACL, true,
         Instant.parse("2024-06-01T12:00:00Z"));
     result.setContentHash(hasher.hash(result));
 
@@ -101,7 +100,7 @@ class ValidationResultHasherTest {
   void verify_tamperedConforms_returnsFalse() {
     ValidationResult result = buildResult(
         new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true,
+        new String[]{"ref/1"}, ValidatorType.SHACL, true,
         Instant.parse("2024-06-01T12:00:00Z"));
     result.setContentHash(hasher.hash(result));
 
@@ -115,7 +114,7 @@ class ValidationResultHasherTest {
   void verify_nullHash_returnsFalse() {
     ValidationResult result = buildResult(
         new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true,
+        new String[]{"ref/1"}, ValidatorType.SHACL, true,
         Instant.parse("2024-06-01T12:00:00Z"));
     result.setContentHash(null);
 
@@ -127,7 +126,7 @@ class ValidationResultHasherTest {
     // null validatedAt causes NPE in canonicalize() — caught by verify(), which returns false
     ValidationResult result = buildResult(
         new String[]{"https://example.org/asset/1"},
-        new String[]{"ref/1"}, ValidatorType.SCHEMA, true,
+        new String[]{"ref/1"}, ValidatorType.SHACL, true,
         null);
     result.setContentHash("anything");
 
@@ -141,11 +140,11 @@ class ValidationResultHasherTest {
     ValidationResult r1 = buildResult(
         new String[]{"https://example.org/asset/1"},
         new String[]{"schema/A", "schema/B", "schema/C"},
-        ValidatorType.SCHEMA, true, ts);
+        ValidatorType.SHACL, true, ts);
     ValidationResult r2 = buildResult(
         new String[]{"https://example.org/asset/1"},
         new String[]{"schema/C", "schema/A", "schema/B"},  // different order
-        ValidatorType.SCHEMA, true, ts);
+        ValidatorType.SHACL, true, ts);
 
     assertEquals(hasher.hash(r1), hasher.hash(r2),
         "Hash must be stable regardless of validatorIds array element order");
@@ -158,11 +157,11 @@ class ValidationResultHasherTest {
     ValidationResult r1 = buildResult(
         new String[]{"asset/1", "asset/2"},
         new String[]{"schema/A"},
-        ValidatorType.SCHEMA, true, ts);
+        ValidatorType.SHACL, true, ts);
     ValidationResult r2 = buildResult(
         new String[]{"asset/2", "asset/1"},  // different order
         new String[]{"schema/A"},
-        ValidatorType.SCHEMA, true, ts);
+        ValidatorType.SHACL, true, ts);
 
     assertEquals(hasher.hash(r1), hasher.hash(r2),
         "Hash must be stable regardless of assetIds array element order");

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImplTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/ValidationResultStoreImplTest.java
@@ -43,35 +43,12 @@ class ValidationResultStoreImplTest {
   @InjectMocks
   private ValidationResultStoreImpl service;
 
-  // --- helper ---
-
-  private static ValidationResultRecord buildRecord(boolean conforms) {
-    return new ValidationResultRecord(
-        List.of("https://example.org/asset/1"),
-        List.of("https://example.org/schema/1"),
-        ValidatorType.SCHEMA,
-        conforms,
-        Instant.parse("2024-06-01T12:00:00Z"),
-        null);
-  }
-
-  private static ValidationResult entityWithId(long id) {
-    ValidationResult e = new ValidationResult();
-    e.setAssetIds(new String[]{"https://example.org/asset/1"});
-    e.setValidatorIds(new String[]{"https://example.org/schema/1"});
-    e.setValidatorType(ValidatorType.SCHEMA);
-    e.setConforms(true);
-    e.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
-    e.setId(id);
-    return e;
-  }
-
   // ===== store — graph write succeeds =====
 
   @Test
   void store_graphWriteSucceeds_statusTransitionsToSynced() {
     ValidationResultRecord record = buildRecord(true);
-    ValidationResult saved = entityWithId(1L);
+    ValidationResult saved = buildEntityWithId(1L);
     when(hasher.hash(any())).thenReturn("aabbcc");
     when(repository.save(any())).thenReturn(saved);
 
@@ -88,7 +65,7 @@ class ValidationResultStoreImplTest {
   @Test
   void store_graphWriteSucceeds_returnsId() {
     ValidationResultRecord record = buildRecord(false);
-    ValidationResult saved = entityWithId(99L);
+    ValidationResult saved = buildEntityWithId(99L);
     when(hasher.hash(any())).thenReturn("hash");
     when(repository.save(any())).thenReturn(saved);
 
@@ -102,7 +79,7 @@ class ValidationResultStoreImplTest {
   @Test
   void store_graphWriteFails_statusMarkedFailed() {
     ValidationResultRecord record = buildRecord(true);
-    ValidationResult saved = entityWithId(2L);
+    ValidationResult saved = buildEntityWithId(2L);
     when(hasher.hash(any())).thenReturn("aabbcc");
     when(repository.save(any())).thenReturn(saved);
     doThrow(new RuntimeException("graph unavailable"))
@@ -119,7 +96,7 @@ class ValidationResultStoreImplTest {
 
   @Test
   void getByAssetId_delegatesWithPageable() {
-    ValidationResult entity = entityWithId(5L);
+    ValidationResult entity = buildEntityWithId(5L);
     Pageable pageable = PageRequest.of(0, 10);
     Page<ValidationResult> page = new PageImpl<>(List.of(entity));
     when(repository.findByAssetId(eq("https://example.org/asset/1"), eq(pageable)))
@@ -135,7 +112,7 @@ class ValidationResultStoreImplTest {
 
   @Test
   void getById_existingId_returnsPopulatedOptional() {
-    ValidationResult entity = entityWithId(10L);
+    ValidationResult entity = buildEntityWithId(10L);
     when(repository.findById(10L)).thenReturn(Optional.of(entity));
 
     Optional<ValidationResult> result = service.getById(10L);
@@ -151,5 +128,70 @@ class ValidationResultStoreImplTest {
     Optional<ValidationResult> result = service.getById(999L);
 
     assertFalse(result.isPresent());
+  }
+
+  // ===== deleteByAssetId =====
+
+  @Test
+  void deleteByAssetId_existingResults_deletesGraphAndPostgresRows() {
+    ValidationResult result1 = buildEntityWithId(10L);
+    ValidationResult result2 = buildEntityWithId(11L);
+    when(repository.findAllByAssetId("https://example.org/asset/1"))
+        .thenReturn(List.of(result1, result2));
+    when(graphWriter.resultIri(10L)).thenReturn("https://fc.example.org/meta/ValidationResult/10");
+    when(graphWriter.resultIri(11L)).thenReturn("https://fc.example.org/meta/ValidationResult/11");
+
+    service.deleteByAssetId("https://example.org/asset/1");
+
+    verify(graphStore).deleteValidationResultClaims("https://fc.example.org/meta/ValidationResult/10");
+    verify(graphStore).deleteValidationResultClaims("https://fc.example.org/meta/ValidationResult/11");
+    verify(repository).deleteAllByAssetId("https://example.org/asset/1");
+  }
+
+  @Test
+  void deleteByAssetId_noResults_performsNoop() {
+    when(repository.findAllByAssetId("https://example.org/asset/unknown"))
+        .thenReturn(List.of());
+
+    service.deleteByAssetId("https://example.org/asset/unknown");
+
+    verify(repository).deleteAllByAssetId("https://example.org/asset/unknown");
+    org.mockito.Mockito.verifyNoInteractions(graphStore);
+  }
+
+  @Test
+  void deleteByAssetId_graphThrows_deletesDbRowsAnyway() {
+    ValidationResult result = buildEntityWithId(20L);
+    when(repository.findAllByAssetId("https://example.org/asset/1"))
+        .thenReturn(List.of(result));
+    when(graphWriter.resultIri(20L)).thenReturn("https://fc.example.org/meta/ValidationResult/20");
+    doThrow(new RuntimeException("graph unavailable"))
+        .when(graphStore).deleteValidationResultClaims(any());
+
+    service.deleteByAssetId("https://example.org/asset/1");
+
+    verify(repository).deleteAllByAssetId("https://example.org/asset/1");
+  }
+
+
+  private static ValidationResultRecord buildRecord(boolean conforms) {
+    return new ValidationResultRecord(
+        List.of("https://example.org/asset/1"),
+        List.of("https://example.org/schema/1"),
+        ValidatorType.SHACL,
+        conforms,
+        Instant.parse("2024-06-01T12:00:00Z"),
+        null);
+  }
+
+  private static ValidationResult buildEntityWithId(long id) {
+    ValidationResult e = new ValidationResult();
+    e.setAssetIds(new String[]{"https://example.org/asset/1"});
+    e.setValidatorIds(new String[]{"https://example.org/schema/1"});
+    e.setValidatorType(ValidatorType.SHACL);
+    e.setConforms(true);
+    e.setValidatedAt(Instant.parse("2024-06-01T12:00:00Z"));
+    e.setId(id);
+    return e;
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/rdf/RdfAssetParserTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/rdf/RdfAssetParserTest.java
@@ -1,0 +1,143 @@
+package eu.xfsc.fc.core.service.validation.rdf;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.apicatalog.jsonld.loader.DocumentLoader;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
+import org.apache.jena.rdf.model.Model;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {RdfAssetParser.class})
+class RdfAssetParserTest {
+
+  private static final String TURTLE_PERSON =
+      "@prefix ex: <http://example.org/> . ex:Alice a ex:Person ; ex:name \"Alice\" .";
+
+  private static final String SHAPE_PERSON = """
+      @prefix sh: <http://www.w3.org/ns/shacl#> .
+      @prefix ex: <http://example.org/> .
+      ex:PersonShape a sh:NodeShape ; sh:targetClass ex:Person .
+      """;
+
+  private static final String JSON_LD_PERSON = """
+      {
+        "@context": {"ex": "http://example.org/"},
+        "@id": "http://example.org/Alice",
+        "@type": "ex:Person",
+        "ex:name": "Alice"
+      }
+      """;
+
+  @MockitoBean(name = "contextCacheFileStore")
+  private FileStore fileStore;
+  @MockitoBean
+  private DocumentLoader documentLoader;
+  @MockitoBean
+  private LoireJwtParser loireJwtParser;
+
+  @Autowired
+  private RdfAssetParser rdfAssetParser;
+
+  @Test
+  void parse_turtleAsset_returnsModel() {
+    AssetMetadata asset = buildTurtleAsset("http://example.org/alice", TURTLE_PERSON);
+
+    Model model = rdfAssetParser.parse(asset);
+
+    assertNotNull(model);
+    assertFalse(model.isEmpty(), "Parsed Turtle should produce a non-empty model");
+  }
+
+  @Test
+  void parse_loireJwtAsset_unwrapsAndReturnsModel() {
+    AssetMetadata asset = buildAssetWithContent("http://example.org/alice", "eyJfakeJwt");
+    when(loireJwtParser.unwrap(any())).thenReturn(new ContentAccessorDirect(JSON_LD_PERSON));
+
+    Model model = rdfAssetParser.parse(asset);
+
+    assertNotNull(model);
+    assertFalse(model.isEmpty(), "Parsed JSON-LD from unwrapped JWT should produce a non-empty model");
+  }
+
+  @Test
+  void parseShape_turtleShape_returnsModel() {
+    Model model = rdfAssetParser.parseShape(new ContentAccessorDirect(SHAPE_PERSON));
+
+    assertNotNull(model);
+    assertFalse(model.isEmpty(), "Parsed SHACL shape should produce a non-empty model");
+  }
+
+  @Test
+  void isJsonLd_jsonLdContent_returnsTrue() {
+    AssetMetadata asset = buildAssetWithContent("http://example.org/a", JSON_LD_PERSON.strip());
+
+    assertTrue(rdfAssetParser.isJsonLd(asset));
+  }
+
+  @Test
+  void isJsonLd_turtleContent_returnsFalse() {
+    AssetMetadata asset = buildTurtleAsset("http://example.org/a", TURTLE_PERSON);
+
+    assertFalse(rdfAssetParser.isJsonLd(asset));
+  }
+
+  @Test
+  void isJsonLd_rdfXmlContent_returnsFalse() {
+    String rdfXmlContent = "<?xml version=\"1.0\"?><rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"/>";
+    AssetMetadata asset = buildAssetWithContent("http://example.org/a", rdfXmlContent);
+
+    assertFalse(rdfAssetParser.isJsonLd(asset));
+  }
+
+  @Test
+  void isRdfXml_xmlContent_returnsTrue() {
+    String rdfXmlContent = "<?xml version=\"1.0\"?><rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"/>";
+    AssetMetadata asset = buildAssetWithContent("http://example.org/a", rdfXmlContent);
+
+    assertTrue(rdfAssetParser.isRdfXml(asset));
+  }
+
+  @Test
+  void isRdfXml_jsonContent_returnsFalse() {
+    AssetMetadata asset = buildAssetWithContent("http://example.org/a", JSON_LD_PERSON.strip());
+
+    assertFalse(rdfAssetParser.isRdfXml(asset));
+  }
+
+  
+  @Test
+  void isRdfXml_turtleContent_returnsFalse() {
+    AssetMetadata asset = buildTurtleAsset("http://example.org/a", TURTLE_PERSON);
+
+    assertFalse(rdfAssetParser.isRdfXml(asset));
+  }
+
+
+  private static AssetMetadata buildTurtleAsset(String id, String turtleContent) {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId(id);
+    asset.setContentType("text/turtle");
+    asset.setContentAccessor(new ContentAccessorDirect(turtleContent));
+    return asset;
+  }
+
+  private static AssetMetadata buildAssetWithContent(String id, String content) {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId(id);
+    asset.setContentAccessor(new ContentAccessorDirect(content));
+    return asset;
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/JsonSchemaValidationStrategyTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/JsonSchemaValidationStrategyTest.java
@@ -1,0 +1,126 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class JsonSchemaValidationStrategyTest {
+
+  private static final String SIMPLE_SCHEMA =
+      "{\"type\":\"object\",\"required\":[\"id\"],\"properties\":{\"id\":{\"type\":\"string\"}}}";
+
+  private static final String CONFORMING_JSON = "{\"id\":\"abc-123\"}";
+
+  private static final String NON_CONFORMING_JSON = "{\"value\":\"missing-id-field\"}";
+
+  // FileStore is not called in these tests — assets have contentAccessor pre-loaded.
+  private final JsonSchemaValidationStrategy strategy =
+      new JsonSchemaValidationStrategy(mock(FileStore.class), new ObjectMapper());
+
+  @Test
+  void validate_conformingJson_returnsConforming() {
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect(SIMPLE_SCHEMA)));
+
+    assertTrue(report.getConforms());
+    assertNotNull(report.getViolations());
+    assertTrue(report.getViolations().isEmpty());
+  }
+
+  @Test
+  void validate_nonConformingJson_returnsViolation() {
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset(NON_CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect(SIMPLE_SCHEMA)));
+
+    assertFalse(report.getConforms());
+    assertFalse(report.getViolations().isEmpty());
+    assertNotNull(report.getViolations().get(0).getMessage());
+  }
+
+  @Test
+  void validate_malformedJson_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset("not json")),
+        List.of(new ContentAccessorDirect(SIMPLE_SCHEMA))));
+  }
+
+  @Test
+  void validate_fileRefInSchema_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect("{\"$ref\":\"file:///etc/passwd\"}"))));
+  }
+
+  @Test
+  void validate_httpRefInSchema_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect("{\"$ref\":\"http://169.254.169.254/latest/meta-data\"}"))));
+  }
+
+  @Test
+  void validate_gopherRefInSchema_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect("{\"$ref\":\"gopher://internal/resource\"}"))));
+  }
+
+  @Test
+  void validate_ftpRefInSchema_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect("{\"$ref\":\"ftp://internal.example.org/schemas/v1\"}"))));
+  }
+
+  @Test
+  void validate_conformingJson_withLocalSchemaRef_returnsConforming() {
+    String schemaWithLocalRef =
+        "{\"type\":\"object\",\"required\":[\"id\"],"
+        + "\"properties\":{\"id\":{\"$ref\":\"#/definitions/IdType\"}},"
+        + "\"definitions\":{\"IdType\":{\"type\":\"string\"}}}";
+
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect(schemaWithLocalRef)));
+
+    assertTrue(report.getConforms());
+    assertNotNull(report.getViolations());
+    assertTrue(report.getViolations().isEmpty());
+  }
+
+  @Test
+  void validate_multipleAssets_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON), buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect(SIMPLE_SCHEMA))));
+  }
+
+  @Test
+  void validate_multipleSchemas_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_JSON)),
+        List.of(new ContentAccessorDirect(SIMPLE_SCHEMA),
+            new ContentAccessorDirect(SIMPLE_SCHEMA))));
+  }
+
+
+  private static AssetMetadata buildAsset(String content) {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId("http://example.org/asset/1");
+    asset.setContentAccessor(new ContentAccessorDirect(content));
+    return asset;
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationStrategyTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/ShaclValidationStrategyTest.java
@@ -1,0 +1,128 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.apicatalog.jsonld.loader.DocumentLoader;
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.verification.LoireJwtParser;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {ShaclValidationStrategy.class, ShaclValidationExecutor.class, RdfAssetParser.class})
+@TestPropertySource(properties = {
+    "federated-catalogue.validation.shacl.timeout-seconds=10",
+    "federated-catalogue.validation.shacl.pool-size=2"
+})
+class ShaclValidationStrategyTest {
+
+  private static final String SHAPE_PERSON_NAME_REQUIRED = """
+      @prefix sh: <http://www.w3.org/ns/shacl#> .
+      @prefix ex: <http://example.org/> .
+      ex:PersonShape a sh:NodeShape ;
+          sh:targetClass ex:Person ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+      """;
+
+  private static final String TURTLE_PERSON_WITH_NAME =
+      "@prefix ex: <http://example.org/> . ex:Alice a ex:Person ; ex:name \"Alice\" .";
+
+  private static final String TURTLE_PERSON_WITHOUT_NAME =
+      "@prefix ex: <http://example.org/> . ex:Bob a ex:Person .";
+
+  @MockitoBean(name = "contextCacheFileStore")
+  private FileStore fileStore;
+  @MockitoBean
+  private DocumentLoader documentLoader;
+  @MockitoBean
+  private LoireJwtParser loireJwtParser;
+
+  @Autowired
+  private ShaclValidationStrategy shaclValidationStrategy;
+
+  @Test
+  void validate_conformingTurtleAsset_returnsConforming() {
+    AssetMetadata asset = buildTurtleAsset("http://example.org/alice", TURTLE_PERSON_WITH_NAME);
+
+    ValidationReport report = shaclValidationStrategy.validate(
+        List.of(asset),
+        List.of(new ContentAccessorDirect(SHAPE_PERSON_NAME_REQUIRED)));
+
+    assertTrue(report.getConforms(), "Conforming Turtle asset should pass SHACL validation");
+    assertNotNull(report.getViolations());
+    assertTrue(report.getViolations().isEmpty(), "Conforming result should have no violations");
+  }
+
+  @Test
+  void validate_nonConformingTurtleAsset_returnsViolation() {
+    AssetMetadata asset = buildTurtleAsset("http://example.org/bob", TURTLE_PERSON_WITHOUT_NAME);
+
+    ValidationReport report = shaclValidationStrategy.validate(
+        List.of(asset),
+        List.of(new ContentAccessorDirect(SHAPE_PERSON_NAME_REQUIRED)));
+
+    assertFalse(report.getConforms(), "Non-conforming Turtle asset should fail SHACL validation");
+    assertNotNull(report.getViolations());
+    assertFalse(report.getViolations().isEmpty(), "Non-conforming result should report violations");
+    assertNotNull(report.getRawReport(), "Raw SHACL report should be populated for non-conforming result");
+  }
+
+  @Test
+  void validate_multipleAssets_mergesGraphsBeforeValidation() {
+    String shapeNameAndAge = """
+        @prefix sh: <http://www.w3.org/ns/shacl#> .
+        @prefix ex: <http://example.org/> .
+        ex:PersonShape a sh:NodeShape ;
+            sh:targetClass ex:Person ;
+            sh:property [ sh:path ex:name ; sh:minCount 1 ] ;
+            sh:property [ sh:path ex:age  ; sh:minCount 1 ] .
+        """;
+    String assetAContent = "@prefix ex: <http://example.org/> . ex:Person1 a ex:Person ; ex:name \"Eve\" .";
+    String assetBContent = "@prefix ex: <http://example.org/> . ex:Person1 ex:age 30 .";
+
+    List<AssetMetadata> assets = List.of(
+        buildTurtleAsset("http://example.org/a", assetAContent),
+        buildTurtleAsset("http://example.org/b", assetBContent));
+
+    ValidationReport report = shaclValidationStrategy.validate(
+        assets,
+        List.of(new ContentAccessorDirect(shapeNameAndAge)));
+
+    assertTrue(report.getConforms(), "Merged graph from two assets should satisfy the shape");
+  }
+
+  @Test
+  void validate_assetWithNullContentAccessor_throwsClientException() {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId("http://example.org/non-rdf-asset");
+    asset.setContentAccessor(null);
+
+    assertThrows(ClientException.class,
+        () -> shaclValidationStrategy.validate(
+            List.of(asset),
+            List.of(new ContentAccessorDirect(SHAPE_PERSON_NAME_REQUIRED))));
+  }
+
+
+  private static AssetMetadata buildTurtleAsset(String id, String turtleContent) {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId(id);
+    asset.setContentType("text/turtle");
+    asset.setContentAccessor(new ContentAccessorDirect(turtleContent));
+    return asset;
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/XmlSchemaValidationStrategyTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/validation/strategy/XmlSchemaValidationStrategyTest.java
@@ -1,0 +1,156 @@
+package eu.xfsc.fc.core.service.validation.strategy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import eu.xfsc.fc.api.generated.model.ValidationReport;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.filestore.FileStore;
+import java.util.List;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.validation.SchemaFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.xml.sax.SAXException;
+
+class XmlSchemaValidationStrategyTest {
+
+  private static final String VALID_XSD =
+      "<?xml version=\"1.0\"?>"
+      + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"
+      + "  <xs:element name=\"root\">"
+      + "    <xs:complexType>"
+      + "      <xs:sequence>"
+      + "        <xs:element name=\"name\" type=\"xs:string\"/>"
+      + "      </xs:sequence>"
+      + "    </xs:complexType>"
+      + "  </xs:element>"
+      + "</xs:schema>";
+
+  private static final String CONFORMING_XML = "<root><name>test</name></root>";
+
+  private static final String NON_CONFORMING_XML = "<root><unknown>x</unknown></root>";
+
+  // FileStore is not called in these tests — assets have contentAccessor pre-loaded.
+  private final ObjectProvider<DocumentBuilderFactory> documentBuilderFactoryProvider =
+      createProviderFor(createSecureDocumentBuilderFactory());
+
+  private final ObjectProvider<SchemaFactory> schemaFactoryProvider =
+      createProviderFor(createSecureSchemaFactory());
+
+  private final XmlSchemaValidationStrategy strategy =
+      new XmlSchemaValidationStrategy(
+          mock(FileStore.class), documentBuilderFactoryProvider, schemaFactoryProvider);
+
+  @Test
+  void validate_conformingXml_returnsConforming() {
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset(CONFORMING_XML)),
+        List.of(new ContentAccessorDirect(VALID_XSD)));
+
+    assertTrue(report.getConforms());
+    assertNotNull(report.getViolations());
+    assertTrue(report.getViolations().isEmpty());
+  }
+
+  @Test
+  void validate_nonConformingXml_returnsViolation() {
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset(NON_CONFORMING_XML)),
+        List.of(new ContentAccessorDirect(VALID_XSD)));
+
+    assertFalse(report.getConforms());
+    assertFalse(report.getViolations().isEmpty());
+  }
+
+  @Test
+  void validate_malformedSchema_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_XML)),
+        List.of(new ContentAccessorDirect("not valid xml schema <<<"))));
+  }
+
+  @Test
+  void validate_malformedAsset_returnsViolation() {
+    ValidationReport report = strategy.validate(
+        List.of(buildAsset("not valid xml <<<")),
+        List.of(new ContentAccessorDirect(VALID_XSD)));
+
+    assertFalse(report.getConforms());
+    assertFalse(report.getViolations().isEmpty());
+  }
+
+  @Test
+  void validate_schemaWithDoctype_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_XML)),
+        List.of(new ContentAccessorDirect(
+            "<?xml version=\"1.0\"?><!DOCTYPE xs:schema SYSTEM \"http://evil.com/evil.dtd\">"
+            + "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">"
+            + "<xs:element name=\"root\" type=\"xs:string\"/></xs:schema>"))));
+  }
+
+  @Test
+  void validate_multipleAssets_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_XML), buildAsset(CONFORMING_XML)),
+        List.of(new ContentAccessorDirect(VALID_XSD))));
+  }
+
+  @Test
+  void validate_multipleSchemas_throwsClientException() {
+    assertThrows(ClientException.class, () -> strategy.validate(
+        List.of(buildAsset(CONFORMING_XML)),
+        List.of(new ContentAccessorDirect(VALID_XSD),
+            new ContentAccessorDirect(VALID_XSD))));
+  }
+
+
+  private static AssetMetadata buildAsset(String content) {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId("http://example.org/asset/1");
+    asset.setContentAccessor(new ContentAccessorDirect(content));
+    return asset;
+  }
+
+  private static DocumentBuilderFactory createSecureDocumentBuilderFactory() {
+    try {
+      DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+      dbf.setNamespaceAware(true);
+      dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      dbf.setExpandEntityReferences(false);
+      return dbf;
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to create secure DocumentBuilderFactory", e);
+    }
+  }
+
+  private static SchemaFactory createSecureSchemaFactory() {
+    try {
+      SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      return factory;
+    } catch (SAXException e) {
+      throw new IllegalStateException("Failed to create secure SchemaFactory", e);
+    }
+  }
+
+  private static <T> ObjectProvider<T> createProviderFor(T value) {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<T> provider = (ObjectProvider<T>) mock(ObjectProvider.class);
+    when(provider.getObject()).thenReturn(value);
+    return provider;
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetectorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetectorTest.java
@@ -26,10 +26,10 @@ import static eu.xfsc.fc.core.service.verification.TestVerificationConstants.GAI
 import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_20_CONTEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class FormatDetectorTest {
+class CredentialFormatDetectorTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-    private final FormatDetector detector = new FormatDetector(OBJECT_MAPPER, List.of(
+    private final CredentialFormatDetector detector = new CredentialFormatDetector(OBJECT_MAPPER, List.of(
             new LoireMatcher(),
               new DanubeTechFormatMatcher()
     ));
@@ -258,7 +258,6 @@ class FormatDetectorTest {
         assertEquals(CredentialFormat.UNKNOWN, result);
     }
 
-    // --- helpers ---
 
     private String buildLoireVcJwt() throws Exception {
         JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/GaiaxTrustFrameworkTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/GaiaxTrustFrameworkTest.java
@@ -40,6 +40,8 @@ import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResultParticipant;
 import eu.xfsc.fc.core.pojo.Validator;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
@@ -72,7 +74,8 @@ import lombok.extern.slf4j.Slf4j;
     DocumentLoaderConfig.class, DocumentLoaderProperties.class, VerificationServiceImpl.class,
     SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class,
     DidDocumentResolver.class, ValidatorCacheJpaDao.class,
-    ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class})
+    ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class,
+    RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 public class GaiaxTrustFrameworkTest {
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireJwtParserTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireJwtParserTest.java
@@ -206,7 +206,6 @@ class LoireJwtParserTest {
     assertTrue(parser.isVpJwt(new ContentAccessorDirect(jwt)));
   }
 
-  // --- helpers ---
 
   private String buildLoireVcJwt() throws Exception {
     return buildJwtWithHeaders("vc+ld+json+jwt", "vc+ld+json");

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RevalidationServiceTest.java
@@ -27,6 +27,8 @@ import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStore;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 import eu.xfsc.fc.core.service.assetstore.IriGenerator;
@@ -73,7 +75,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
   VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, ValidatorCacheJpaDao.class, AssetStoreImpl.class, AssetJpaDao.class, AssetAuditRepository.class,
   DocumentLoaderConfig.class, DocumentLoaderProperties.class, DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
   JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
-  IriGenerator.class, IriValidator.class, ObjectMapper.class, SecurityAuditorAware.class})
+  IriGenerator.class, IriValidator.class, ObjectMapper.class, SecurityAuditorAware.class,
+  RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 //@Import(EmbeddedNeo4JConfig.class)
 public class RevalidationServiceTest {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SchemaValidationServiceTest.java
@@ -20,6 +20,8 @@ import org.springframework.test.context.ContextConfiguration;
 import eu.xfsc.fc.core.config.DatabaseConfig;
 import eu.xfsc.fc.core.security.SecurityAuditorAware;
 import eu.xfsc.fc.core.config.DidResolverConfig;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.config.DocumentLoaderConfig;
 import eu.xfsc.fc.core.config.DocumentLoaderProperties;
 import eu.xfsc.fc.core.config.FileStoreConfig;
@@ -51,6 +53,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SchemaValidationServiceTest.TestApplication.class, FileStoreConfig.class,
         DocumentLoaderConfig.class, DocumentLoaderProperties.class, SchemaValidationServiceImpl.class,
+        RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class,
         VerificationServiceImpl.class, CredentialVerificationStrategy.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class,
         DidResolverConfig.class, DidDocumentResolver.class, ValidatorCacheJpaDao.class, HttpDocumentResolver.class,
         AdminConfigRepository.class, SchemaModuleConfigService.class,

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SignatureVerificationTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/SignatureVerificationTest.java
@@ -37,6 +37,8 @@ import eu.xfsc.fc.core.exception.VerificationException;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 import eu.xfsc.fc.core.pojo.Validator;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
@@ -51,7 +53,8 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {SignatureVerificationTest.TestApplication.class, FileStoreConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
         VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class, DidDocumentResolver.class, ValidatorCacheJpaDao.class,
-        ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class})
+        ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class,
+        RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class SignatureVerificationTest {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/ValidatorCacheTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/ValidatorCacheTest.java
@@ -12,6 +12,8 @@ import eu.xfsc.fc.core.dao.schemas.SchemaAuditRepository;
 import eu.xfsc.fc.core.dao.schemas.SchemaJpaDao;
 import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.pojo.Validator;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.resolve.DidDocumentResolver;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
 import eu.xfsc.fc.core.service.schemastore.SchemaStoreImpl;
@@ -43,7 +45,8 @@ import java.time.temporal.ChronoUnit;
         VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
         DidResolverConfig.class, DidDocumentResolver.class, HttpDocumentResolver.class,
         JwtSignatureVerifier.class, ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class,
-        SecurityAuditorAware.class})
+        SecurityAuditorAware.class,
+        RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class})
 //@DirtiesContext
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 public class ValidatorCacheTest {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
@@ -43,6 +43,8 @@ import eu.xfsc.fc.core.dao.validatorcache.ValidatorCacheJpaDao;
 import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.VerificationException;
 import eu.xfsc.fc.core.service.resolve.HttpDocumentResolver;
+import eu.xfsc.fc.core.service.validation.rdf.RdfAssetParser;
+import eu.xfsc.fc.core.service.validation.strategy.ShaclValidationExecutor;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
 import eu.xfsc.fc.core.service.verification.claims.JenaAllTriplesExtractor;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
@@ -70,7 +72,8 @@ import static org.mockito.Mockito.when;
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {VerificationServiceTest.TestApplication.class, FileStoreConfig.class, DocumentLoaderConfig.class, DocumentLoaderProperties.class,
         VerificationServiceImpl.class, SchemaStoreImpl.class, SchemaJpaDao.class, SchemaAuditRepository.class, DatabaseConfig.class, DidResolverConfig.class, ValidatorCacheJpaDao.class, HttpDocumentResolver.class,
-        ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class, JenaAllTriplesExtractor.class, ClaimExtractionService.class})
+        ProtectedNamespaceFilter.class, ProtectedNamespaceProperties.class, SecurityAuditorAware.class, JenaAllTriplesExtractor.class, ClaimExtractionService.class,
+        RdfAssetParser.class, ShaclValidationExecutor.class, LoireJwtParser.class})
 @AutoConfigureEmbeddedDatabase(provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.ZONKY)
 public class VerificationServiceTest {
 
@@ -1163,7 +1166,6 @@ public class VerificationServiceTest {
                 "VC credential extractor must return CredentialClaim instances");
     }
 
-  // --- helpers ---
 
   /** Builds a fake danubetech-style JWT wrapping the given VC JSON under a {@code vc} claim. */
   private static String fakeVcJwt(String vcJson) {

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/claims/JenaAllTriplesExtractorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/claims/JenaAllTriplesExtractorTest.java
@@ -16,14 +16,8 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
-import org.apache.jena.riot.Lang;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
 
 /**
  * Unit tests for {@link JenaAllTriplesExtractor}.
@@ -81,26 +75,6 @@ class JenaAllTriplesExtractorTest {
     assertEquals(claim.getObjectString(), result);
     assertFalse(result.startsWith("<"), "Blank node must not be formatted as IRI");
     assertFalse(result.startsWith("\""), "Blank node must not be formatted as literal");
-  }
-
-  // --- detectLang ---
-
-  @ParameterizedTest(name = "{index} => contentType: {0}, expected: {1}")
-  @MethodSource("detectLangTestCases")
-  void detectLang_returnsCorrectLanguage(String contentType, Lang expected) {
-    assertEquals(expected, JenaAllTriplesExtractor.detectLang(contentType));
-  }
-
-  private static Stream<Arguments> detectLangTestCases() {
-    return Stream.of(
-        Arguments.of(null, Lang.JSONLD),
-        Arguments.of("text/turtle", Lang.TURTLE),
-        Arguments.of("application/n-triples", Lang.NTRIPLES),
-        Arguments.of("application/rdf+xml", Lang.RDFXML),
-        Arguments.of("application/ld+json", Lang.JSONLD),
-        Arguments.of("application/json", Lang.JSONLD),
-        Arguments.of("unknown/type", Lang.JSONLD)
-    );
   }
 
   // --- extractClaims: parse formats ---

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/signature/JwtSignatureVerifierTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/signature/JwtSignatureVerifierTest.java
@@ -319,7 +319,6 @@ class JwtSignatureVerifierTest {
     assertThrows(ClientException.class, () -> verifier.verifyFromDataUrl(dataUrl));
   }
 
-  // --- helpers ---
 
   private void mockDidDoc(String kid, Map<String, Object> jwkMap) {
     VerificationMethod vm = mock(VerificationMethod.class);

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/util/RdfFormatDetectorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/util/RdfFormatDetectorTest.java
@@ -1,0 +1,65 @@
+package eu.xfsc.fc.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import org.apache.jena.riot.Lang;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+/**
+ * Unit tests for {@link RdfFormatDetector}.
+ */
+class RdfFormatDetectorTest {
+
+  @ParameterizedTest(name = "{index} => contentType: {0}, rawContent: {1}, expected: {2}")
+  @MethodSource("detectRdfLangTestCases")
+  void detectRdfLang_returnsCorrectLanguage(String contentType, String rawContent, Lang expected) {
+    assertEquals(expected, RdfFormatDetector.detect(contentType, rawContent));
+  }
+
+  private static Stream<Arguments> detectRdfLangTestCases() {
+    return Stream.of(
+        // content-type detection
+        Arguments.of("text/turtle", null, Lang.TURTLE),
+        Arguments.of("application/n-triples", null, Lang.NT),
+        Arguments.of("application/rdf+xml", null, Lang.RDFXML),
+        Arguments.of("application/ld+json", null, Lang.JSONLD11),
+        Arguments.of("application/json", null, Lang.JSONLD11),
+        Arguments.of("application/vc+ld+json", null, Lang.JSONLD11),
+        // content-type with charset param
+        Arguments.of("application/ld+json; charset=UTF-8", null, Lang.JSONLD11),
+        // content inspection fallback
+        Arguments.of(null, "{\"@context\": {}}", Lang.JSONLD11),
+        Arguments.of(null, "@prefix ex: <http://example.org/> .", Lang.TURTLE),
+        Arguments.of(null, "@base <http://example.org/> .", Lang.TURTLE),
+        Arguments.of(null, "<?xml version=\"1.0\"?>", Lang.RDFXML),
+        Arguments.of(null, "<rdf:RDF", Lang.RDFXML),
+        // N-Triples heuristics (IRI subject, blank-node subject, comment line)
+        Arguments.of(null, "<http://example.org/s> <http://example.org/p> <http://example.org/o> .", Lang.NT),
+        Arguments.of(null, "_:b0 <http://example.org/p> \"value\" .", Lang.NT),
+        Arguments.of(null, "# NT comment header", Lang.NT),
+        Arguments.of("application/n-triples", null, Lang.NT)
+    );
+  }
+
+  @Test
+  void detect_unknownContentTypeAndContent_throwsClientException() {
+    assertThrows(ClientException.class, () -> RdfFormatDetector.detect("unknown/type", null));
+  }
+
+  @Test
+  void detect_nullContentTypeAndNullContent_throwsClientException() {
+    assertThrows(ClientException.class, () -> RdfFormatDetector.detect(null, null));
+  }
+
+  @Test
+  void detect_unknownContentTypeAndUnrecognisedContent_throwsClientException() {
+    assertThrows(ClientException.class, () -> RdfFormatDetector.detect(null, "TOTALLY UNKNOWN FORMAT"));
+  }
+}

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -91,6 +91,8 @@ public class SecurityConfig {
           .requestMatchers(HttpMethod.GET, "/assets/*/human-readable").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.GET, "/assets/*/machine-readable").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.GET, "/assets/*/validations").hasAnyRole(ASSET_READ, ADMIN_ALL)
+          .requestMatchers(HttpMethod.POST, "/assets/validate").hasAnyRole(ASSET_READ, ADMIN_ALL)
+          .requestMatchers(HttpMethod.POST, "/assets/*/validate").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.POST, "/assets/*/provenance").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)
           .requestMatchers(HttpMethod.GET, "/assets/*/provenance", "/assets/*/provenance/*").hasAnyRole(ASSET_READ, ADMIN_ALL)
           .requestMatchers(HttpMethod.POST, "/assets/*/provenance/*/verify", "/assets/*/provenance/verify").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/model/GraphRebuildRequest.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/model/GraphRebuildRequest.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Min;
 @lombok.ToString
 public class GraphRebuildRequest {
     
+    
     @Min(1)   
     private int chunkCount;
     @Min(0)   

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/AssetService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/AssetService.java
@@ -10,10 +10,14 @@ import eu.xfsc.fc.api.generated.model.ProvenanceCredential;
 import eu.xfsc.fc.api.generated.model.ProvenanceCredentials;
 import eu.xfsc.fc.api.generated.model.ProvenanceVerificationResult;
 import eu.xfsc.fc.api.generated.model.StoredValidationResult;
+import eu.xfsc.fc.api.generated.model.ValidationRequest;
+import eu.xfsc.fc.api.generated.model.ValidationResponse;
 import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.exception.ServerException;
+import eu.xfsc.fc.core.service.validation.AssetValidationService;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.pojo.AssetFilter;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
 import eu.xfsc.fc.core.pojo.AssetType;
@@ -80,6 +84,7 @@ public class AssetService implements AssetsApiDelegate {
   @Qualifier("assetFileStore") private final FileStore assetFileStore;
   private final AssetProperties assetProperties;
   private final ValidationResultStore validationResultStore;
+  private final AssetValidationService assetValidationService;
   private final ProvenanceService provenanceService;
 
   /**
@@ -531,6 +536,24 @@ public class AssetService implements AssetsApiDelegate {
     }
   }
 
+
+  /**
+   * POST /assets/validate — validates one or more assets against stored schemas.
+   *
+   * <p>Single-asset requests run full type-based dispatch (SHACL, JSON Schema, XML Schema).
+   * Multi-asset requests merge into one data graph for SHACL-only validation.</p>
+   *
+   * @param validationRequest asset IRIs and schema selection
+   * @return validation response with result ID and optional report
+   */
+  @Override
+  public ResponseEntity<ValidationResponse> validateAssets(ValidationRequest validationRequest) {
+    if (validationRequest == null) {
+      throw new ClientException("Request body is required");
+    }
+    log.debug("validateAssets; assetIds={}", validationRequest.getAssetIds());
+    return ResponseEntity.ok(assetValidationService.validateAssets(validationRequest));
+  }
 
   /**
    * Verify a credential body, check participant access, and store it.

--- a/fc-service-server/src/main/resources/application.yml
+++ b/fc-service-server/src/main/resources/application.yml
@@ -142,6 +142,8 @@ federated-catalogue:
       - text/turtle
       - application/n-triples
       - application/rdf+xml
+  validation:
+    max-assets-per-request: 20  # Maximum number of asset IDs allowed in a single validateAssets request
   assets:
     human-readable-content-types:
       - application/pdf

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetControllerTest.java
@@ -45,10 +45,13 @@ import eu.xfsc.fc.core.pojo.ContentAccessorBinary;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.pojo.GraphQuery;
+import eu.xfsc.fc.api.generated.model.ValidationResponse;
+import eu.xfsc.fc.core.exception.VerificationException;
 import eu.xfsc.fc.core.service.assetstore.AssetStore;
 import eu.xfsc.fc.core.service.filestore.FileStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.schemastore.SchemaStore;
+import eu.xfsc.fc.core.service.validation.AssetValidationService;
 import eu.xfsc.fc.core.service.verification.VerificationService;
 import eu.xfsc.fc.core.util.HashUtils;
 import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
@@ -60,6 +63,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.mockito.ArgumentCaptor;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import org.neo4j.harness.Neo4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -88,6 +94,8 @@ public class AssetControllerTest {
     private final static String PARTICIPANT_ISSUER = "did:example:issuer";
     private final static String RESOURCE_ISSUER = "did:web:compliance.lab.gaia-x.eu";
     private final static String ASSET_FILE_NAME = "default-credential.json";
+    private static final byte[] NON_RDF_PDF_BYTES = "%PDF-1.4 fake".getBytes(StandardCharsets.UTF_8);
+    private static final String NON_RDF_PDF_HASH = HashUtils.calculateSha256AsHex(NON_RDF_PDF_BYTES);
 
     @Autowired
     private Neo4j embeddedDatabaseServer;
@@ -104,6 +112,8 @@ public class AssetControllerTest {
     // can't remove it for some reason, many tests fails with auth error
     @MockitoSpyBean(name = "schemaFileStore")
     private FileStore fileStore;
+    @MockitoSpyBean
+    private AssetValidationService assetValidationService;
 
     @Autowired
     private SchemaStore schemaStore;
@@ -127,29 +137,22 @@ public class AssetControllerTest {
     }
     
     @AfterEach
-    public void deleteTestAsset() throws IOException {
-        // Clean up all test assets to avoid cross-test pollution
-        // Try by the default test fixture hash
+    public void deleteTestAsset() {
         try {
             assetStorePublisher.deleteAsset(assetMeta.getAssetHash());
         } catch (NotFoundException e) {
             // expected if not created
         }
-        
-        // Also try to clean up any asset created via API using the default credential
         try {
-            String defaultCredentialHash = HashUtils.calculateSha256AsHex(getMockFileDataAsString(ASSET_FILE_NAME));
-            if (!defaultCredentialHash.equals(assetMeta.getAssetHash())) {
-                assetStorePublisher.deleteAsset(defaultCredentialHash);
-            }
-        } catch (NotFoundException | IOException e) {
-            // expected if not created
+            assetStorePublisher.deleteAsset(NON_RDF_PDF_HASH);
+        } catch (NotFoundException e) {
+            // expected if test did not create a non-RDF PDF asset
         }
         validationResultRepository.deleteAll();
     }
 
     @Test
-    public void readAssetsShouldReturnUnauthorizedResponse() throws Exception {
+    public void readAssets_noAuth_returnsUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/assets")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
@@ -158,7 +161,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void readAssetsShouldReturnBadRequestResponse() throws Exception {
+    public void readAssets_invalidParams_returnsBadRequest() throws Exception {
       mockMvc.perform(MockMvcRequestBuilders.get("/assets?statuses=123")
               .with(csrf())
               .accept(MediaType.APPLICATION_JSON))
@@ -167,7 +170,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void readAssetsShouldReturnSuccessResponse() throws Exception {
+    public void readAssets_validRequest_returnsSuccess() throws Exception {
         assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
         MvcResult result =  mockMvc.perform(MockMvcRequestBuilders.get("/assets")
                         .with(csrf())
@@ -183,7 +186,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void readAssetsByFilterShouldReturnSuccessResponse() throws Exception {
+    public void readAssetsByFilter_validFilter_returnsSuccess() throws Exception {
         assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
         
         MvcResult result =  mockMvc.perform(MockMvcRequestBuilders.get("/assets")
@@ -260,7 +263,7 @@ public class AssetControllerTest {
     }
 
     @Test
-    public void readAssetByHashShouldReturnUnauthorizedResponse() throws Exception {
+    public void readAsset_noAuth_returnsUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/assets/" + assetMeta.getAssetHash())
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
@@ -269,14 +272,14 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void readAssetByHashShouldReturnNotFoundResponse() throws Exception {
+    public void readAsset_nonExistentId_returnsNotFound() throws Exception {
       mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", "urn:uuid:00000000-0000-0000-0000-000000000099").with(csrf()))
           .andExpect(status().isNotFound());
     }
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void readAssetByHashShouldReturnSuccessResponse() throws Exception {
+    public void readAsset_existingId_returnsOk() throws Exception {
         assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
 
         mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", assetMeta.getId())
@@ -287,25 +290,21 @@ public class AssetControllerTest {
     @Test
     @WithMockUser(roles = {ASSET_READ})
     public void readNonRdfAssetById_returnsOkWithMetadata() throws Exception {
-        byte[] pdfBytes = "%PDF-1.4 fake".getBytes(StandardCharsets.UTF_8);
-        String hash = HashUtils.calculateSha256AsHex(pdfBytes);
         Instant now = Instant.now();
 
-        AssetMetadata nonRdfMeta = new AssetMetadata(hash, null, AssetStatus.ACTIVE,
-                TEST_ISSUER, null, now, now, new ContentAccessorBinary(pdfBytes));
+        AssetMetadata nonRdfMeta = new AssetMetadata(NON_RDF_PDF_HASH, null, AssetStatus.ACTIVE,
+                TEST_ISSUER, null, now, now, new ContentAccessorBinary(NON_RDF_PDF_BYTES));
         nonRdfMeta.setContentType("application/pdf");
-        nonRdfMeta.setFileSize((long) pdfBytes.length);
+        nonRdfMeta.setFileSize((long) NON_RDF_PDF_BYTES.length);
         assetStorePublisher.storeUnverified(nonRdfMeta, "test.pdf");
 
         mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}", nonRdfMeta.getId())
                 .with(csrf()))
             .andExpect(status().isOk());
-
-        assetStorePublisher.deleteAsset(nonRdfMeta.getAssetHash());
     }
 
     @Test
-    public void deleteAssetShouldReturnUnauthorizedResponse() throws Exception {
+    public void deleteAsset_noAuth_returnsUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -315,7 +314,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser
-    public void deleteAssetReturnForbiddenResponse() throws Exception {
+    public void deleteAsset_noPermission_returnsForbidden() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -326,7 +325,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = ASSET_DELETE_WITH_PREFIX, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = "")})))
-    public void deleteAssetWithoutIssuerReturnForbiddenResponse() throws Exception {
+    public void deleteAsset_withoutIssuer_returnsForbidden() throws Exception {
       assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
       mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
               .with(csrf())
@@ -338,7 +337,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_DELETE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void deleteAssetReturnNotFoundResponse() throws Exception {
+    public void deleteAsset_nonExistent_returnsNotFound() throws Exception {
       mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
               .with(csrf())
               .contentType(MediaType.APPLICATION_JSON)
@@ -349,7 +348,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_DELETE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void deleteAssetReturnSuccessResponse() throws Exception {
+    public void deleteAsset_validRequest_returnsOk() throws Exception {
         assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
@@ -360,7 +359,32 @@ public class AssetControllerTest {
     }
 
     @Test
-    public void addAssetShouldReturnUnauthorizedResponse() throws Exception {
+    @WithMockJwtAuth(authorities = {ASSET_DELETE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void deleteAsset_hasValidationResults_cascadesDelete() throws Exception {
+        assetStorePublisher.storeCredential(assetMeta, getStaticVerificationResult());
+
+        ValidationResult vr = new ValidationResult();
+        vr.setAssetIds(new String[]{assetMeta.getId()});
+        vr.setValidatorIds(new String[]{"https://example.org/schema/1"});
+        vr.setValidatorType(ValidatorType.SHACL);
+        vr.setConforms(true);
+        vr.setValidatedAt(java.time.Instant.now());
+        vr.setContentHash(validationResultHasher.hash(vr));
+        validationResultRepository.saveAndFlush(vr);
+        assertEquals(1L, validationResultRepository.count(), "Precondition: 1 result seeded");
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/assets/{asset_hash}", assetMeta.getAssetHash())
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        assertEquals(0L, validationResultRepository.count(), "Validation results must be deleted with the asset");
+    }
+
+    @Test
+    public void addAsset_noAuth_returnsUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -370,7 +394,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser
-    public void addAssetReturnForbiddenResponse() throws Exception {
+    public void addAsset_noPermission_returnsForbidden() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                         .content(getMockFileDataAsString(ASSET_FILE_NAME))
                         .with(csrf())
@@ -382,7 +406,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void addAssetWithoutIssuerReturnUnprocessableEntity() throws Exception {
+    public void addAsset_withoutIssuer_returnsUnprocessableEntity() throws Exception {
       mockMvc.perform(MockMvcRequestBuilders.post("/assets")
               .content(getMockFileDataAsString("credential-without-issuer.json"))
               .with(csrf())
@@ -394,7 +418,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void addAssetReturnCreatedResponse() throws Exception {
+    public void addAsset_validRequest_returnsCreated() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                 .content(getMockFileDataAsString(ASSET_FILE_NAME))
                 .with(csrf())
@@ -432,7 +456,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = RESOURCE_ISSUER)})))
-    public void addResourceReturnCreatedResponse() throws Exception {
+    public void addResource_validRequest_returnsCreated() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                 .content(getMockFileDataAsString("credential-resource.json"))
                 .with(csrf())
@@ -448,7 +472,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = PARTICIPANT_ISSUER)})))
-    public void addParicipantReturnCreatedResponse() throws Exception {
+    public void addAsset_validParticipant_returnsCreated() throws Exception {
         schemaStore.initializeDefaultSchemas();
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                 .content(getMockFileDataAsString("default-participant.json"))
@@ -470,7 +494,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = PARTICIPANT_ISSUER)})))
-    public void addShaclInvalidAssetReturnCreatedResponse() throws Exception {
+    public void addAsset_shaclInvalid_returnsCreated() throws Exception {
         schemaStore.initializeDefaultSchemas();
         schemaStore.addSchema(getAccessor("mock-data/legal-personShape.ttl"));
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/assets")
@@ -488,7 +512,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void addDuplicateAssetReturnConflictWithAssetStorage() throws Exception {
+    public void addAsset_duplicate_returnsConflict() throws Exception {
       String asset = getMockFileDataAsString(ASSET_FILE_NAME);
       ContentAccessorDirect contentAccessor = new ContentAccessorDirect(asset);
       String hash = HashUtils.calculateSha256AsHex(asset);
@@ -533,7 +557,7 @@ public class AssetControllerTest {
     }
 
     @Test
-    public void revokeAssetShouldReturnUnauthorizedResponse() throws Exception {
+    public void revokeAsset_noAuth_returnsUnauthorized() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/assets/123/revoke")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -543,7 +567,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser
-    public void revokeAssetReturnForbiddenResponse() throws Exception {
+    public void revokeAsset_noPermission_returnsForbidden() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/assets/123/revoke")
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
@@ -554,7 +578,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void revokeAssetReturnNotFound() throws Exception {
+    public void revokeAsset_nonExistentAsset_returnsNotFound() throws Exception {
       mockMvc.perform(MockMvcRequestBuilders.post("/assets/{asset_hash}/revoke", assetMeta.getAssetHash())
               .with(csrf())
               .contentType(MediaType.APPLICATION_JSON)
@@ -565,7 +589,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void revokeAssetReturnSuccessResponse() throws Exception {
+    public void revokeAsset_validRequest_returnsOk() throws Exception {
         final CredentialVerificationResult vr = new CredentialVerificationResult(Instant.now(), AssetStatus.ACTIVE.getValue(), "issuer",
                 Instant.now(), "vhash", List.of(), List.of());
         assetStorePublisher.storeCredential(assetMeta, vr);
@@ -580,7 +604,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_CREATE_WITH_PREFIX, ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void revokeThenAddAssetReturnCorrectResponse() throws Exception {
+    public void revokeAndReaddAsset_validFlow_returnsCreated() throws Exception {
         String content = getMockFileDataAsString(ASSET_FILE_NAME);
         String hash = HashUtils.calculateSha256AsHex(content);
         try {
@@ -646,7 +670,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_UPDATE_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void revokeAsset_withNotActiveStatus_returnConflictResponse() throws Exception {
+    public void revokeAsset_nonActiveStatus_returnsConflict() throws Exception {
         final CredentialVerificationResult vr = new CredentialVerificationResult(Instant.now(), AssetStatus.ACTIVE.getValue(), "issuer",
                 Instant.now(), "vhash", List.of(), List.of());
         AssetMetadata deprecatedMeta = createAssetMetadata();
@@ -666,7 +690,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
-    public void addAsset_withReadOnlyPermission_returnForbiddenResponse() throws Exception {
+    public void addAsset_withReadOnlyPermission_returnsForbidden() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                         .content(getMockFileDataAsString(ASSET_FILE_NAME))
                         .with(csrf())
@@ -677,7 +701,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser
-    public void readAssets_withoutPermissionRole_shouldReturnForbiddenResponse() throws Exception {
+    public void readAssets_noPermission_returnsForbidden() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/assets")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
@@ -687,7 +711,7 @@ public class AssetControllerTest {
     @Test
     @WithMockJwtAuth(authorities = {ADMIN_ALL_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
         @StringClaim(name = "participant_id", value = "admin-participant")})))
-    public void addAsset_withAdminAllRole_returnCreatedResponse() throws Exception {
+    public void addAsset_withAdminAllRole_returnsCreated() throws Exception {
         MvcResult result = mockMvc.perform(MockMvcRequestBuilders.post("/assets")
                 .content(getMockFileDataAsString(ASSET_FILE_NAME))
                 .with(csrf())
@@ -702,7 +726,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {"ADMIN_ALL"})
-    public void readAssets_withAdminAllRole_returnSuccessResponse() throws Exception {
+    public void readAssets_withAdminAllRole_returnsOk() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/assets")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
@@ -730,7 +754,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void getAssetValidations_nonExistentAsset_returns404() throws Exception {
+    public void getAssetValidations_nonExistentAsset_returnsNotFound() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/assets/did:web:example.org:nonexistent/validations")
                         .with(csrf())
                         .accept(MediaType.APPLICATION_JSON))
@@ -761,12 +785,14 @@ public class AssetControllerTest {
             ValidationResult vr = new ValidationResult();
             vr.setAssetIds(new String[]{assetMeta.getId()});
             vr.setValidatorIds(new String[]{"https://example.org/schema/" + i});
-            vr.setValidatorType(ValidatorType.SCHEMA);
+            vr.setValidatorType(ValidatorType.SHACL);
             vr.setConforms(true);
             vr.setValidatedAt(java.time.Instant.now());
             vr.setContentHash(validationResultHasher.hash(vr));
             validationResultRepository.saveAndFlush(vr);
         }
+
+        assertEquals(3L, validationResultRepository.count(), "Precondition: 3 results seeded");
 
         String allBody = mockMvc.perform(MockMvcRequestBuilders.get(
                         "/assets/" + assetMeta.getId() + "/validations")
@@ -776,6 +802,7 @@ public class AssetControllerTest {
                 .andReturn().getResponse().getContentAsString();
         List<?> allResults = objectMapper.readValue(allBody, List.class);
         assertEquals(3, allResults.size(), "Expected 3 stored validation results");
+        assertTrue(allBody.contains("SHACL"), "Expected SHACL validatorType in response");
 
         String limitedBody = mockMvc.perform(MockMvcRequestBuilders.get(
                         "/assets/" + assetMeta.getId() + "/validations")
@@ -807,7 +834,7 @@ public class AssetControllerTest {
 
     @Test
     @WithMockUser(roles = {ASSET_READ})
-    public void getValidationResult_withReadRole_shouldReturnSuccessOrNotFound() throws Exception {
+    public void getValidationResult_nonExistentId_returnsNotFound() throws Exception {
         // Returns 404 if validation result doesn't exist, 200 if it does
         mockMvc.perform(MockMvcRequestBuilders.get("/validations/999999")
                         .with(csrf())
@@ -821,7 +848,7 @@ public class AssetControllerTest {
         ValidationResult vr = new ValidationResult();
         vr.setAssetIds(new String[]{"did:web:example.org:test-asset"});
         vr.setValidatorIds(new String[]{"https://example.org/schema/1"});
-        vr.setValidatorType(ValidatorType.SCHEMA);
+        vr.setValidatorType(ValidatorType.SHACL);
         vr.setConforms(true);
         vr.setValidatedAt(java.time.Instant.parse("2024-06-01T12:00:00Z"));
         vr.setContentHash(validationResultHasher.hash(vr));
@@ -836,9 +863,162 @@ public class AssetControllerTest {
         var dto = objectMapper.readValue(body, java.util.Map.class);
         assertEquals(saved.getId().intValue(), dto.get("id"));
         assertEquals(List.of("did:web:example.org:test-asset"), dto.get("assetIds"));
-        assertEquals("SCHEMA", dto.get("validatorType"));
+        assertEquals("SHACL", dto.get("validatorType"));
         assertEquals(true, dto.get("conforms"));
         assertNotNull(dto.get("contentHash"));
+    }
+
+    // ===== Validate endpoints — auth rejection =====
+
+    @Test
+    public void validateAsset_withoutAuth_returnsUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-000000000001\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    public void validateAsset_withoutPermission_returnsForbidden() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-000000000001\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void validateAssets_withoutAuth_returnsUnauthorized() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    public void validateAssets_withoutPermission_returnsForbidden() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    // ===== validateAssets — input validation =====
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_emptyBody_returnsBadRequest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_emptyAssetIds_returnsBadRequest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": []}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_tooManyAssetIds_returnsBadRequest() throws Exception {
+        List<String> twentyOneIds = java.util.stream.IntStream.range(0, 21)
+                .mapToObj(i -> "urn:uuid:00000000-0000-0000-0000-" + String.format("%012d", i))
+                .collect(Collectors.toList());
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of("assetIds", twentyOneIds)))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_missingContentType_returnsBadRequest() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-000000000001\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError());
+    }
+
+    // ===== validateAsset / validateAssets — boundary responses =====
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_storedRdfAsset_returnsOk() throws Exception {
+        ValidationResponse mockedResponse = new ValidationResponse();
+        mockedResponse.setConforms(true);
+        doReturn(mockedResponse).when(assetValidationService).validateAssets(any());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-000000000001\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAssets_nonExistentAsset_returnsNotFound() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-does-not-exist\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAsset_nonExistentAsset_returnsNotFound() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"urn:uuid:00000000-0000-0000-0000-does-not-exist\"]}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithMockJwtAuth(authorities = {ASSET_READ_WITH_PREFIX}, claims = @OpenIdClaims(otherClaims = @Claims(stringClaims = {
+        @StringClaim(name = "participant_id", value = TEST_ISSUER)})))
+    public void validateAsset_unsupportedContentType_returnsUnprocessableEntity() throws Exception {
+        doThrow(new VerificationException("unsupported content type for asset"))
+            .when(assetValidationService).validateAssets(any());
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/assets/validate")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"assetIds\": [\"" + assetMeta.getId() + "\"], \"validateAgainstAllSchemas\": true}")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnprocessableEntity());
     }
 
     // ===== Helpers =====

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/GraphRebuildValidationResultRestoreTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/GraphRebuildValidationResultRestoreTest.java
@@ -1,11 +1,14 @@
 package eu.xfsc.fc.server.controller;
 
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
+import static eu.xfsc.fc.server.util.CommonConstants.ASSET_READ;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,6 +18,8 @@ import eu.xfsc.fc.core.dao.validation.ValidationResult;
 import eu.xfsc.fc.core.dao.validation.ValidationResultRepository;
 import eu.xfsc.fc.core.dao.validation.ValidatorType;
 import eu.xfsc.fc.core.service.graphdb.GraphRebuildService;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.core.service.validation.ValidationResultGraphWriter;
 import eu.xfsc.fc.core.service.validation.ValidationResultHasher;
 import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
 import eu.xfsc.fc.server.model.GraphRebuildRequest;
@@ -33,6 +38,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -83,9 +89,40 @@ class GraphRebuildValidationResultRestoreTest {
   @Autowired
   private TransactionTemplate transactionTemplate;
 
+  @MockitoSpyBean
+  private ValidationResultGraphWriter graphWriter;
+
+  private static final int REBUILD_CHUNK_COUNT = 1;
+  private static final int REBUILD_CHUNK_ID = 0;
+  private static final int REBUILD_THREADS = 2;
+  private static final int REBUILD_BATCH_SIZE = 100;
+
   @AfterEach
   void cleanup() {
     validationResultRepository.deleteAll();
+  }
+
+  @Test
+  void postGraphRebuild_noAuth_returnsUnauthorized() throws Exception {
+    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(
+        REBUILD_CHUNK_COUNT, REBUILD_CHUNK_ID, REBUILD_THREADS, REBUILD_BATCH_SIZE);
+    mockMvc.perform(MockMvcRequestBuilders.post("/actuator/graph-rebuild")
+            .content(jsonMapper.writeValueAsString(rebuildRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser(roles = {ASSET_READ})
+  void postGraphRebuild_nonAdminRole_returnsForbidden() throws Exception {
+    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(
+        REBUILD_CHUNK_COUNT, REBUILD_CHUNK_ID, REBUILD_THREADS, REBUILD_BATCH_SIZE);
+    mockMvc.perform(MockMvcRequestBuilders.post("/actuator/graph-rebuild")
+            .content(jsonMapper.writeValueAsString(rebuildRequest))
+            .contentType(MediaType.APPLICATION_JSON)
+            .with(csrf()))
+        .andExpect(status().isForbidden());
   }
 
   /**
@@ -96,12 +133,12 @@ class GraphRebuildValidationResultRestoreTest {
    */
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void testValidationResultGraphSyncStatusUpdatedAfterRebuild() throws Exception {
+  void rebuildValidationResults_failedResult_updatesStatusToSynced() throws Exception {
     Long validationResultId = transactionTemplate.execute(txStatus -> {
       ValidationResult result = new ValidationResult();
       result.setAssetIds(new String[]{"did:example:asset1", "did:example:asset2"});
       result.setValidatorIds(new String[]{"https://example.org/schema/v1"});
-      result.setValidatorType(ValidatorType.SCHEMA);
+      result.setValidatorType(ValidatorType.SHACL);
       result.setConforms(true);
       result.setValidatedAt(Instant.now());
       result.setReport(null);
@@ -117,7 +154,8 @@ class GraphRebuildValidationResultRestoreTest {
           "Initial graph_sync_status should be FAILED");
     });
 
-    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(1, 0, 2, 100);
+    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(
+        REBUILD_CHUNK_COUNT, REBUILD_CHUNK_ID, REBUILD_THREADS, REBUILD_BATCH_SIZE);
     mockMvc.perform(MockMvcRequestBuilders.post("/actuator/graph-rebuild")
             .content(jsonMapper.writeValueAsString(rebuildRequest))
             .contentType(MediaType.APPLICATION_JSON)
@@ -143,13 +181,13 @@ class GraphRebuildValidationResultRestoreTest {
    */
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void testMultipleValidationResultsRestoredInBatch() throws Exception {
+  void rebuildValidationResults_multipleFailedResults_restoresBatch() throws Exception {
     transactionTemplate.executeWithoutResult(txStatus -> {
       for (int i = 1; i <= 5; i++) {
         ValidationResult result = new ValidationResult();
         result.setAssetIds(new String[]{"did:example:asset" + i});
         result.setValidatorIds(new String[]{"https://example.org/schema/v" + i});
-        result.setValidatorType(ValidatorType.SCHEMA);
+        result.setValidatorType(ValidatorType.SHACL);
         result.setConforms(i % 2 == 0);
         result.setValidatedAt(Instant.now());
         result.setReport(i % 2 == 0 ? null : "{\"violations\": []}");
@@ -168,7 +206,8 @@ class GraphRebuildValidationResultRestoreTest {
       assertTrue(failedCount > 0, "Should have at least one FAILED result before rebuild");
     });
 
-    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(1, 0, 2, 100);
+    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(
+        REBUILD_CHUNK_COUNT, REBUILD_CHUNK_ID, REBUILD_THREADS, REBUILD_BATCH_SIZE);
     mockMvc.perform(MockMvcRequestBuilders.post("/actuator/graph-rebuild")
             .content(jsonMapper.writeValueAsString(rebuildRequest))
             .contentType(MediaType.APPLICATION_JSON)
@@ -188,18 +227,41 @@ class GraphRebuildValidationResultRestoreTest {
   }
 
   /**
-   * Tests rebuild behavior with no validation results in the database.
+   * Tests that when graph write fails for a result during rebuild, the result stays FAILED
+   * and the overall rebuild does not mark as failed.
    *
-   * <p>Ensures rebuild completes successfully even when there are no validation
-   * results to restore (edge case).</p>
+   * <p>Per-item graph write failures are logged and counted but do not abort the rebuild.
+   * The result's {@code graph_sync_status} remains {@code FAILED} because
+   * {@link eu.xfsc.fc.core.service.validation.ValidationResultStoreImpl#syncToGraph} catches
+   * the exception and re-persists the FAILED status.</p>
    */
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void testRebuildWithNoValidationResults() throws Exception {
-    validationResultRepository.deleteAll();
-    assertEquals(0, validationResultRepository.count());
+  void rebuildValidationResults_graphWriteThrows_resultRemainsFailedAndRebuildNotFailed() throws Exception {
+    doThrow(new RuntimeException("simulated graph write failure"))
+        .when(graphWriter).write(any(ValidationResult.class), any(GraphStore.class));
 
-    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(1, 0, 2, 100);
+    Long validationResultId = transactionTemplate.execute(txStatus -> {
+      ValidationResult result = new ValidationResult();
+      result.setAssetIds(new String[]{"did:example:asset-error"});
+      result.setValidatorIds(new String[]{"https://example.org/schema/error-test"});
+      result.setValidatorType(ValidatorType.SHACL);
+      result.setConforms(false);
+      result.setValidatedAt(Instant.now());
+      result.setReport("{\"violations\":[]}");
+      result.setContentHash(validationResultHasher.hash(result));
+      result.setGraphSyncStatus(GraphSyncStatus.FAILED);
+      return validationResultRepository.saveAndFlush(result).getId();
+    });
+
+    transactionTemplate.executeWithoutResult(txStatus -> {
+      ValidationResult before = validationResultRepository.findById(validationResultId).orElseThrow();
+      assertEquals(GraphSyncStatus.FAILED, before.getGraphSyncStatus(),
+          "Initial graph_sync_status should be FAILED");
+    });
+
+    GraphRebuildRequest rebuildRequest = new GraphRebuildRequest(
+        REBUILD_CHUNK_COUNT, REBUILD_CHUNK_ID, REBUILD_THREADS, REBUILD_BATCH_SIZE);
     mockMvc.perform(MockMvcRequestBuilders.post("/actuator/graph-rebuild")
             .content(jsonMapper.writeValueAsString(rebuildRequest))
             .contentType(MediaType.APPLICATION_JSON)
@@ -208,8 +270,12 @@ class GraphRebuildValidationResultRestoreTest {
 
     await().atMost(10, SECONDS).until(() -> !graphRebuildService.isRunning());
     assertFalse(graphRebuildService.getStatus().isFailed(),
-        "Rebuild should not have failed: " + graphRebuildService.getStatus().getErrorMessage());
+        "Per-item graph write failures must not fail the overall rebuild");
 
-    assertEquals(0, validationResultRepository.count());
+    transactionTemplate.executeWithoutResult(txStatus -> {
+      ValidationResult after = validationResultRepository.findById(validationResultId).orElseThrow();
+      assertEquals(GraphSyncStatus.FAILED, after.getGraphSyncStatus(),
+          "graph_sync_status should remain FAILED when graph write throws during rebuild");
+    });
   }
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/NonCredentialRdfGraphExtractionTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/NonCredentialRdfGraphExtractionTest.java
@@ -72,7 +72,7 @@ public class NonCredentialRdfGraphExtractionTest {
   private static final String RDFXML_OBJECT = "File Storage Service";
 
   // Single-triple JSON-LD document — no VerifiableCredential/VerifiablePresentation wrapper.
-  // FormatDetector returns UNKNOWN → non-credential extraction path is taken → JenaAllTriplesExtractor is used.
+  // CredentialFormatDetector returns UNKNOWN → non-credential extraction path is taken → JenaAllTriplesExtractor is used.
   private static final String SINGLE_TRIPLE_JSONLD = """
       {
           "@context": {"ex": "http://example.org/"},

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphAdminServiceTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphAdminServiceTest.java
@@ -176,7 +176,6 @@ class GraphAdminServiceTest {
     assertEquals("out-of-sync", body.getSyncAssessment());
   }
 
-  // --- Helpers ---
 
   private void stubEnabledBackend(GraphBackendType type, boolean healthy) {
     when(graphStore.getBackendType()).thenReturn(type);

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ValidationResultCleanupListenerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ValidationResultCleanupListenerTest.java
@@ -1,0 +1,95 @@
+package eu.xfsc.fc.server.service;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+
+import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+import eu.xfsc.fc.core.util.HashUtils;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+/**
+ * Tests {@code ValidationResultCleanupListener} rollback behaviour.
+ *
+ * <p>Verifies that when the listener throws inside the BEFORE_COMMIT phase, the outer
+ * asset-deletion transaction is rolled back and the asset row remains in the database.</p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = {"graphstore.impl=none"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+class ValidationResultCleanupListenerTest {
+
+  private static final String TEST_ISSUER = "http://example.org/test-issuer";
+  private static final String ASSET_ID = "did:web:test:cleanup-rollback-asset";
+  private static final String ASSET_CONTENT = "{\"@context\": \"https://example.org/\", \"id\": \"" + ASSET_ID + "\"}";
+  private static final String ASSET_HASH = HashUtils.calculateSha256AsHex(ASSET_CONTENT);
+
+  @Autowired
+  private AssetStore assetStore;
+
+  @MockitoSpyBean
+  private ValidationResultStore validationResultStore;
+
+  @AfterEach
+  void cleanUp() {
+    reset(validationResultStore);
+    try {
+      assetStore.deleteAsset(ASSET_HASH);
+    } catch (NotFoundException e) {
+      // expected — either the rollback worked (asset still there and we just deleted it)
+      // or the test never stored it
+    }
+  }
+
+  @Test
+  void deleteAsset_listenerThrows_rollsBackAndAssetRemainsInDatabase() {
+    AssetMetadata asset = buildTestAsset();
+    CredentialVerificationResult vr = new CredentialVerificationResult(
+        Instant.now(), AssetStatus.ACTIVE.getValue(), TEST_ISSUER, Instant.now(), ASSET_ID,
+        List.of(), List.of());
+    assetStore.storeCredential(asset, vr);
+
+    doThrow(new RuntimeException("forced listener failure"))
+        .when(validationResultStore).deleteByAssetId(any());
+
+    assertThrows(RuntimeException.class, () -> assetStore.deleteAsset(ASSET_HASH),
+        "deleteAsset must propagate the listener exception");
+
+    AssetMetadata found = assetStore.getById(ASSET_ID);
+    assertNotNull(found, "Asset must still exist after the rolled-back transaction");
+  }
+
+
+  private static AssetMetadata buildTestAsset() {
+    AssetMetadata asset = new AssetMetadata();
+    asset.setId(ASSET_ID);
+    asset.setIssuer(TEST_ISSUER);
+    asset.setAssetHash(ASSET_HASH);
+    asset.setStatus(AssetStatus.ACTIVE);
+    asset.setUploadDatetime(Instant.now());
+    asset.setStatusDatetime(Instant.now());
+    asset.setContentAccessor(new ContentAccessorDirect(ASSET_CONTENT));
+    return asset;
+  }
+}

--- a/keycloak/realms/dev/gaia-x-realm.json
+++ b/keycloak/realms/dev/gaia-x-realm.json
@@ -663,6 +663,46 @@
       },
       "notBefore": 0,
       "groups": []
+    },
+    {
+      "username": "fc-ca-test",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "CHANGE_ME_dev_only",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-gaia-x"
+      ],
+      "clientRoles": {
+        "federated-catalogue": [
+          "Ro-MU-CA"
+        ]
+      }
+    },
+    {
+      "username": "fc-restricted-test",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "CHANGE_ME_dev_only",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "default-roles-gaia-x"
+      ],
+      "clientRoles": {
+        "federated-catalogue": [
+          "SCHEMA_READ"
+        ]
+      }
     }
   ],
   "scopeMappings": [

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -729,7 +729,7 @@ components:
           description: Validator IDs (schema or trust framework) used for validation
         validatorType:
           type: string
-          enum: [SCHEMA, TRUST_FRAMEWORK]
+          enum: [SHACL, JSON_SCHEMA, XML_SCHEMA, TRUST_FRAMEWORK]
           description: Distinguishes on-demand schema validation from external trust framework validation results
         conforms:
           type: boolean
@@ -855,6 +855,114 @@ components:
           type: array
           items:
             type: string
+
+    ValidationRequest:
+      type: object
+      required:
+        - assetIds
+      properties:
+        assetIds:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          maxItems: 20
+          description: >
+            Asset IRIs to validate (1 up to the configured maximum, default 20 - see
+            `federated-catalogue.validation.max-assets-per-request`). A single-ID request runs full type-based dispatch
+            (SHACL for RDF assets, JSON Schema for JSON, XML Schema for XML).
+            Multiple IDs merge all assets into a single data graph for SHACL-only validation;
+            all assets must be RDF assets in that case.
+        schemaIds:
+          type: array
+          items:
+            type: string
+          description: >
+            Optional schema IDs to validate against. For single-asset requests, each schema
+            must match the asset type (SHACL shape for RDF, JSON Schema for JSON, XML Schema
+            for XML). For multi-asset requests, each must be a SHACL shape.
+            Mutually exclusive with validateAgainstAllSchemas=true.
+        validateAgainstAllSchemas:
+          type: boolean
+          default: false
+          description: >
+            If true, validate against all stored schemas matching the asset type (single-asset)
+            or all stored SHACL shapes (multi-asset).
+
+    ValidationResponse:
+      type: object
+      required:
+        - assetIds
+        - schemaIds
+        - conforms
+        - validatedAt
+        - validationResultIds
+      properties:
+        assetIds:
+          type: array
+          items:
+            type: string
+          description: Asset IRIs that were validated
+        schemaIds:
+          type: array
+          items:
+            type: string
+          description: Schema IDs that were validated against
+        conforms:
+          type: boolean
+          description: True if all assets passed validation against all schemas
+        validatedAt:
+          type: string
+          format: date-time
+          description: Timestamp of the validation run
+        validationResultIds:
+          type: array
+          items:
+            type: integer
+            format: int64
+          minItems: 1
+          description: >
+            IDs of all ValidationResult records stored for this request, one per validator paradigm that ran.
+        report:
+          $ref: '#/components/schemas/ValidationReport'
+
+    ValidationReport:
+      type: object
+      required:
+        - conforms
+      properties:
+        conforms:
+          type: boolean
+          description: True if validation passed with no violations
+        violations:
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationViolation'
+          description: List of constraint violations (empty if conforms=true)
+        rawReport:
+          type: string
+          nullable: true
+          description: Serialised raw report (SHACL Turtle for RDF; error message for JSON/XML)
+
+    ValidationViolation:
+      type: object
+      properties:
+        focusNode:
+          type: string
+          description: The RDF resource that violated the constraint
+        resultPath:
+          type: string
+          description: The property path involved in the violation
+        message:
+          type: string
+          description: Human-readable violation message
+        severity:
+          type: string
+          enum: [VIOLATION, WARNING, INFO]
+          description: Violation severity level
+        sourceShape:
+          type: string
+          description: The SHACL shape that was violated
 
   parameters:
     OffsetParam:
@@ -1462,6 +1570,51 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '409':
           $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /assets/validate:
+    post:
+      tags:
+        - Assets
+      summary: Validate one or more assets against stored schemas
+      description: >
+        Validates stored assets against SHACL, JSON Schema, or XML Schema depending on asset
+        type and request size. A single-ID request runs full type-based dispatch: RDF assets
+        validate via SHACL (and optionally JSON Schema / XML Schema if the serialisation
+        matches); non-RDF assets validate via JSON Schema or XML Schema. A multi-ID request
+        merges all asset content into a single data graph and validates via SHACL only
+        (R₁ ∪ R₂ against S); all assets must be RDF assets. Maximum number of assets per request
+        is configurable via `federated-catalogue.validation.max-assets-per-request` (default: 20).
+      operationId: validateAssets
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationRequest'
+      responses:
+        '200':
+          description: Validation completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationResponse'
+        '400':
+          $ref: '#/components/responses/ClientError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          description: Asset type is not validatable (not RDF or unsupported content type)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           $ref: '#/components/responses/ServerError'
   /assets/{id}:


### PR DESCRIPTION
# 📦 [CAT-FR-CO-05] On-demand Validation of Assets against Schemas

## 🚀 Summary

Implements on-demand asset validation. A caller can validate any stored asset
against any stored schema at any time after upload — SHACL for RDF assets,
JSON Schema and XML Schema for non-RDF assets. Validation results are persisted
via the CO-02 storage layer.

Asset deletion is extended with a cascade: `AssetStoreImpl` publishes an
`AssetDeletedEvent`; `ValidationResultCleanupListener` deletes all associated
validation results atomically at `BEFORE_COMMIT`, avoiding cross-boundary
service injection between the `assetstore` and `validation` domains.

**Requirement:** CAT-FR-CO-05 — On-demand Validation of Assets against Schemas

This change is part of the Enhancement of XFSC Federated Catalogue. Details can be found here (permalink):

https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

## ✅ What's in this PR

- [x] Feature implemented
- [x] Tests added or updated
- [x] Code formatted and linted
- [x] OpenAPI spec updated

**On-demand validation (CO-05):**
- `AssetValidationService` orchestrates validation and dispatches to applicable
  `ValidationStrategy` implementations. Single-asset requests try all applicable strategies;
  multi-asset requests are SHACL-only and capped (default 20, `federated-catalogue.validation.max-assets-per-request`).
- Three strategies under `validation.strategy`:
  - `ShaclValidationStrategy` — RDF assets (JSON-LD, Turtle, N-Triples, RDF/XML, Loire JWT) via
    `RdfAssetParser` + `ShaclValidationExecutor` (TopBraid SHACL with configurable timeout/pool)
  - `JsonSchemaValidationStrategy` — JSON Schema Draft 2020-12; rejects `$ref` URIs using
    `file://`, `http://`, `gopher://`, `ftp://` to prevent SSRF
  - `XmlSchemaValidationStrategy` — XSD 1.0; obtains hardened parser factories from `XmlSecurityConfig`
- `XmlSecurityConfig` — centralised hardened `DocumentBuilderFactory` and `SchemaFactory` beans
  (`@Scope(prototype)`) shared with `SchemaStoreImpl`; enforces `disallow-doctype-decl`,
  `FEATURE_SECURE_PROCESSING`, blocked external entities, and `ACCESS_EXTERNAL_DTD`/`SCHEMA`
- Format detection split by responsibility:
  - `RdfFormatDetector` (`util`) — RDF serialization (content-type via Jena `RDFLanguages`
    with content-prefix fallback); throws `ClientException` for unknown input
  - `CredentialFormatDetector` (`verification`) — credential-level format (VC 1.1 vs VC 2.0,
    JWT vs JSON-LD)
- REST endpoints (with permissions in `SecurityConfig` and OpenAPI updates):
  - `POST /assets/validate` — validate one or more stored assets
  - `GET /assets/{id}/validations` — paginated stored results for an asset
  - `GET /validations/{id}` — retrieve a single stored result
- `ValidationReportFactory` maps SHACL, JSON Schema, and XML SAX errors into the `ValidationReport` API model

**Asset deletion cascade (CO-05 extension to CO-02):**
- `AssetStoreImpl.deleteAsset` publishes `AssetDeletedEvent`; `ValidationResultCleanupListener`
  consumes it at `@TransactionalEventListener(BEFORE_COMMIT)` and removes both rows and graph triples atomically.
- `GraphStore.deleteValidationResultClaims(String resultIri)` added to interface + Neo4j/Fuseki/Dummy.
  In Neo4j the IRI is a bound Cypher parameter (`$uri`); in Fuseki it is validated by
  `requireSafeIri` before SPARQL interpolation.

## 🧪 How to Test

1. Start the local Docker stack (`docker-compose up`).
2. Upload an asset (`POST /assets`) and a schema (`POST /schemas`); validate it via
   `POST /assets/validate` with either `schemaIds` or `validateAgainstAllSchemas: true`.
   Cover SHACL on RDF, JSON Schema on JSON, XSD on XML, and a non-conforming case
   (expect `200` with violations).
3. Multi-asset SHACL: `POST /assets/validate` with multiple `assetIds` — combined data graph.
4. Cascade: delete the asset and confirm the `validation_result` row is gone.
5. Unit tests:
   `mvn test -pl fc-service-core -Dtest='AssetValidationServiceImplTest,*ValidationStrategyTest,*ValidationResult*,RdfAssetParserTest'`
6. Controller tests: `mvn test -pl fc-service-server -Dtest=AssetControllerTest`

## 🔍 Related Issues

Implements CAT-FR-CO-05 (On-demand Validation of Assets against Schemas)
Depends on CAT-FR-CO-02 (Validation Result Storage) — already merged

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] I've updated documentation if necessary
- [x] My changes follow the project's coding style