### PR TITLE
Merge to upstream/pvc for deployment

### DIFF
--- a/deployment/helm/fc-service/README.md
+++ b/deployment/helm/fc-service/README.md
@@ -309,8 +309,64 @@ The Keycloak OAuth2 client secret (`fc-keycloak-client-secret`) is intentionally
 - `readOnlyRootFilesystem: true`
 - All Linux capabilities dropped
 
-`/tmp` (Spring Boot JAR extraction) and `/logs` (Logback) are mounted as `emptyDir` volumes. Both are configurable via `volumes` / `volumeMounts` in `values.yaml`.
+`/tmp` (Spring Boot JAR extraction) and `/logs` (Logback) are mounted as `emptyDir` volumes. Both are configurable via `volumes` / `volumeMounts` in `values.yaml`. The non-RDF asset and schema stores are backed by a `PersistentVolumeClaim`; see *Persistent file store* below. The context cache (`contextCacheFiles`) is overlaid with an `emptyDir` to remain ephemeral.
 
 PostgreSQL runs as root (`allowPrivilegeEscalation: false` only) — required by the official image's gosu-based initialisation.
 
 Fuseki runs as UID 9008 (`fuseki` user). The pod security context sets `fsGroup: 9008` so the mounted PVC is writable on first start.
+
+---
+
+## Persistent file store
+
+The chart provisions one `PersistentVolumeClaim` for `fc-service` so that non-RDF asset binaries (`assetFileStore`) and persisted schema files (`schemaFileStore`) survive pod restarts and rescheduling. The `contextCacheFileStore` is kept ephemeral via an `emptyDir` overlaid on top of the PVC at the cache subdirectory.
+
+### Layout
+
+| Path inside the pod | Backed by | Persistence |
+|---|---|---|
+| `/var/lib/fc-service/filestore/assetFiles/` | PVC | Persistent |
+| `/var/lib/fc-service/filestore/schemaFiles/` | PVC | Persistent |
+| `/var/lib/fc-service/filestore/contextCacheFiles/` | `emptyDir` | Ephemeral (overlays PVC) |
+| `/tmp`, `/logs` | `emptyDir` | Ephemeral |
+
+The mount path **must** equal the `DATASTORE_FILE_PATH` env var, since Spring binds it to `${datastore.file-path}` which `FileStoreImpl` uses as the base path for all three stores. The subdirectory names (`assetFiles`, `schemaFiles`, `contextCacheFiles`) are the application's runtime defaults — no override is needed in the chart.
+
+### Values
+
+| Key | Default | Purpose |
+|---|---|---|
+| `persistence.enabled` | `true` | Toggle the PVC + the persistent volume mounts. Disabling reverts to the historical pure-`emptyDir` layout (any uploaded asset is lost on pod restart). |
+| `persistence.mountPath` | `/var/lib/fc-service/filestore` | Container path the PVC is mounted at. Must equal `DATASTORE_FILE_PATH`. |
+| `persistence.size` | `10Gi` | Requested PVC capacity. May be undersized for binary-heavy tenants — operators should size up before deployment. |
+| `persistence.accessModes` | `[ReadWriteOnce]` | RWO is sufficient for the single-replica deployment; horizontal scaling of `fc-service` requires a future RWX-or-object-store change. |
+| `persistence.storageClassName` | `""` | Empty selects the cluster's default `StorageClass`. **If your cluster has no default class, set this explicitly** or the PVC will stay `Pending`. On clusters whose default class has `reclaimPolicy: Delete`, the underlying `PersistentVolume` is destroyed when the PVC is deleted — pin a Retain-class here if the volume must survive. See *Reclaim policy* below. |
+| `podSecurityContext.fsGroup` | `1000` | Group ownership of the PVC mount — required for the non-root UID 1000 container to write to the volume. Some CSI drivers (notably certain NFS provisioners) ignore `fsGroup`; on those, pre-chown the volume or override this value. |
+
+### Reclaim policy
+
+Two independent layers control data survival, and they live at different places — there is no PVC-level reclaim field that does anything (the Kubernetes API silently drops `spec.persistentVolumeReclaimPolicy` on a PVC, because that field exists only on the `PersistentVolume`).
+
+1. **Helm-level: the chart sets `helm.sh/resource-policy: keep` on the PVC.** This means `helm uninstall` will not delete the PVC object. It does *not* protect the underlying volume.
+2. **StorageClass-level: the `StorageClass.reclaimPolicy` field.** This decides what happens to the underlying `PersistentVolume` once the PVC is deleted: `Retain` keeps the PV (data preserved, manual cleanup required), `Delete` destroys it.
+
+The chart can only directly control layer 1. For layer 2 you have two production-grade options:
+
+- **Pin a Retain-class** via `persistence.storageClassName`. Pre-create a `StorageClass` (or use one provided by your platform) with `reclaimPolicy: Retain`, then point the chart at it. Many managed clouds default to a `Delete`-class — in that case the default is **not safe** against a full `helm uninstall`.
+- **Treat the Helm annotation as enough**, accept that `helm uninstall` followed by an explicit `kubectl delete pvc` *will* destroy the volume, and rely on a backup outside this chart.
+
+The chart does not — and cannot — guarantee data survival across a `helm uninstall` on a cluster with a `Delete`-default provisioner. The `helm.sh/resource-policy: keep` annotation only guards the PVC object, not the PV behind it.
+
+### Resizing
+
+If your cluster's `StorageClass` has `allowVolumeExpansion: true`, increase `persistence.size` and re-apply the chart (or `kubectl edit pvc fc-service-filestore` directly). The pod must usually be restarted for the new size to be visible inside the container.
+
+### Disabling persistence
+
+For ephemeral test deployments, set `persistence.enabled=false`. The chart will not render the PVC and the pod falls back to writing the filestore to the container's root filesystem — which, combined with `readOnlyRootFilesystem: true`, means **file-store writes will fail**. Disabling is therefore only useful when uploads are not exercised (e.g., chart-rendering CI).
+
+### Known caveats
+
+- **No default StorageClass.** Set `persistence.storageClassName` explicitly, or the PVC stays `Pending` indefinitely.
+- **SELinux-enforcing clusters.** May require additional `seLinuxOptions` on the pod or PVC; not set by this chart.
+- **Single point of failure.** The PV typically lives on one node. If that node fails and the PV cannot be re-attached, the pod stays `Pending` until the PV is available. This is consistent with the single-replica `ReadWriteOnce` scope of this chart.

