### PR TITLE
fix(CAT-FR-LM-02): bypass trust-framework role check for provenance VCs

### DIFF
--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/provenance/ProvenanceCredentialParser.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/provenance/ProvenanceCredentialParser.java
@@ -52,7 +52,9 @@ public class ProvenanceCredentialParser {
   public CredentialVerificationResult parseAndValidateVc(String rawVc, String format) {
     try {
       ContentAccessorDirect content = new ContentAccessorDirect(rawVc, format);
-      return verificationService.verifyCredential(content);
+      // Provenance credentials carry PROV-O predicates instead of trust-framework roles
+      // (Participant/ServiceOffering/Resource), so role resolution must be bypassed.
+      return verificationService.verifyCredential(content, false);
     } catch (VerificationException ex) {
       throw new ClientException("Invalid provenance credential: " + ex.getMessage(), ex);
     }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/provenance/ProvenanceServiceImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/provenance/ProvenanceServiceImpl.java
@@ -246,7 +246,7 @@ public class ProvenanceServiceImpl implements ProvenanceService {
     Instant now = Instant.now();
     try {
       ContentAccessorDirect content = new ContentAccessorDirect(entity.getCredentialContent());
-      CredentialVerificationResult result = verificationService.verifyCredential(content);
+      CredentialVerificationResult result = verificationService.verifyCredential(content, false);
 
       return new ProvenanceVerificationResult()
           .isValid(true)

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationService.java
@@ -28,6 +28,22 @@ public interface VerificationService {
   CredentialVerificationResult verifyCredential(ContentAccessor payload) throws VerificationException;
 
   /**
+   * Validates the credential payload with an explicit trust-framework role requirement.
+   *
+   * <p>Use {@code requireRole = false} for credential families that intentionally do not
+   * carry a trust-framework-recognised type — e.g. provenance credentials whose
+   * {@code credentialSubject} only declares PROV-O predicates. With the default
+   * {@code requireRole = true}, an unresolvable type yields a {@link eu.xfsc.fc.core.exception.ClientException}.</p>
+   *
+   * @param payload ContentAccessor to credential which should be validated.
+   * @param requireRole whether to reject the credential when its type cannot be resolved
+   *     to a role in any active trust-framework bundle.
+   * @return a credential metadata validation result.
+   */
+  CredentialVerificationResult verifyCredential(ContentAccessor payload, boolean requireRole)
+      throws VerificationException;
+
+  /**
    * Validates the credential payload with custom verification toggles (JSON-LD format).
    *
    * @param payload ContentAccessor to credential which should be validated.

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationServiceImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationServiceImpl.java
@@ -82,15 +82,26 @@ public class VerificationServiceImpl implements VerificationService {
    */
   @Override
   public CredentialVerificationResult verifyCredential(ContentAccessor payload) throws VerificationException {
-    return verifyCredential(payload, verifySemantics, verifySchema, verifyVPSignature, verifyVCSignature);
+    return verifyCredential(payload, verifySemantics, verifySchema, verifyVPSignature, verifyVCSignature, true);
+  }
+
+  @Override
+  public CredentialVerificationResult verifyCredential(ContentAccessor payload, boolean requireRole)
+      throws VerificationException {
+    return verifyCredential(payload, verifySemantics, verifySchema, verifyVPSignature, verifyVCSignature, requireRole);
   }
 
   @Override
   public CredentialVerificationResult verifyCredential(ContentAccessor payload, boolean verifySemantics, boolean verifySchema,
 		  boolean verifyVPSignatures, boolean verifyVCSignatures) throws VerificationException {
+    return verifyCredential(payload, verifySemantics, verifySchema, verifyVPSignatures, verifyVCSignatures, true);
+  }
+
+  private CredentialVerificationResult verifyCredential(ContentAccessor payload, boolean verifySemantics, boolean verifySchema,
+		  boolean verifyVPSignatures, boolean verifyVCSignatures, boolean requireRole) throws VerificationException {
     CredentialVerificationResult result = resolveStrategy(payload).ingest(payload,
         verifySemantics, verifySchema, verifyVPSignatures, verifyVCSignatures);
-    if (!(result instanceof NonCredentialVerificationResult) && result.getRole() == null) {
+    if (requireRole && !(result instanceof NonCredentialVerificationResult) && result.getRole() == null) {
       String bundleInfo = getActiveTrustFrameworkBundleInfos();
       throw new ClientException(
           "Credential type is not resolvable in any active trust-framework bundle."

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/provenance/ProvenanceCredentialParserTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/provenance/ProvenanceCredentialParserTest.java
@@ -5,9 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xfsc.fc.core.dao.provenance.ProvenanceType;
 import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.CredentialVerificationResult;
 import eu.xfsc.fc.core.service.verification.VerificationService;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -17,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -131,6 +138,19 @@ class ProvenanceCredentialParserTest {
         """.formatted(SUBJECT_ID);
 
     assertThrows(ClientException.class, () -> parser.extractCredentialInfo(vc));
+  }
+
+  @Test
+  void parseAndValidateVc_bypassesTrustFrameworkRoleCheck() {
+    // Provenance VCs intentionally lack Participant/ServiceOffering/Resource type — the
+    // role-resolution guard must be opted out on this path.
+    String rawVc = vcWith("prov:wasGeneratedBy", OBJECT_VALUE);
+    when(verificationService.verifyCredential(ArgumentMatchers.any(ContentAccessor.class), ArgumentMatchers.eq(false)))
+        .thenReturn(mock(CredentialVerificationResult.class));
+
+    parser.parseAndValidateVc(rawVc, "JSONLD");
+
+    verify(verificationService).verifyCredential(ArgumentMatchers.any(ContentAccessor.class), ArgumentMatchers.eq(false));
   }
 
   @Test

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ProvenanceServiceTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ProvenanceServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import eu.xfsc.fc.api.generated.model.AssetStatus;
@@ -145,7 +146,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_validVc_storesPersistentRecord() {
-    when(verificationService.verifyCredential(any())).thenReturn(successResult(ASSET_IRI, ISSUER));
+    when(verificationService.verifyCredential(any(), eq(false))).thenReturn(successResult(ASSET_IRI, ISSUER));
 
     ProvenanceCredential result = provenanceService.add(ASSET_ID, null, VALID_VC, null);
 
@@ -158,7 +159,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_validVc_storesProvOTriplesInGraph() {
-    when(verificationService.verifyCredential(any())).thenReturn(successResult(ASSET_IRI, ISSUER));
+    when(verificationService.verifyCredential(any(), eq(false))).thenReturn(successResult(ASSET_IRI, ISSUER));
 
     provenanceService.add(ASSET_ID, null, VALID_VC, null);
 
@@ -176,7 +177,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_wrongSubjectId_throwsClientException() {
-    when(verificationService.verifyCredential(any()))
+    when(verificationService.verifyCredential(any(), eq(false)))
         .thenReturn(successResult("did:web:wrong:subject", ISSUER));
 
     assertThrows(ClientException.class, () ->
@@ -185,7 +186,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_noPredicate_throwsClientException() {
-    when(verificationService.verifyCredential(any()))
+    when(verificationService.verifyCredential(any(), eq(false)))
         .thenReturn(successResult(ASSET_IRI, ISSUER));
 
     assertThrows(ClientException.class, () ->
@@ -194,7 +195,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_duplicateCredentialId_throwsConflictException() {
-    when(verificationService.verifyCredential(any())).thenReturn(successResult(ASSET_IRI, ISSUER));
+    when(verificationService.verifyCredential(any(), eq(false))).thenReturn(successResult(ASSET_IRI, ISSUER));
 
     provenanceService.add(ASSET_ID, null, VALID_VC, null);
 
@@ -204,7 +205,7 @@ class ProvenanceServiceTest {
 
   @Test
   void add_protectedNamespaceObject_throwsClientException() {
-    when(verificationService.verifyCredential(any()))
+    when(verificationService.verifyCredential(any(), eq(false)))
         .thenReturn(successResult(ASSET_IRI, ISSUER));
 
     assertThrows(ClientException.class, () ->
@@ -245,7 +246,7 @@ class ProvenanceServiceTest {
   @Test
   void verifyOne_validVc_returnsValidResult() {
     insertRecord(CREDENTIAL_ID, 1, ISSUED_AT);
-    when(verificationService.verifyCredential(any())).thenReturn(successResult(ASSET_IRI, ISSUER));
+    when(verificationService.verifyCredential(any(), eq(false))).thenReturn(successResult(ASSET_IRI, ISSUER));
 
     var result = provenanceService.verifyOne(ASSET_ID, CREDENTIAL_ID);
 
@@ -271,7 +272,7 @@ class ProvenanceServiceTest {
     insertRecord("did:vc:prov-later-001", 1, laterTime);
     insertRecord("did:vc:prov-earlier-001", 1, ISSUED_AT);
 
-    when(verificationService.verifyCredential(any()))
+    when(verificationService.verifyCredential(any(), eq(false)))
         .thenReturn(successResult(ASSET_IRI, ISSUER))
         .thenThrow(new VerificationException("Signature invalid"));
 
@@ -283,7 +284,7 @@ class ProvenanceServiceTest {
 
   @Test
   void deleteByAssetId_removesRelationalRowsAndProvOTriples() {
-    when(verificationService.verifyCredential(any())).thenReturn(successResult(ASSET_IRI, ISSUER));
+    when(verificationService.verifyCredential(any(), eq(false))).thenReturn(successResult(ASSET_IRI, ISSUER));
     provenanceService.add(ASSET_ID, null, VALID_VC, null);
     assertTrue(provenanceRepository.existsByCredentialId(CREDENTIAL_ID),
         "precondition: row exists before cascade delete");


### PR DESCRIPTION
## 🚀 Summary

Provenance credentials carry PROV-O predicates (prov:wasGeneratedBy etc.) instead of trust-framework roles (Participant/ServiceOffering/Resource), so the role-resolution guard introduced for CAT-FR-CO-01 rejected every provenance upload with HTTP 400. Add a requireRole overload to VerificationService and use requireRole=false from the provenance add/verify paths; existing /verification and asset-upload callers keep the strict check.

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnit tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style
