### PR TITLE
Enhancement [CAT-FR-CO-03] part two - external trust framework interface

### DIFF
--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/exception/ServiceUnavailableException.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/exception/ServiceUnavailableException.java
@@ -1,0 +1,16 @@
+package eu.xfsc.fc.core.exception;
+
+/**
+ * Thrown when an external service required to fulfil a request is currently unreachable.
+ * Maps to HTTP 503 Service Unavailable.
+ */
+public class ServiceUnavailableException extends ServiceException {
+
+  public ServiceUnavailableException(String message) {
+    super(message);
+  }
+
+  public ServiceUnavailableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.service.trustframework;
 
 import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileConfig;
 
 import java.io.StringReader;
 import java.util.Collection;
@@ -55,6 +56,15 @@ public class TrustFrameworkRegistry {
    */
   private static final Pattern VALID_SPARQL_URI_PATTERN = Pattern.compile("^[^<>\\s\\n\\r]*$");
 
+  public static final String DEFAULT_API_VERSION = "1.0";
+  public static final int DEFAULT_TIMEOUT_SECONDS = 30;
+
+  // Property keys for deriving TrustFrameworkProfileConfig from bundle properties
+  public static final String CLIENT_TYPE = "client_type";
+  public static final String SERVICE_URL = "service_url";
+  public static final String API_VERSION = "api_version";
+  public static final String TIMEOUT_SECONDS = "timeout_seconds";
+
   private final Map<String, ResolvedRole> typeIndex;
   private final Map<String, TrustFrameworkBundle> bundleIndex;
   private final Set<String> activeProfileIds;
@@ -104,7 +114,7 @@ public class TrustFrameworkRegistry {
     }
     if (!ns.endsWith("/") && !ns.endsWith("#")) {
       throw new IllegalArgumentException(
-          "Bundle '" + config.id() + "' namespace '" + ns + "' must end with '/' or '#'");
+          "Bundle '%s' namespace '%s' must end with '/' or '#'".formatted(config.id(), ns));
     }
   }
 