--- a/deployment/helm/fc-service/templates/_helpers.tpl
+++ b/deployment/helm/fc-service/templates/_helpers.tpl
@@ -168,3 +168,38 @@ Fuseki selector labels
 app.kubernetes.io/name: {{ include "fc-service.fuseki.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Volumes for fc-service. Prepends a PVC-backed filestore volume and an overlay
+emptyDir for the context cache when persistence is enabled; always appends the
+user-supplied .Values.volumes (logs, tmp by default).
+*/}}
+{{- define "fc-service.volumes" -}}
+{{- if .Values.persistence.enabled }}
+- name: filestore
+  persistentVolumeClaim:
+    claimName: {{ include "fc-service.fullname" . }}-filestore
+- name: context-cache
+  emptyDir: {}
+{{- end }}
+{{- range .Values.volumes }}
+- {{ toYaml . | nindent 2 | trim }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Volume mounts for fc-service. Mounts the filestore PVC at the configured path
+(must equal DATASTORE_FILE_PATH) and overlays the contextCacheFiles subdirectory
+with an ephemeral emptyDir so the context cache stays per-pod.
+*/}}
+{{- define "fc-service.volumeMounts" -}}
+{{- if .Values.persistence.enabled }}
+- name: filestore
+  mountPath: {{ .Values.persistence.mountPath }}
+- name: context-cache
+  mountPath: {{ printf "%s/contextCacheFiles" .Values.persistence.mountPath }}
+{{- end }}
+{{- range .Values.volumeMounts }}
+- {{ toYaml . | nindent 2 | trim }}
+{{- end }}
+{{- end -}}

--- a/deployment/helm/fc-service/templates/deployment.yaml
+++ b/deployment/helm/fc-service/templates/deployment.yaml
@@ -55,14 +55,10 @@ spec:
             periodSeconds: {{ .Values.probes.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.volumes }}