@@ -147,6 +157,37 @@ public class TrustFrameworkRegistry {
    */
   public Optional<TrustFrameworkBundle> getBundle(String profileId) {
     return Optional.ofNullable(bundleIndex.get(profileId));
+  }
+
+  /**
+   * Derives a {@link TrustFrameworkProfileConfig} from the bundle registered under the given
+   * profile ID. Returns empty when no bundle is registered for that ID.
+   *
+   * <p>Fields absent from the bundle configuration fall back to safe defaults:
+   * {@code apiVersion} defaults to {@code DEFAULT_API_VERSION}, {@code timeoutSeconds} to {@code DEFAULT_TIMEOUT_SECONDS}.
+   *
+   * @param profileId the ID of the profile to look up
+   * @return an Optional containing the derived config, or empty if no bundle is registered
+   */
+  public Optional<TrustFrameworkProfileConfig> getProfileConfig(String profileId) {
+    return getBundle(profileId).map(bundle -> {
+      FrameworkBundleConfig cfg = bundle.config();
+      Map<String, String> props = cfg.properties();
+      String clientType = props.get(CLIENT_TYPE);
+      String serviceUrl = props.get(SERVICE_URL);
+      String rawApiVersion = props.get(API_VERSION);
+      String apiVersion = rawApiVersion != null ? rawApiVersion : DEFAULT_API_VERSION;
+      String rawTimeout = props.get(TIMEOUT_SECONDS);
+      int timeoutSeconds = rawTimeout != null ? Integer.parseInt(rawTimeout) : DEFAULT_TIMEOUT_SECONDS;
+      return new TrustFrameworkProfileConfig(
+          cfg.id(),
+          cfg.family(),
+          clientType,
+          serviceUrl,
+          apiVersion,
+          timeoutSeconds
+      );
+    });
   }
 
   /**

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
@@ -1,0 +1,127 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import com.nimbusds.jwt.JWTParser;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.ConflictException;
+import eu.xfsc.fc.core.exception.ServiceUnavailableException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Service;
+
+/**
+ * Orchestrates a single compliance check: resolves the profile, verifies the family is enabled,
+ * dispatches to the appropriate {@link TrustFrameworkClient}, and maps transport failures to
+ * HTTP-appropriate exceptions.
+ *
+ * <p>Unknown profile IDs throw {@link ClientException}. Disabled families throw
+ * {@link ConflictException}. Network timeouts bubble as {@link TimeoutException} (→ 504);
+ * other I/O failures bubble as {@link ServiceUnavailableException} (→ 503).
+ * {@link UnverifiableAttestation} is a first-class outcome produced by the client when the
+ * service returned a credential that could not be locally verified — it is not an error.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ComplianceCheckOrchestrator {
+
+  // MDC keys written for the duration of each compliance check so that all log lines
+  // from this thread — including nested calls into RestTemplate and client implementations —
+  // automatically carry asset and profile context without explicit parameter threading.
+  // With a structured/JSON log appender (e.g. Logstash encoder) these become first-class
+  // fields in every log event. To add more context: MDC.put(key, value) + MDC.remove(key)
+  // in a finally block; no log-pattern change needed for structured output.
+  private static final String MDC_ASSET_ID = "assetId";
+  private static final String MDC_PROFILE_ID = "frameworkProfileId";
+
+  private final TrustFrameworkRegistry registry;
+  private final TrustFrameworkService tfService;
+  private final TrustFrameworkClientRegistry clientRegistry;
+
+  /**
+   * Runs a compliance check for the given asset against the named trust-framework profile.
+   *
+   * @param assetId            identifier of the asset being checked
+   * @param frameworkProfileId profile to use for the check; must not be {@code null}
+   * @param assetPayload       raw credential payload forwarded to the compliance service; must not be {@code null}
+   * @return the compliance outcome; never {@code null}. Returns {@link UnverifiableAttestation}
+   *         when {@code assetPayload} is a parseable JWT whose {@code id} claim is non-blank and
+   *         does not equal {@code assetId}, without contacting the compliance service.
+   * @throws ClientException              when inputs are null, the profile is not registered,
+   *                                      or the resolved client type is unknown
+   * @throws ConflictException            when the profile's family is disabled
+   * @throws TimeoutException             when the compliance service did not respond in time
+   * @throws ServiceUnavailableException  when the compliance service could not be reached
+   */
+  public ComplianceCheckOutcome check(String assetId, String frameworkProfileId, String assetPayload) {
+    if (frameworkProfileId == null) {
+      throw new ClientException("frameworkProfileId must not be null");
+    }
+    if (assetPayload == null) {
+      throw new ClientException("assetPayload must not be null");
+    }
+
+    String vpId = extractVpId(assetPayload);
+    if (!vpId.isBlank() && !vpId.equals(assetId)) {
+      return new UnverifiableAttestation(
+          FailureCategory.UNVERIFIABLE_ATTESTATION,
+          assetPayload,
+          "VP id '%s' does not match requested asset id '%s'".formatted(vpId, assetId)
+      );
+    }
+
+    MDC.put(MDC_ASSET_ID, assetId);
+    MDC.put(MDC_PROFILE_ID, frameworkProfileId);
+    try {
+      return doCheck(frameworkProfileId, assetPayload);
+    } finally {
+      MDC.remove(MDC_ASSET_ID);
+      MDC.remove(MDC_PROFILE_ID);
+    }
+  }
+
+  private String extractVpId(String payload) {
+    try {
+      String value = JWTParser.parse(payload).getJWTClaimsSet().getStringClaim("id");
+      return value != null ? value : "";
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+  private ComplianceCheckOutcome doCheck(String frameworkProfileId, String assetPayload) {
+    TrustFrameworkProfileConfig config = registry.getProfileConfig(frameworkProfileId)
+        .orElseThrow(() -> new ClientException("Unknown trust-framework profile: " + frameworkProfileId));
+
+    if (!tfService.isEnabled(config.familyId())) {
+      throw new ConflictException("Trust-framework family is disabled: " + config.familyId());
+    }
+
+    TrustFrameworkClient client;
+    try {
+      client = clientRegistry.resolve(config.clientType());
+    } catch (IllegalArgumentException e) {
+      throw new ClientException("Unknown clientType: " + config.clientType(), e);
+    }
+
+    var credential = new ContentAccessorDirect(assetPayload);
+    ComplianceCheckOutcome result;
+    try {
+      result = client.check(credential, config);
+    } catch (ClientException | TimeoutException | ServiceUnavailableException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      log.error("Unexpected exception from compliance client", e);
+      throw new ServiceUnavailableException("Compliance client error: " + e.getMessage(), e);
+    }
+    if (result == null) {
+      throw new ServiceUnavailableException("Compliance client returned null for profile: " + frameworkProfileId);
+    }
+    return result;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOutcome.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOutcome.java
@@ -1,0 +1,17 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+/**
+ * Sealed result type for a trust-framework compliance check.
+ *
+ * <p>Permitted subtypes cover every possible outcome: an issued attestation credential,
+ * a trust-list membership entry, or a failure that could not be verified.
+ * Callers should use an exhaustive switch expression to dispatch on the concrete type.
+ */
+public sealed interface ComplianceCheckOutcome
+    permits IssuedAttestation, UnverifiableAttestation {
+
+  /**
+   * Returns {@code true} when the check produced a positive compliance result.
+   */
+  boolean compliant();
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStore.java
@@ -1,0 +1,36 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import eu.xfsc.fc.core.dao.validation.ValidationResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Write and read boundary for compliance check results.
+ *
+ * <p>Persists each {@link ComplianceCheckOutcome} as a {@link ValidationResult} record
+ * with {@code validatorType=TRUST_FRAMEWORK}, then exposes typed read-back by asset.
+ * This is a thin wrapper over {@link eu.xfsc.fc.core.service.validation.ValidationResultStore}
+ * and must never bypass it.</p>
+ */
+public interface ComplianceResultStore {
+
+  /**
+   * Persists the compliance outcome and returns the storage ID of the created record.
+   *
+   * @param assetId            IRI of the asset that was checked
+   * @param frameworkProfileId profile that performed the check (stored as first validator ID)
+   * @param familyId           trust-framework family (stored as second validator ID)
+   * @param outcome            the compliance outcome to persist; must not be {@code null}
+   * @return the ID of the stored record; never {@code null}
+   */
+  Long store(String assetId, String frameworkProfileId, String familyId, ComplianceCheckOutcome outcome);
+
+  /**
+   * Returns a paginated list of compliance results for the given asset ID.
+   *
+   * @param assetId  the asset IRI to query
+   * @param pageable paging and sorting parameters
+   * @return page of results; never {@code null}
+   */
+  Page<ValidationResult> findByAssetId(String assetId, Pageable pageable);
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStoreImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStoreImpl.java
@@ -1,0 +1,96 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import eu.xfsc.fc.core.dao.validation.ValidationResult;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.service.validation.ValidationResultRecord;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+/**
+ * Thin persistence wrapper that maps {@link ComplianceCheckOutcome} variants to
+ * {@link ValidationResultRecord} entries with {@code validatorType=TRUST_FRAMEWORK}.
+ *
+ * <p>Variant-specific fields are serialised to JSON in the {@code report} column.
+ * For issued attestations the raw credential JWT is stored; the issuing service is
+ * identified by the JWT's standard {@code iss} claim and need not be extracted separately.
+ * The report is always written; for issued attestations it carries positive evidence,
+ * not just error detail.</p>
+ */
+@Service
+@RequiredArgsConstructor
+public class ComplianceResultStoreImpl implements ComplianceResultStore {
+
+  private static final String FIELD_FAILURE_CATEGORY = "failureCategory";
+  private static final String FIELD_ATTESTATION_CREDENTIAL = "attestationCredential";
+  private static final String FIELD_VERIFICATION_ERROR = "verificationError";
+  private static final String FIELD_RAW_ATTESTATION = "rawAttestation";
+
+  private static final int MAX_RAW_ATTESTATION_SIZE = 65_536;
+  private static final String TRUNCATION_MARKER = "...[TRUNCATED]";
+
+  private final ValidationResultStore validationResultStore;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public Long store(String assetId, String frameworkProfileId, String familyId,
+                    ComplianceCheckOutcome outcome) {
+    String report = buildReport(outcome);
+    var record = new ValidationResultRecord(
+        List.of(assetId),
+        List.of(frameworkProfileId, familyId),
+        ValidatorType.TRUST_FRAMEWORK,
+        outcome.compliant(),
+        Instant.now(),
+        report
+    );
+    return validationResultStore.store(record);
+  }
+
+  @Override
+  public Page<ValidationResult> findByAssetId(String assetId, Pageable pageable) {
+    return validationResultStore.getByAssetId(assetId, pageable);
+  }
+
+  private static String truncate(String value) {
+    if (value.length() <= MAX_RAW_ATTESTATION_SIZE) {
+      return value;
+    }
+    return value.substring(0, MAX_RAW_ATTESTATION_SIZE) + TRUNCATION_MARKER;
+  }
+
+  private String buildReport(ComplianceCheckOutcome outcome) {
+    ObjectNode node = objectMapper.createObjectNode();
+    switch (outcome) {
+      case IssuedAttestation ia -> {
+        if (ia.attestationCredential() != null) {
+          node.put(FIELD_ATTESTATION_CREDENTIAL, ia.attestationCredential());
+        }
+      }
+      case UnverifiableAttestation ua -> {
+        node.put(FIELD_FAILURE_CATEGORY, ua.failureCategory().name());
+        if (ua.rawAttestation() != null) {
+          node.put(FIELD_RAW_ATTESTATION, truncate(ua.rawAttestation()));
+        }
+        if (ua.verificationError() != null) {
+          node.put(FIELD_VERIFICATION_ERROR, ua.verificationError());
+        }
+      }
+    }
+    try {
+      return objectMapper.writeValueAsString(node);
+    } catch (JsonProcessingException e) {
+      // ObjectNode serialisation never fails in practice
+      throw new IllegalStateException("Failed to serialise compliance report", e);
+    }
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/FailureCategory.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/FailureCategory.java
@@ -1,0 +1,8 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+/**
+ * Classifies the reason a compliance check could not produce a positive outcome.
+ */
+public enum FailureCategory {
+  UNVERIFIABLE_ATTESTATION
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/GxdchComplianceClient.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/GxdchComplianceClient.java
@@ -1,0 +1,157 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
+import eu.xfsc.fc.core.exception.ServiceUnavailableException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * {@link TrustFrameworkClient} implementation for the GXDCH Loire (V2) compliance API.
+ *
+ * <p>Posts a JWT Verifiable Presentation to the Loire standard-compliance endpoint and maps
+ * the response to a {@link ComplianceCheckOutcome}.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GxdchComplianceClient implements TrustFrameworkClient {
+
+  private static final String CLIENT_TYPE = "gxdch-loire";
+  private static final String COMPLIANCE_PATH = "/api/credential-offers/standard-compliance";
+
+  private final ConcurrentHashMap<Integer, RestTemplate> restTemplateCache = new ConcurrentHashMap<>();
+
+  @Override
+  public String clientType() {
+    return CLIENT_TYPE;
+  }
+
+  /**
+   * Submits the VP JWT to the Loire compliance endpoint and returns the outcome.
+   *
+   * <p>Short-circuits to {@link UnverifiableAttestation} with
+   * {@link FailureCategory#UNVERIFIABLE_ATTESTATION} when the VP JWT payload has no {@code id}
+   * claim, without sending any HTTP request.
+   *
+   * <p>On HTTP 201, the response body is a compliance credential JWT mapped to
+   * {@link IssuedAttestation}. A 201 body that is not a parseable JWT maps to
+   * {@link UnverifiableAttestation} rather than returning null-field attestation fields.
+   * On HTTP 400, the asset is non-compliant and an {@link UnverifiableAttestation} is returned.
+   * HTTP 5xx and I/O exceptions bubble to the caller (orchestrator maps them to
+   * {@link eu.xfsc.fc.core.exception.ServiceUnavailableException} /
+   * {@link eu.xfsc.fc.core.exception.TimeoutException}).
+   *
+   * @param credential the VP JWT to submit
+   * @param config     profile configuration providing the Loire service URL and timeout
+   * @return the compliance check outcome; never {@code null}
+   */
+  @Override
+  public ComplianceCheckOutcome check(ContentAccessor credential, TrustFrameworkProfileConfig config) {
+    String vpJwt = credential.getContentAsString();
+    String assetId = extractJwtClaim(vpJwt, "id");
+    if (assetId.isBlank()) {
+      return new UnverifiableAttestation(
+          FailureCategory.UNVERIFIABLE_ATTESTATION,
+          vpJwt,
+          "VP JWT has no 'id' claim"
+      );
+    }
+
+    String serviceUrl = config.serviceUrl().replaceAll("/+$", "");
+    // URI.create() preserves existing percent-encoding; Apache HttpClient uses raw form as-is.
+    URI uri = URI.create(serviceUrl + COMPLIANCE_PATH
+        + "?vcid=" + URLEncoder.encode(assetId, StandardCharsets.UTF_8));
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.TEXT_PLAIN);
+    HttpEntity<String> request = new HttpEntity<>(vpJwt, headers);
+
+    RestTemplate rest = buildRestTemplate(config.timeoutSeconds());
+    try {
+      var response = rest.postForEntity(uri, request, String.class);
+      return parseComplianceJwt(response.getBody());
+    } catch (HttpClientErrorException.BadRequest e) {
+      return new UnverifiableAttestation(
+          FailureCategory.UNVERIFIABLE_ATTESTATION,
+          e.getResponseBodyAsString(),
+          e.getStatusText()
+      );
+    } catch (ResourceAccessException e) {
+      if (e.getCause() instanceof SocketTimeoutException) {
+        throw new TimeoutException("Compliance service timed out: " + e.getMessage());
+      }
+      log.error("Compliance service unreachable", e);
+      throw new ServiceUnavailableException("Compliance service unreachable: " + e.getMessage(), e);
+    } catch (HttpServerErrorException e) {
+      log.error("Compliance service returned server error", e);
+      throw new ServiceUnavailableException("Compliance service error: " + e.getStatusCode(), e);
+    }
+  }
+
+  private RestTemplate buildRestTemplate(int timeoutSeconds) {
+    return restTemplateCache.computeIfAbsent(timeoutSeconds, t -> {
+      var timeout = Duration.ofSeconds(t);
+      var factory = new HttpComponentsClientHttpRequestFactory();
+      factory.setConnectTimeout(timeout);
+      factory.setReadTimeout(timeout);
+      return new RestTemplate(factory);
+    });
+  }
+
+  private String extractJwtClaim(String jwt, String claim) {
+    try {
+      JWTClaimsSet claims = readJwtPayload(jwt);
+      String value = claims.getStringClaim(claim);
+      return value != null ? value : "";
+    } catch (Exception e) {
+      log.error("Failed to extract claim '{}' from JWT", claim, e);
+      return "";
+    }
+  }
+
+  private ComplianceCheckOutcome parseComplianceJwt(String jwt) {
+    try {
+      JWTClaimsSet claims = readJwtPayload(jwt);
+      // Signature not verified: the compliance credential arrives over HTTPS directly from GXDCH;
+      // the transport layer provides authenticity. The raw JWT is stored as-is for downstream
+      // relying parties who may verify it independently.
+      Instant validUntil = claims.getExpirationTime() != null
+          ? claims.getExpirationTime().toInstant()
+          : null;
+      return new IssuedAttestation(jwt, validUntil);
+    } catch (Exception e) {
+      log.warn("Failed to parse compliance credential JWT", e);
+      return new UnverifiableAttestation(
+          FailureCategory.UNVERIFIABLE_ATTESTATION,
+          jwt,
+          "Compliance credential is not a parseable JWT"
+      );
+    }
+  }
+
+  private JWTClaimsSet readJwtPayload(String jwt) throws ParseException {
+    return JWTParser.parse(jwt).getJWTClaimsSet();
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/IssuedAttestation.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/IssuedAttestation.java
@@ -1,0 +1,22 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import java.time.Instant;
+
+/**
+ * Outcome indicating that the trust framework issued a verifiable attestation credential
+ * for the asset under check.
+ *
+ * @param attestationCredential raw attestation credential string (JWT), or {@code null} if not
+ *                              retained; the JWT's {@code iss} claim identifies the issuing service
+ * @param credentialValidUntil  expiry timestamp of the issued credential; {@code null} if the
+ *                              credential carries no {@code exp} claim
+ */
+public record IssuedAttestation(
+    String attestationCredential, Instant credentialValidUntil
+) implements ComplianceCheckOutcome {
+
+  @Override
+  public boolean compliant() {
+    return true;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClient.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClient.java
@@ -1,0 +1,27 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+
+/**
+ * SPI for trust-framework compliance check implementations.
+ *
+ * <p>Each implementation handles one client type (e.g. {@code "gaiax-ipfs"},
+ * {@code "train"}). Implementations are registered via {@link TrustFrameworkClientRegistry}.
+ */
+public interface TrustFrameworkClient {
+
+  /**
+   * Returns the client-type key that this implementation handles.
+   * Must match the {@code clientType} field in {@link TrustFrameworkProfileConfig}.
+   */
+  String clientType();
+
+  /**
+   * Performs a compliance check for the given credential against the specified profile configuration.
+   *
+   * @param credential the credential payload to check (verifiable presentation or self-description)
+   * @param config     resolved profile configuration providing endpoint and trust-list parameters
+   * @return the outcome of the compliance check; never {@code null}
+   */
+  ComplianceCheckOutcome check(ContentAccessor credential, TrustFrameworkProfileConfig config);
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClientRegistry.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClientRegistry.java
@@ -1,0 +1,19 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+/**
+ * Registry that maps client-type keys to {@link TrustFrameworkClient} implementations.
+ *
+ * <p>Callers resolve the correct client by passing the {@code clientType} from a
+ * {@link TrustFrameworkProfileConfig} to {@link #resolve(String)}.
+ */
+public interface TrustFrameworkClientRegistry {
+
+  /**
+   * Returns the {@link TrustFrameworkClient} registered for the given client-type key.
+   *
+   * @param clientType the client-type key to look up
+   * @return the matching client implementation; never {@code null}
+   * @throws IllegalArgumentException when no client is registered for the given type
+   */
+  TrustFrameworkClient resolve(String clientType);
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClientRegistryImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkClientRegistryImpl.java
@@ -1,0 +1,43 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Spring-managed registry that maps client-type keys to {@link TrustFrameworkClient}
+ * implementations. Discovers all beans implementing {@link TrustFrameworkClient} and registers
+ * them by their {@link TrustFrameworkClient#clientType()} key.
+ */
+@Slf4j
+@Service
+public class TrustFrameworkClientRegistryImpl implements TrustFrameworkClientRegistry {
+
+  private final Map<String, TrustFrameworkClient> clients;
+
+  public TrustFrameworkClientRegistryImpl(List<TrustFrameworkClient> clientBeans) {
+    this.clients = clientBeans.stream()
+        .collect(Collectors.toMap(
+            TrustFrameworkClient::clientType,
+            c -> c,
+            (a, b) -> {
+              throw new IllegalStateException(
+                  "Duplicate TrustFrameworkClient for type: " + a.clientType());
+            }
+        ));
+    log.info("Registered {} trust-framework clients: {}", clients.size(), clients.keySet());
+  }
+
+  @Override
+  public TrustFrameworkClient resolve(String clientType) {
+    TrustFrameworkClient client = clients.get(clientType);
+    if (client == null) {
+      throw new IllegalArgumentException(
+          "No client registered for type: " + clientType + ". Available: " + clients.keySet());
+    }
+    return client;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkProfileConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/TrustFrameworkProfileConfig.java
@@ -1,0 +1,22 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+/**
+ * Resolved configuration for a single trust-framework profile, derived from the bundle
+ * metadata and used when invoking a {@link TrustFrameworkClient}.
+ *
+ * @param frameworkProfileId unique identifier of the trust-framework profile
+ * @param familyId           family identifier grouping related profiles
+ * @param clientType         key selecting the {@link TrustFrameworkClient} implementation
+ * @param serviceUrl         base URL of the compliance service endpoint
+ * @param apiVersion         API version string sent to the compliance service
+ * @param timeoutSeconds     per-request timeout in seconds
+ */
+public record TrustFrameworkProfileConfig(
+    String frameworkProfileId,
+    String familyId,
+    String clientType,
+    String serviceUrl,
+    String apiVersion,
+    int timeoutSeconds
+) {
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/UnverifiableAttestation.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/UnverifiableAttestation.java
@@ -1,0 +1,20 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+/**
+ * Outcome indicating that the attestation presented by the asset could not be verified.
+ *
+ * @param failureCategory   the category of failure that prevented verification
+ * @param rawAttestation    the raw attestation payload that was inspected
+ * @param verificationError human-readable description of why verification failed
+ */
+public record UnverifiableAttestation(
+    FailureCategory failureCategory,
+    String rawAttestation,
+    String verificationError
+) implements ComplianceCheckOutcome {
+
+  @Override
+  public boolean compliant() {
+    return false;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriter.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/validation/ValidationResultGraphWriter.java
@@ -99,4 +99,3 @@ public class ValidationResultGraphWriter {
   }
 
 }
-

--- a/fc-service-core/src/main/resources/trustframeworks/mock-2026/framework.yaml
+++ b/fc-service-core/src/main/resources/trustframeworks/mock-2026/framework.yaml
@@ -1,0 +1,22 @@
+# Mock Trust Framework bundle — for local development and integration testing only
+#
+# This bundle is intentionally minimal: no ontology, no SHACL shapes.
+# validation_type is "shacl" so the bundle is indexed by TrustFrameworkRegistry,
+# but there are no shape files to validate against.
+#
+# serviceUrl should be overridden per environment (e.g. WireMock container in compose).
+
+id: mock-2026
+family: mock
+namespace: "https://example.com/mock/2026#"
+validation_type: shacl
+
+roles:
+  MockParticipant:
+    additional_roots: [ ]
+    types: [ ]
+
+properties:
+  client_type: gxdch-loire
+  api_version: loire
+  service_url: "http://localhost"

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
@@ -1,0 +1,181 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.ConflictException;
+import eu.xfsc.fc.core.exception.ServiceUnavailableException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
+
+/**
+ * Unit tests for {@link ComplianceCheckOrchestrator}. All dependencies are mocked.
+ * No Spring context required.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceCheckOrchestratorTest {
+
+  private static final String PROFILE_ID = "mock-2026";
+  private static final String FAMILY_ID = "mock";
+  private static final String ASSET_ID = "https://example.com/asset-001";
+  private static final String ASSET_PAYLOAD = "test-asset-payload";
+  // JWT with payload {"id":"urn:example:test-asset-001"}
+  private static final String VP_JWT_ASSET_ID = "urn:example:test-asset-001";
+  private static final String VP_JWT_MATCHING =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+          + ".eyJpZCI6InVybjpleGFtcGxlOnRlc3QtYXNzZXQtMDAxIn0.";
+  // JWT with payload {"id":"urn:example:different-asset"} — id differs from ASSET_ID
+  private static final String VP_JWT_MISMATCHED_ID =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+          + ".eyJpZCI6InVybjpleGFtcGxlOmRpZmZlcmVudC1hc3NldCJ9.";
+  private static final TrustFrameworkProfileConfig MOCK_CONFIG = new TrustFrameworkProfileConfig(
+      PROFILE_ID, FAMILY_ID, "gxdch-loire", "http://localhost", "loire", 30);
+
+  @Mock
+  private TrustFrameworkRegistry registry;
+
+  @Mock
+  private TrustFrameworkService tfService;
+
+  @Mock
+  private TrustFrameworkClientRegistry clientRegistry;
+
+  @Mock
+  private TrustFrameworkClient mockClient;
+
+  private ComplianceCheckOrchestrator orchestrator;
+
+  @BeforeEach
+  void setUp() {
+    orchestrator = new ComplianceCheckOrchestrator(registry, tfService, clientRegistry);
+  }
+
+  @Test
+  void check_nullFrameworkProfileId_throwsClientException() {
+    assertThrows(ClientException.class,
+        () -> orchestrator.check(ASSET_ID, null, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_nullAssetPayload_throwsClientException() {
+    assertThrows(ClientException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, null));
+  }
+
+  @Test
+  void check_unknownProfileId_throwsClientException() {
+    when(registry.getProfileConfig("unknown-id")).thenReturn(Optional.empty());
+
+    assertThrows(ClientException.class,
+        () -> orchestrator.check(ASSET_ID, "unknown-id", ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_familyDisabled_throwsConflictException() {
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(false);
+
+    assertThrows(ConflictException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_clientRegistryThrowsIllegalArgument_throwsClientException() {
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenThrow(new IllegalArgumentException("unknown clientType"));
+
+    assertThrows(ClientException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_familyEnabled_delegatesToClientAndReturnsOutcome() {
+    var expected = new IssuedAttestation("some-jwt", null);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenReturn(expected);
+
+    ComplianceCheckOutcome result = orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD);
+
+    assertInstanceOf(IssuedAttestation.class, result);
+  }
+
+  @Test
+  void check_clientThrowsTimeoutException_propagates() {
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenThrow(new TimeoutException("timed out"));
+
+    assertThrows(TimeoutException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_clientThrowsServiceUnavailableException_propagates() {
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenThrow(new ServiceUnavailableException("unreachable"));
+
+    assertThrows(ServiceUnavailableException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_clientReturnsNull_throwsServiceUnavailableException() {
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenReturn(null);
+
+    assertThrows(ServiceUnavailableException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+
+  @Test
+  void check_vpIdMismatch_returnsUnverifiableAttestation() {
+    ComplianceCheckOutcome outcome = orchestrator.check(ASSET_ID, PROFILE_ID, VP_JWT_MISMATCHED_ID);
+
+    assertInstanceOf(UnverifiableAttestation.class, outcome);
+  }
+
+  @Test
+  void check_vpIdMatches_delegatesToClient() {
+    var expected = new IssuedAttestation("cred-jwt", null);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenReturn(expected);
+
+    ComplianceCheckOutcome result = orchestrator.check(VP_JWT_ASSET_ID, PROFILE_ID, VP_JWT_MATCHING);
+
+    assertInstanceOf(IssuedAttestation.class, result);
+  }
+
+  @Test
+  void check_clientThrowsClientException_propagates() {
+    var cause = new ClientException("business error from compliance service");
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("gxdch-loire")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenThrow(cause);
+
+    assertThrows(ClientException.class,
+        () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOutcomeTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOutcomeTest.java
@@ -1,0 +1,53 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure unit tests for the {@link ComplianceCheckOutcome} sealed hierarchy.
+ * No Spring context required.
+ */
+class ComplianceCheckOutcomeTest {
+
+  @Test
+  void issuedAttestation_isCompliant() {
+    var outcome = new IssuedAttestation(null, Instant.parse("2025-12-31T00:00:00Z"));
+
+    assertTrue(outcome.compliant());
+    assertNull(outcome.attestationCredential());
+  }
+
+  @Test
+  void unverifiableAttestation_isNotCompliant_withCategory() {
+    var outcome = new UnverifiableAttestation(
+        FailureCategory.UNVERIFIABLE_ATTESTATION,
+        "{\"raw\": \"jwt-here\"}",
+        "Signature verification failed"
+    );
+
+    assertFalse(outcome.compliant());
+    assertEquals(FailureCategory.UNVERIFIABLE_ATTESTATION, outcome.failureCategory());
+    assertEquals("{\"raw\": \"jwt-here\"}", outcome.rawAttestation());
+    assertEquals("Signature verification failed", outcome.verificationError());
+  }
+
+  @Test
+  void sealedInterface_exhaustivePatternMatch() {
+    // Compile-time exhaustiveness: will not compile if a new permitted subtype is added
+    // without updating the switch.
+    ComplianceCheckOutcome outcome = new IssuedAttestation(null, Instant.now());
+
+    String label = switch (outcome) {
+      case IssuedAttestation ia -> "issued";
+      case UnverifiableAttestation ua -> "unverifiable";
+    };
+
+    assertEquals("issued", label);
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStoreImplTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceResultStoreImplTest.java
@@ -1,0 +1,134 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.dao.validation.ValidationResult;
+import eu.xfsc.fc.core.service.validation.ValidationResultRecord;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+/**
+ * Unit tests for {@link ComplianceResultStoreImpl}.
+ * Pure Mockito — no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class ComplianceResultStoreImplTest {
+
+  @Mock
+  private ValidationResultStore validationResultStore;
+
+  private ComplianceResultStoreImpl subject;
+
+  @BeforeEach
+  void setUp() {
+    subject = new ComplianceResultStoreImpl(validationResultStore, new ObjectMapper());
+  }
+
+  @Test
+  void store_issuedAttestation_delegatesWithConformsTrueAndTrustFrameworkType() {
+    var outcome = new IssuedAttestation("{\"vc\":\"jwt\"}", Instant.parse("2025-12-31T00:00:00Z"));
+    when(validationResultStore.store(any())).thenReturn(42L);
+
+    Long id = subject.store("asset:1", "gaia-x-2511", "gaia-x", outcome);
+
+    assertEquals(42L, id);
+    ArgumentCaptor<ValidationResultRecord> captor = forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+    ValidationResultRecord record = captor.getValue();
+    assertEquals(List.of("asset:1"), record.assetIds());
+    assertEquals(List.of("gaia-x-2511", "gaia-x"), record.validatorIds());
+    assertEquals(ValidatorType.TRUST_FRAMEWORK, record.validatorType());
+    assertTrue(record.conforms());
+    assertNotNull(record.validatedAt());
+    assertNotNull(record.report());
+    assertTrue(record.report().contains("attestationCredential"));
+  }
+
+  @Test
+  void store_unverifiableAttestation_delegatesWithConformsFalseAndFailureCategory() {
+    var outcome = new UnverifiableAttestation(
+        FailureCategory.UNVERIFIABLE_ATTESTATION,
+        "{\"raw\":\"jwt\"}",
+        "Signature verification failed"
+    );
+    when(validationResultStore.store(any())).thenReturn(99L);
+
+    Long id = subject.store("asset:2", "gaia-x-2511", "gaia-x", outcome);
+
+    assertEquals(99L, id);
+    ArgumentCaptor<ValidationResultRecord> captor = forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+    ValidationResultRecord record = captor.getValue();
+    assertEquals(ValidatorType.TRUST_FRAMEWORK, record.validatorType());
+    assertFalse(record.conforms());
+    assertNotNull(record.report());
+    assertTrue(record.report().contains("UNVERIFIABLE_ATTESTATION"));
+  }
+
+  @Test
+  void store_unverifiableAttestation_rawAttestationAtSizeLimit_storedVerbatim() {
+    String atLimit = "x".repeat(65_536);
+    var outcome = new UnverifiableAttestation(
+        FailureCategory.UNVERIFIABLE_ATTESTATION, atLimit, null);
+    when(validationResultStore.store(any())).thenReturn(1L);
+
+    subject.store("asset:3", "gaia-x-2511", "gaia-x", outcome);
+
+    ArgumentCaptor<ValidationResultRecord> captor = forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+    String report = captor.getValue().report();
+    assertFalse(report.contains("[TRUNCATED]"));
+    assertTrue(report.contains(atLimit));
+  }
+
+  @Test
+  void store_unverifiableAttestation_rawAttestationExceedsLimit_truncatedWithMarker() {
+    String oversized = "x".repeat(65_537);
+    var outcome = new UnverifiableAttestation(
+        FailureCategory.UNVERIFIABLE_ATTESTATION, oversized, null);
+    when(validationResultStore.store(any())).thenReturn(1L);
+
+    subject.store("asset:4", "gaia-x-2511", "gaia-x", outcome);
+
+    ArgumentCaptor<ValidationResultRecord> captor = forClass(ValidationResultRecord.class);
+    verify(validationResultStore).store(captor.capture());
+    String report = captor.getValue().report();
+    assertTrue(report.contains("...[TRUNCATED]"));
+    assertFalse(report.contains(oversized));
+  }
+
+  @Test
+  void findByAssetId_delegatesToValidationResultStore() {
+    var pageable = PageRequest.of(0, 10);
+    Page<ValidationResult> expected = new PageImpl<>(List.of());
+    String value = "asset:1";
+    when(validationResultStore.getByAssetId(eq(value), eq(pageable))).thenReturn(expected);
+
+    Page<ValidationResult> result = subject.findByAssetId(value, pageable);
+
+    assertEquals(expected, result);
+    verify(validationResultStore).getByAssetId(value, pageable);
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/GxdchComplianceClientTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/GxdchComplianceClientTest.java
@@ -1,0 +1,208 @@
+package eu.xfsc.fc.core.service.trustframework.compliance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import eu.xfsc.fc.core.exception.ServiceUnavailableException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Unit tests for {@link GxdchComplianceClient} against a local HTTP stub.
+ * No Spring context required.
+ */
+class GxdchComplianceClientTest {
+
+  // JWT with payload {"id":"https://example.com/asset-001"} — sent as VP body
+  private static final String TEST_VP_JWT =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+      + ".eyJpZCI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYXNzZXQtMDAxIn0.";
+
+  // JWT with payload {} — no id claim
+  private static final String VP_JWT_NO_ID =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.";
+
+  // Compliance credential JWT with iss=did:web:compliance.example, exp=1767223999
+  private static final String CANNED_CC_JWT =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+      + ".eyJpc3MiOiJkaWQ6d2ViOmNvbXBsaWFuY2UuZXhhbXBsZSIsImV4cCI6MTc2NzIyMzk5OX0.";
+
+  private MockWebServer server;
+  private GxdchComplianceClient client;
+  private TrustFrameworkProfileConfig config;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    server = new MockWebServer();
+    server.start();
+
+    client = new GxdchComplianceClient();
+
+    config = new TrustFrameworkProfileConfig(
+        "mock-2026",
+        "mock",
+        "gxdch-loire",
+        server.url("").toString(),
+        "loire",
+        30
+    );
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    server.shutdown();
+  }
+
+  @Test
+  void clientType_returns_gxdchLoire() {
+    assertEquals("gxdch-loire", client.clientType());
+  }
+
+  @Test
+  void check_201WithComplianceJwt_returnsIssuedAttestation() throws InterruptedException {
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(201)
+        .setBody(CANNED_CC_JWT)
+        .addHeader("Content-Type", "text/plain"));
+
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    ComplianceCheckOutcome outcome = client.check(credential, config);
+
+    assertInstanceOf(IssuedAttestation.class, outcome);
+    assertTrue(outcome.compliant());
+    var attestation = (IssuedAttestation) outcome;
+    assertEquals(CANNED_CC_JWT, attestation.attestationCredential());
+
+    RecordedRequest req = server.takeRequest();
+    String expectedVcid = URLEncoder.encode("https://example.com/asset-001", StandardCharsets.UTF_8);
+    assertTrue(req.getPath().contains("/api/credential-offers/standard-compliance"),
+        "Path must include Loire compliance endpoint");
+    assertTrue(req.getPath().contains("vcid=" + expectedVcid),
+        "vcid query param must be single-percent-encoded");
+    assertEquals(TEST_VP_JWT, req.getBody().readUtf8());
+  }
+
+  @Test
+  void check_400Response_returnsUnverifiableAttestation() {
+
+    final String errorBody = "Invalid Certificate: mock non-compliant asset";
+    server.enqueue(new MockResponse()
+        .setResponseCode(400)
+        .setBody(errorBody)
+        .addHeader("Content-Type", "text/plain"));
+
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    ComplianceCheckOutcome outcome = client.check(credential, config);
+
+    assertInstanceOf(UnverifiableAttestation.class, outcome);
+    assertFalse(outcome.compliant());
+    var unverifiable = (UnverifiableAttestation) outcome;
+    assertEquals(FailureCategory.UNVERIFIABLE_ATTESTATION, unverifiable.failureCategory());
+    assertEquals(errorBody, unverifiable.rawAttestation());
+  }
+
+  @Test
+  void check_vpJwtWithNoIdClaim_returnsUnverifiableAttestation_withoutHttpCall() {
+
+    var credential = new ContentAccessorDirect(VP_JWT_NO_ID);
+
+    ComplianceCheckOutcome outcome = client.check(credential, config);
+
+    assertInstanceOf(UnverifiableAttestation.class, outcome);
+    assertFalse(outcome.compliant());
+    var unverifiable = (UnverifiableAttestation) outcome;
+    assertEquals(FailureCategory.UNVERIFIABLE_ATTESTATION, unverifiable.failureCategory());
+    assertEquals(VP_JWT_NO_ID, unverifiable.rawAttestation());
+    assertEquals("VP JWT has no 'id' claim", unverifiable.verificationError());
+    assertEquals(0, server.getRequestCount(), "No HTTP request must be sent for missing id claim");
+  }
+
+  @Test
+  void check_slowUpstream_throwsTimeoutException() {
+
+    server.enqueue(new MockResponse()
+        .setBodyDelay(3, TimeUnit.SECONDS)
+        .setResponseCode(201)
+        .setBody(CANNED_CC_JWT));
+
+    var shortTimeoutConfig = new TrustFrameworkProfileConfig(
+        "mock-2026", "mock", "gxdch-loire",
+        server.url("").toString(), "loire", 1
+    );
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    assertThrows(TimeoutException.class, () -> client.check(credential, shortTimeoutConfig));
+  }
+
+  @Test
+  void check_5xxResponse_throwsServiceUnavailableException() {
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(500)
+        .setBody("Internal Server Error"));
+
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    assertThrows(ServiceUnavailableException.class, () -> client.check(credential, config));
+  }
+
+  @Test
+  void check_serviceUrlWithTrailingSlash_stripsTrailingSlash() throws InterruptedException {
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(201)
+        .setBody(CANNED_CC_JWT)
+        .addHeader("Content-Type", "text/plain"));
+
+    var trailingSlashConfig = new TrustFrameworkProfileConfig(
+        "mock-2026", "mock", "gxdch-loire",
+        server.url("") + "/", "loire", 30
+    );
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    assertInstanceOf(IssuedAttestation.class, client.check(credential, trailingSlashConfig),
+        "Expected HTTP request to be made and compliance credential returned");
+
+    RecordedRequest req = server.takeRequest(1, TimeUnit.SECONDS);
+    assertNotNull(req, "Expected an HTTP request to be recorded");
+    assertTrue(req.getPath().startsWith("/api/credential-offers/standard-compliance"),
+        "Path must not have double slash from trailing serviceUrl");
+  }
+
+  @Test
+  void check_malformedComplianceJwtOn201_returnsUnverifiableAttestation() {
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(201)
+        .setBody("not-a-jwt")
+        .addHeader("Content-Type", "text/plain"));
+
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    ComplianceCheckOutcome outcome = client.check(credential, config);
+
+    assertInstanceOf(UnverifiableAttestation.class, outcome);
+    assertFalse(outcome.compliant());
+    var unverifiable = (UnverifiableAttestation) outcome;
+    assertEquals(FailureCategory.UNVERIFIABLE_ATTESTATION, unverifiable.failureCategory());
+    assertEquals("Compliance credential is not a parseable JWT", unverifiable.verificationError());
+  }
+}

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -99,6 +99,11 @@ public class SecurityConfig {
           .requestMatchers(HttpMethod.POST, "/assets").hasAnyRole(ASSET_CREATE, ADMIN_ALL)
           .requestMatchers(HttpMethod.DELETE, "/assets/*").hasAnyRole(ASSET_DELETE, ADMIN_ALL)
 
+          // Compliance check APIs
+          .requestMatchers(HttpMethod.POST, "/assets/*/compliance-check").hasAnyRole(ASSET_UPDATE, ADMIN_ALL)
+          .requestMatchers(HttpMethod.GET, "/assets/*/compliance-checks").hasAnyRole(ASSET_READ, ADMIN_ALL)
+          .requestMatchers(HttpMethod.GET, "/trust-frameworks").authenticated()
+
           // Validation result read APIs
           .requestMatchers(HttpMethod.GET, "/validations/**").hasAnyRole(ASSET_READ, ADMIN_ALL)
 

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/handler/RestExceptionHandler.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/handler/RestExceptionHandler.java
@@ -21,6 +21,7 @@ import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.GraphStoreDisabledException;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.exception.ServerException;
+import eu.xfsc.fc.core.exception.ServiceUnavailableException;
 import eu.xfsc.fc.core.exception.TimeoutException;
 import eu.xfsc.fc.core.exception.UnsupportedQueryLanguageException;
 import eu.xfsc.fc.core.exception.VerificationException;
@@ -133,6 +134,18 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     log.info("handleGraphStoreDisabledException; error: {}", exception.getMessage());
     return new ResponseEntity<>(
         new Error("graph_store_disabled", exception.getMessage()), SERVICE_UNAVAILABLE);
+  }
+
+  /**
+   * Method handles the ServiceUnavailableException.
+   *
+   * @param exception Thrown ServiceUnavailableException.
+   * @return The custom Federated Catalogue application error with status code 503.
+   */
+  @ExceptionHandler({ServiceUnavailableException.class})
+  protected ResponseEntity<Error> handleServiceUnavailableException(ServiceUnavailableException exception) {
+    log.warn("handleServiceUnavailableException; error: {}", exception.getMessage(), exception);
+    return new ResponseEntity<>(new Error("service_unavailable", exception.getMessage()), SERVICE_UNAVAILABLE);
   }
 
   /**

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/ComplianceCheckService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/ComplianceCheckService.java
@@ -1,0 +1,107 @@
+package eu.xfsc.fc.server.service;
+
+import java.util.List;
+
+import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
+import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileConfig;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import eu.xfsc.fc.api.generated.model.ComplianceCheckRequest;
+import eu.xfsc.fc.api.generated.model.ComplianceCheckResult;
+import eu.xfsc.fc.api.generated.model.StoredValidationResult;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPublicEntry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceCheckOrchestrator;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceCheckOutcome;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceResultStore;
+import eu.xfsc.fc.core.service.trustframework.compliance.IssuedAttestation;
+import eu.xfsc.fc.core.service.trustframework.compliance.UnverifiableAttestation;
+import eu.xfsc.fc.server.generated.controller.ComplianceApiDelegate;
+import eu.xfsc.fc.server.util.OffsetBasedPageRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * HTTP delegate for compliance check endpoints. Orchestrates a compliance check,
+ * persists the result, and maps outcomes to API DTOs.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ComplianceCheckService implements ComplianceApiDelegate {
+
+  private final ComplianceCheckOrchestrator orchestrator;
+  private final ComplianceResultStore resultStore;
+  private final TrustFrameworkService trustFrameworkService;
+  private final TrustFrameworkRegistry registry;
+
+  @Override
+  public ResponseEntity<ComplianceCheckResult> runComplianceCheck(String assetId,
+                                                                  ComplianceCheckRequest request) {
+    log.debug("runComplianceCheck; assetId={}, frameworkProfileId={}", assetId,
+        request.getFrameworkProfileId());
+
+    ComplianceCheckOutcome outcome = orchestrator.check(assetId, request.getFrameworkProfileId(),
+        request.getCredential());
+
+    String familyId = registry.getProfileConfig(request.getFrameworkProfileId())
+        .map(TrustFrameworkProfileConfig::familyId)
+        .orElse(request.getFrameworkProfileId());
+
+    resultStore.store(assetId, request.getFrameworkProfileId(), familyId, outcome);
+
+    return ResponseEntity.ok(toDto(outcome));
+  }
+
+  @Override
+  public ResponseEntity<List<StoredValidationResult>> getComplianceChecks(String assetId,
+                                                                          Integer offset, Integer limit) {
+    log.debug("getComplianceChecks; assetId={}", assetId);
+
+    int effectiveOffset = offset != null ? offset : 0;
+    int effectiveLimit = limit != null ? limit : 100;
+
+    List<StoredValidationResult> results =
+        resultStore.findByAssetId(assetId,
+                new OffsetBasedPageRequest(effectiveOffset, effectiveLimit))
+            .stream()
+            .map(ValidationResultMapper::toDto)
+            .toList();
+
+    return ResponseEntity.ok(results);
+  }
+
+  @Override
+  public ResponseEntity<List<TrustFrameworkPublicEntry>> getTrustFrameworksPublic() {
+    log.debug("getTrustFrameworksPublic");
+
+    var activeBundles = registry.getActiveBundles();
+    List<TrustFrameworkPublicEntry> entries = trustFrameworkService.findAll().stream()
+        .filter(TrustFrameworkConfig::enabled)
+        .map(cfg -> {
+          List<String> profiles = activeBundles.stream()
+              .filter(bundle -> cfg.id().equals(bundle.config().family()))
+              .map(bundle -> bundle.config().id())
+              .toList();
+          return new TrustFrameworkPublicEntry()
+              .id(cfg.id())
+              .name(cfg.name())
+              .profiles(profiles);
+        })
+        .toList();
+
+    return ResponseEntity.ok(entries);
+  }
+
+  private ComplianceCheckResult toDto(ComplianceCheckOutcome outcome) {
+    ComplianceCheckResult result = new ComplianceCheckResult();
+    result.setConforms(outcome.compliant());
+    switch (outcome) {
+      case IssuedAttestation ia -> result.setAttestationCredential(ia.attestationCredential());
+      case UnverifiableAttestation ua -> result.setFailureCategory(ua.failureCategory().name());
+    }
+    return result;
+  }
+}

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/ComplianceCheckControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/ComplianceCheckControllerTest.java
@@ -1,0 +1,245 @@
+package eu.xfsc.fc.server.controller;
+
+import static eu.xfsc.fc.server.util.CommonConstants.ASSET_READ;
+import static eu.xfsc.fc.server.util.CommonConstants.ASSET_UPDATE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.exception.ConflictException;
+import eu.xfsc.fc.core.exception.TimeoutException;
+import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
+import eu.xfsc.fc.core.service.trustframework.FrameworkBundleConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
+import eu.xfsc.fc.core.service.trustframework.ValidationType;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceCheckOrchestrator;
+import eu.xfsc.fc.core.service.trustframework.compliance.IssuedAttestation;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+
+/**
+ * Integration tests for the compliance check endpoints.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@TestPropertySource(properties = {"graphstore.impl=fuseki"})
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+public class ComplianceCheckControllerTest {
+
+  private static final String ASSET_ID = "urn:example:test-asset-001";
+  private static final String MOCK_PROFILE_ID = "mock-2026";
+  private static final String UNKNOWN_PROFILE_ID = "no-such-profile";
+  private static final String CANNED_VC_JWT =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+          + ".eyJpc3MiOiJkaWQ6d2ViOmNvbXBsaWFuY2UuZXhhbXBsZSIsImV4cCI6MTc2NzIyMzk5OX0.";
+  // JWT with payload {"id":"urn:example:test-asset-001"}
+  private static final String TEST_VP_JWT =
+      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+          + ".eyJpZCI6InVybjpleGFtcGxlOnRlc3QtYXNzZXQtMDAxIn0.";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private ComplianceCheckOrchestrator orchestrator;
+
+  @MockitoBean
+  private TrustFrameworkService trustFrameworkService;
+
+  @MockitoBean
+  private TrustFrameworkRegistry registry;
+
+  @Test
+  @WithMockUser(roles = {ASSET_UPDATE})
+  void runComplianceCheck_unknownProfileId_returns400() throws Exception {
+    when(orchestrator.check(any(), eq(UNKNOWN_PROFILE_ID), any()))
+        .thenThrow(new ClientException("Unknown trust-framework profile: " + UNKNOWN_PROFILE_ID));
+
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(UNKNOWN_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {ASSET_UPDATE})
+  void runComplianceCheck_familyDisabled_returns409() throws Exception {
+    when(orchestrator.check(any(), eq(MOCK_PROFILE_ID), any()))
+        .thenThrow(new ConflictException("Trust-framework family is disabled: mock"));
+
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(MOCK_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @WithMockUser(roles = {ASSET_UPDATE})
+  void runComplianceCheck_compliantOutcome_returns200WithConformsTrue() throws Exception {
+    when(orchestrator.check(any(), eq(MOCK_PROFILE_ID), any()))
+        .thenReturn(new IssuedAttestation(CANNED_VC_JWT, null));
+
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(MOCK_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.conforms").value(true))
+        .andExpect(jsonPath("$.attestationCredential").value(CANNED_VC_JWT));
+  }
+
+  @Test
+  @WithMockUser(roles = {ASSET_READ})
+  void getComplianceChecks_authenticated_returns200WithArray() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/compliance-checks", ASSET_ID)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray());
+  }
+
+  @Test
+  @WithMockUser
+  void getTrustFrameworksPublic_noEnabledFrameworks_returnsEmptyArray() throws Exception {
+    when(trustFrameworkService.findAll()).thenReturn(List.of(
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, false, null, null)));
+    when(registry.getActiveBundles()).thenReturn(List.of());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @WithMockUser
+  void getTrustFrameworksPublic_enabledFramework_returnsEntryWithIdAndName() throws Exception {
+    when(trustFrameworkService.findAll()).thenReturn(List.of(
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, true, null, null)));
+    when(registry.getActiveBundles()).thenReturn(List.of());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value("gaia-x"))
+        .andExpect(jsonPath("$[0].name").value("Gaia-X Trust Framework"))
+        .andExpect(jsonPath("$[0].profiles").isArray())
+        .andExpect(jsonPath("$[0].profiles").isEmpty());
+  }
+
+  @Test
+  @WithMockUser
+  void getTrustFrameworksPublic_enabledFrameworkWithActiveProfile_returnsProfileInEntry() throws Exception {
+    when(trustFrameworkService.findAll()).thenReturn(List.of(
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, true, null, null)));
+    var bundleCfg = new FrameworkBundleConfig("gaia-x-2511", "gaia-x",
+        "https://compliance.gaia-x.eu/", ValidationType.SHACL, Map.of(), Map.of());
+    when(registry.getActiveBundles()).thenReturn(List.of(new TrustFrameworkBundle(bundleCfg, null, null)));
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].id").value("gaia-x"))
+        .andExpect(jsonPath("$[0].profiles[0]").value("gaia-x-2511"));
+  }
+
+  @Test
+  @WithMockUser(roles = {ASSET_UPDATE})
+  void runComplianceCheck_serviceTimeout_returns504() throws Exception {
+    when(orchestrator.check(any(), eq(MOCK_PROFILE_ID), any()))
+        .thenThrow(new TimeoutException("Compliance service timed out"));
+
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(MOCK_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isGatewayTimeout());
+  }
+
+  // Security: unauthenticated POST → 401
+  @Test
+  void runComplianceCheck_unauthenticated_returns401() throws Exception {
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(MOCK_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // Security: wrong role for POST → 403
+  @Test
+  @WithMockUser(roles = {ASSET_READ})
+  void runComplianceCheck_insufficientRole_returns403() throws Exception {
+    String body = """
+        {"frameworkProfileId": "%s", "credential": "%s"}
+        """.formatted(MOCK_PROFILE_ID, TEST_VP_JWT);
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/assets/{id}/compliance-check", ASSET_ID)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  // Security: unauthenticated GET compliance-checks → 401
+  @Test
+  void getComplianceChecks_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/assets/{id}/compliance-checks", ASSET_ID)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+
+  // Security: unauthenticated GET trust-frameworks → 401
+  @Test
+  void getTrustFrameworksPublic_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
+}

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ComplianceCheckServiceTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ComplianceCheckServiceTest.java
@@ -1,0 +1,213 @@
+package eu.xfsc.fc.server.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+
+import eu.xfsc.fc.api.generated.model.ComplianceCheckRequest;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPublicEntry;
+import eu.xfsc.fc.core.dao.validation.ValidationResult;
+import eu.xfsc.fc.core.dao.validation.ValidatorType;
+import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
+import eu.xfsc.fc.core.service.trustframework.FrameworkBundleConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
+import eu.xfsc.fc.core.service.trustframework.ValidationType;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceCheckOrchestrator;
+import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceResultStore;
+import eu.xfsc.fc.core.service.trustframework.compliance.FailureCategory;
+import eu.xfsc.fc.core.service.trustframework.compliance.IssuedAttestation;
+import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileConfig;
+import eu.xfsc.fc.core.service.trustframework.compliance.UnverifiableAttestation;
+
+@ExtendWith(MockitoExtension.class)
+class ComplianceCheckServiceTest {
+
+  private static final String ASSET_ID = "urn:example:asset-001";
+  private static final String PROFILE_ID = "gaia-x-2511";
+  private static final String FAMILY_ID = "gaia-x";
+  private static final String CANNED_VC_JWT = "eyJhbGciOiJub25lIn0.e30.";
+  private static final String CREDENTIAL = "eyJhbGciOiJub25lIn0.payload.";
+
+  @Mock
+  private ComplianceCheckOrchestrator orchestrator;
+  @Mock
+  private ComplianceResultStore resultStore;
+  @Mock
+  private TrustFrameworkService trustFrameworkService;
+  @Mock
+  private TrustFrameworkRegistry registry;
+
+  @InjectMocks
+  private ComplianceCheckService service;
+
+  @Test
+  void runComplianceCheck_issuedAttestation_returnsConformsTrueAndCredential() {
+    var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
+    when(orchestrator.check(ASSET_ID, PROFILE_ID, CREDENTIAL)).thenReturn(outcome);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+
+    var response = service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getConforms()).isTrue();
+    assertThat(response.getBody().getAttestationCredential()).isEqualTo(CANNED_VC_JWT);
+    assertThat(response.getBody().getFailureCategory()).isNull();
+  }
+
+  @Test
+  void runComplianceCheck_unverifiableAttestation_returnsConformsFalseAndFailureCategory() {
+    var outcome = new UnverifiableAttestation(FailureCategory.UNVERIFIABLE_ATTESTATION, "raw", "bad sig");
+    when(orchestrator.check(ASSET_ID, PROFILE_ID, CREDENTIAL)).thenReturn(outcome);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+
+    var response = service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody().getConforms()).isFalse();
+    assertThat(response.getBody().getFailureCategory()).isEqualTo("UNVERIFIABLE_ATTESTATION");
+    assertThat(response.getBody().getAttestationCredential()).isNull();
+  }
+
+  @Test
+  void runComplianceCheck_profileConfigPresent_storeReceivesFamilyIdFromRegistry() {
+    var profileConfig = new TrustFrameworkProfileConfig(PROFILE_ID, FAMILY_ID, "gxdch", null, "1.0", 30);
+    var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
+    when(orchestrator.check(any(), any(), any())).thenReturn(outcome);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(profileConfig));
+
+    service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
+
+    verify(resultStore).store(ASSET_ID, PROFILE_ID, FAMILY_ID, outcome);
+  }
+
+  @Test
+  void runComplianceCheck_profileConfigAbsent_storeReceivesProfileIdAsFamilyId() {
+    var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
+    when(orchestrator.check(any(), any(), any())).thenReturn(outcome);
+    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+
+    service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
+
+    verify(resultStore).store(ASSET_ID, PROFILE_ID, PROFILE_ID, outcome);
+  }
+
+  @Test
+  void getComplianceChecks_nullOffsetAndLimit_usesDefaultPagination() {
+    when(resultStore.findByAssetId(eq(ASSET_ID), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    service.getComplianceChecks(ASSET_ID, null, null);
+
+    var captor = ArgumentCaptor.forClass(Pageable.class);
+    verify(resultStore).findByAssetId(eq(ASSET_ID), captor.capture());
+    assertThat(captor.getValue().getOffset()).isZero();
+    assertThat(captor.getValue().getPageSize()).isEqualTo(100);
+  }
+
+  @Test
+  void getComplianceChecks_explicitOffsetAndLimit_usesProvidedValues() {
+    when(resultStore.findByAssetId(eq(ASSET_ID), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+
+    service.getComplianceChecks(ASSET_ID, 5, 25);
+
+    var captor = ArgumentCaptor.forClass(Pageable.class);
+    verify(resultStore).findByAssetId(eq(ASSET_ID), captor.capture());
+    assertThat(captor.getValue().getOffset()).isEqualTo(5L);
+    assertThat(captor.getValue().getPageSize()).isEqualTo(25);
+  }
+
+  @Test
+  void getComplianceChecks_resultsMappedToDtos() {
+    var entity = new ValidationResult();
+    entity.setAssetIds(new String[] {ASSET_ID});
+    entity.setValidatorIds(new String[] {PROFILE_ID});
+    entity.setValidatorType(ValidatorType.TRUST_FRAMEWORK);
+    entity.setConforms(true);
+    entity.setValidatedAt(Instant.parse("2026-01-01T00:00:00Z"));
+    entity.setContentHash("abc123");
+    when(resultStore.findByAssetId(eq(ASSET_ID), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(entity)));
+
+    var response = service.getComplianceChecks(ASSET_ID, null, null);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).hasSize(1);
+    assertThat(response.getBody().getFirst().getConforms()).isTrue();
+  }
+
+  @Test
+  void getTrustFrameworksPublic_disabledFrameworkExcluded() {
+    var enabled = tfConfig("gaia-x", "GAIA-X", true);
+    var disabled = tfConfig("untp", "UNTP", false);
+    when(trustFrameworkService.findAll()).thenReturn(List.of(enabled, disabled));
+    when(registry.getActiveBundles()).thenReturn(List.of());
+
+    var response = service.getTrustFrameworksPublic();
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getBody()).extracting(TrustFrameworkPublicEntry::getId)
+        .containsExactly("gaia-x")
+        .doesNotContain("untp");
+  }
+
+  @Test
+  void getTrustFrameworksPublic_profilesMatchedByFamilyId() {
+    var tfCfg = tfConfig("gaia-x", "GAIA-X", true);
+    when(trustFrameworkService.findAll()).thenReturn(List.of(tfCfg));
+    var matchingBundle = bundle("gaia-x-2511", "gaia-x");
+    var otherBundle = bundle("untp-v1", "untp");
+    when(registry.getActiveBundles()).thenReturn(List.of(matchingBundle, otherBundle));
+
+    var response = service.getTrustFrameworksPublic();
+
+    assertThat(response.getBody()).hasSize(1);
+    assertThat(response.getBody().getFirst().getProfiles())
+        .containsExactly("gaia-x-2511")
+        .doesNotContain("untp-v1");
+  }
+
+  @Test
+  void getTrustFrameworksPublic_noActiveBundles_emptyProfilesList() {
+    when(trustFrameworkService.findAll()).thenReturn(List.of(tfConfig("gaia-x", "GAIA-X", true)));
+    when(registry.getActiveBundles()).thenReturn(List.of());
+
+    var response = service.getTrustFrameworksPublic();
+
+    assertThat(response.getBody()).hasSize(1);
+    assertThat(response.getBody().getFirst().getProfiles()).isEmpty();
+  }
+
+  private static ComplianceCheckRequest request(String profileId, String credential) {
+    return new ComplianceCheckRequest().frameworkProfileId(profileId).credential(credential);
+  }
+
+  private static TrustFrameworkConfig tfConfig(String id, String name, boolean enabled) {
+    return new TrustFrameworkConfig(id, name, null, "1.0", 30, enabled, null, null);
+  }
+
+  private static TrustFrameworkBundle bundle(String profileId, String familyId) {
+    var config = new FrameworkBundleConfig(profileId, familyId, "https://example.org/",
+        ValidationType.SHACL, Map.of(), Map.of());
+    return new TrustFrameworkBundle(config, null, null);
+  }
+}

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -1006,6 +1006,47 @@ components:
           type: string
           description: The SHACL shape that was violated
 
+    ComplianceCheckRequest:
+      type: object
+      required: [ frameworkProfileId, credential ]
+      properties:
+        frameworkProfileId:
+          type: string
+          description: The trust-framework profile ID to check against (e.g. "mock-2026")
+        credential:
+          type: string
+          description: Raw VP JWT credential to submit to the compliance service
+
+    ComplianceCheckResult:
+      type: object
+      properties:
+        conforms:
+          type: boolean
+          description: True when the compliance service issued an attestation
+        failureCategory:
+          type: string
+          nullable: true
+          description: Set when conforms is false; describes how the check failed (currently UNVERIFIABLE_ATTESTATION)
+        attestationCredential:
+          type: string
+          nullable: true
+          description: Raw JWT compliance credential returned by the service (present only on conforms=true)
+
+    TrustFrameworkPublicEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Family ID (e.g. "gaia-x", "mock")
+        name:
+          type: string
+          description: Human-readable family name
+        profiles:
+          type: array
+          items:
+            type: string
+          description: Profile IDs registered for this family (e.g. ["gaia-x-2511"])
+
   parameters:
     OffsetParam:
       name: offset
@@ -1098,6 +1139,8 @@ tags:
     description: Graph database status and backend switching.
   - name: Validations
     description: Stored validation results.
+  - name: Compliance
+    description: Trust-framework compliance check endpoints.
 paths:
   /admin/me:
     get:
@@ -2105,6 +2148,110 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /assets/{id}/compliance-check:
+    post:
+      tags:
+        - Compliance
+      summary: Run a compliance check for an asset
+      operationId: runComplianceCheck
+      security:
+        - jwt: [ ]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComplianceCheckRequest'
+      responses:
+        '200':
+          description: Compliance check completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComplianceCheckResult'
+        '400':
+          $ref: '#/components/responses/ClientError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          description: Compliance service is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '504':
+          description: Compliance service did not respond in time
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /assets/{id}/compliance-checks:
+    get:
+      tags:
+        - Compliance
+      summary: Get stored compliance check results for an asset
+      operationId: getComplianceChecks
+      security:
+        - jwt: [ ]
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/LimitParam'
+      responses:
+        '200':
+          description: List of compliance check results for the asset
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StoredValidationResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /trust-frameworks:
+    get:
+      tags:
+        - Compliance
+      summary: List enabled trust frameworks and their profiles (public discovery)
+      operationId: getTrustFrameworksPublic
+      security:
+        - jwt: [ ]
+      responses:
+        '200':
+          description: List of enabled trust framework families with their profile IDs
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrustFrameworkPublicEntry'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/ServerError'
 


### PR DESCRIPTION
## 🚀 Summary

Part 2 of CAT-FR-CO-03. Introduces the external trust-framework compliance check SPI and its first production-ready implementation, wiring it up to a new REST endpoint. Part 1 (the bundle loader and registry infrastructure, on the cleanup branch) is a prerequisite.

The core idea: any registered trust framework can now be asked to perform a compliance check against its own remote service. The catalogue proxies the credential, maps the outcome to a first-class result object, persists it, and returns it to the caller. Adding a second trust framework's compliance client requires only a new `TrustFrameworkClient` implementation - no changes to the orchestration layer.

## ✅ What's Changed

- [x] Feature implemented
- [x] Tests added
- [x] OpenAPI spec updated
- [x] Mock bundle added for local dev/testing
- [x] Exception handling wired to `RestExceptionHandler`

## 🧪 How to Test

Covered by JUnit tests. For manual testing, enable the `mock-2026` bundle (set `enabled=true` in the DB or via a test fixture), point `serviceUrl` at a WireMock container, and call `POST /assets/{id}/compliance-check` with a `frameworkProfileId` matching the mock profile. The `ComplianceCheckControllerTest` covers the happy path and error scenarios (unknown profile, disabled family, timeout, service unavailable).

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] My changes follow the project's coding style
- [x] I've updated documentation if necessary: https://github.com/federated-catalogue-enhancements-2026/docs/pull/30