+            {{- include "fc-service.volumeMounts" . | nindent 12 }}
       volumes:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- include "fc-service.volumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/fc-service/templates/pvc.yaml
+++ b/deployment/helm/fc-service/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "fc-service.fullname" . }}-filestore
+  labels:
+    {{- include "fc-service.labels" . | nindent 4 }}
+  annotations:
+    # Prevents `helm uninstall` from deleting the PVC object. Whether the
+    # underlying PersistentVolume survives is controlled by the StorageClass's
+    # reclaimPolicy (Retain vs. Delete), not by this annotation and not by any
+    # field on the PVC itself. See README §Persistent file store.
+    "helm.sh/resource-policy": keep
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- with .Values.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/deployment/helm/fc-service/values.yaml
+++ b/deployment/helm/fc-service/values.yaml
@@ -35,8 +35,13 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  # Matches securityContext.runAsUser below. Required so the persistence PVC
+  # (mounted at /var/lib/fc-service/filestore) is owned by a group the
+  # non-root UID can write to. Honored by most CSI drivers; on drivers that
+  # ignore fsGroup (e.g. some NFS provisioners), set this to the value your
+  # provisioner expects or pre-chown the volume.
+  fsGroup: 1000
 
 securityContext:
   allowPrivilegeEscalation: false
@@ -103,6 +108,32 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# Persistent file store for non-RDF asset binaries and persisted schema files.
+# Backs the assetFileStore and schemaFileStore Spring beans
+# (federated-catalogue.file-store.{asset,schema}.location, see
+# fc-service-core/.../FileStoreConfig.java). The contextCacheFileStore is
+# overlaid by an ephemeral emptyDir so the cache stays per-pod.
+#
+# The mount path MUST equal the DATASTORE_FILE_PATH env value below — Spring
+# binds DATASTORE_FILE_PATH to ${datastore.file-path}, which FileStoreImpl uses
+# as the base for all three stores.
+persistence:
+  enabled: true
+  mountPath: /var/lib/fc-service/filestore
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  # Empty = use the cluster's default StorageClass. If the cluster has no
+  # default StorageClass, set this explicitly or the PVC will stay Pending.
+  # On managed clusters whose default class has reclaimPolicy=Delete, the
+  # underlying PersistentVolume will be destroyed when the PVC is deleted —
+  # set this to a Retain-class explicitly if the volume must survive a
+  # `helm uninstall`. See README §Persistent file store.
+  storageClassName: ""
+
+# Additional ephemeral mounts. The persistent filestore + context-cache
+# overlay are added automatically by the fc-service.volumes /
+# fc-service.volumeMounts helpers when persistence.enabled is true.
 volumeMounts:
   - name: logs
     mountPath: /logs


### PR DESCRIPTION
## 🚀 Summary

Provisions a single PersistentVolumeClaim for fc-service so non-RDF asset binaries and persisted schema files survive pod restarts and rescheduling. The contextCacheFileStore is overlaid with an emptyDir and stays ephemeral.

The PVC is mounted at the existing DATASTORE_FILE_PATH (/var/lib/fc-service/filestore), so no Spring property or env-var changes are needed. FileStoreImpl already auto-creates the assetFiles/schemaFiles subdirectories on first write via FileUtils.openOutputStream. This also fixes a latent bug: with readOnlyRootFilesystem=true and the previously unmounted /var/lib/fc-service/filestore, all FileStore writes were silently failing in Kubernetes.

Helm-level guard helm.sh/resource-policy: keep prevents helm uninstall from deleting the PVC object; the StorageClass.reclaimPolicy governs whether the underlying PV survives (chart cannot control this directly). README § Persistent file store documents both layers and the no-default-class, SELinux, and single-replica-PV caveats.

Changes:

New: templates/pvc.yaml (gated by persistence.enabled).
_helpers.tpl: two new partials (fc-service.volumes, fc-service.volumeMounts) that prepend the PVC + context-cache emptyDir when persistence is enabled.
deployment.yaml: switched volumes/volumeMounts passthroughs to use the helpers.
values.yaml: new persistence block; podSecurityContext.fsGroup=1000 so UID 1000 can write to the PVC mount.
README.md: new "Persistent file store" section; "Security context" paragraph extended with a forward pointer.

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style
