### PR TITLE
Enhancement [CAT-FR-CO-03] part3 - external trust framework bundle overrides

### DIFF
--- a/docker/docker-compose.strict.yml
+++ b/docker/docker-compose.strict.yml
@@ -1,16 +1,39 @@
 # Strict verification overlay — enables signature, schema, and Gaia-X Trust Framework validation.
+# Also adds the mock compliance service (WireMock) for @uses.compliance-mock BDD scenarios.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.strict.yml --env-file dev.env up
 #   ./dev.sh strict
 #
+# BDD tests: set CAT_WIREMOCK_HOST=http://localhost:8089 in env.sh.
+#
 # See: cat-integration-tests/docs/adr/003-interim-two-config-test-strategy.md
 
 services:
+  compliance-mock:
+    container_name: "compliance-mock"
+    image: wiremock/wiremock:3.13.2
+    networks:
+      - "gaia-x"
+    ports:
+      # 8089 on host to avoid conflict with Keycloak (8080).
+      # BDD tests reach WireMock admin API at http://localhost:8089.
+      - "8089:8080"
+
   server:
     environment:
-      # Enable the gaia-x trust framework. List multiple families as "gaia-x,untp".
-      FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS: "gaia-x"
+      # Enable gaia-x and mock trust frameworks.
+      FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS: "gaia-x,mock"
       FEDERATED_CATALOGUE_VERIFICATION_SCHEMA: "true"
       FEDERATED_CATALOGUE_VERIFICATION_VP_SIGNATURE: "true"
       FEDERATED_CATALOGUE_VERIFICATION_VC_SIGNATURE: "true"
+      # Mount the trustframeworks directory as the filesystem override source.
+      # Bundles here override classpath bundles by id (e.g. redirecting URLs to local services).
+      FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH: /app/trustframeworks-override
+    volumes:
+      # Mount all bundle subdirectories as the override directory.
+      # Each subdirectory (e.g. mock-2026/, gaia-x-2511/) overrides the matching classpath bundle by id.
+      - ./trustframeworks:/app/trustframeworks-override:ro
+    depends_on:
+      compliance-mock:
+        condition: service_started

--- a/docker/trustframeworks/gaia-x-2511/framework.yaml
+++ b/docker/trustframeworks/gaia-x-2511/framework.yaml
@@ -1,0 +1,9 @@
+# Filesystem overlay for the classpath gaia-x-2511 bundle.
+# Mounted at /app/trustframeworks-override by docker-compose.strict.yml.
+# Only diffs from the classpath bundle live here; everything else is inherited.
+#
+# Redirects trust-anchor resolution from the public Gaia-X Lab registry to the
+# internal did-server nginx mock (see docker/did-server/).
+id: gaia-x-2511
+properties:
+  trust_anchor_url: "https://did-server/api/trustAnchor/chain/file"

--- a/docker/trustframeworks/mock-2026/framework.yaml
+++ b/docker/trustframeworks/mock-2026/framework.yaml
@@ -1,0 +1,13 @@
+# Filesystem overlay for the classpath mock-2026 bundle.
+# Mounted at /app/trustframeworks-override by docker-compose.strict.yml.
+#
+# Purpose: mock-2026 — exercises the catalogue's "call a GXDCH compliance service"
+# code path against a WireMock stub instead of a real GXDCH operator.
+# mock-2026 stays as the permanent local-dev / BDD compliance-stub path
+# (driven by @uses.compliance-mock scenarios in cat-integration-tests).
+#
+# Redirects service_url from the classpath placeholder ("http://localhost")
+# to the compliance-mock WireMock container on the gaia-x Docker network.
+id: mock-2026
+properties:
+  service_url: "http://compliance-mock:8080"

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/config/TrustFrameworkRegistryConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/config/TrustFrameworkRegistryConfig.java
@@ -5,17 +5,32 @@ import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 
 import java.io.IOException;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Exposes a {@link TrustFrameworkRegistry} bean populated from classpath bundles at boot.
+ * Exposes a {@link TrustFrameworkRegistry} bean populated from classpath bundles at boot,
+ * with optional filesystem overrides applied on top.
  */
 @Configuration
 public class TrustFrameworkRegistryConfig {
 
+  private final String overridePath;
+
+  /**
+   * Constructs the configuration with an optional filesystem override path for trust-framework bundles.
+   *
+   * @param overridePath path injected from {@code federated-catalogue.trust-frameworks.override-path};
+   *                     blank means no filesystem override
+   */
+  public TrustFrameworkRegistryConfig(
+      @Value("${federated-catalogue.trust-frameworks.override-path:}") String overridePath) {
+    this.overridePath = overridePath;
+  }
+
   @Bean
   public TrustFrameworkRegistry trustFrameworkRegistry() throws IOException {
-    return new TrustFrameworkRegistry(new TrustFrameworkBundleLoader().loadFromClasspath());
+    return new TrustFrameworkRegistry(new TrustFrameworkBundleLoader(overridePath).load());
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleLoader.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleLoader.java
@@ -1,13 +1,17 @@
 package eu.xfsc.fc.core.service.trustframework;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
@@ -16,23 +20,145 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 /**
  * Scans the classpath for trust-framework bundles under {@code trustframeworks/<bundleId>/framework.yaml}
  * and constructs a {@link TrustFrameworkBundle} for each.
+ *
+ * <p>When an override path is configured, filesystem bundles found there are applied on top of classpath bundles
+ * using one of two strategies:
+ * <ul>
+ *   <li><strong>Overlay</strong> — if the filesystem YAML's {@code id} matches an existing classpath bundle, the
+ *       filesystem map is deep-merged onto the classpath config (scalar and nested-map fields are overridden per key;
+ *       list fields are replaced wholesale). Sibling files ({@code ontology.ttl}, {@code shapes.ttl}) are inherited
+ *       from the classpath bundle when the filesystem directory does not provide its own copy.</li>
+ *   <li><strong>Add</strong> — if the {@code id} is brand-new (no classpath match), the filesystem bundle is loaded
+ *       as a full bundle via the normal {@link #loadBundle(Resource)} path and appended to the result.</li>
+ * </ul>
+ * Filesystem YAMLs without an {@code id} field are skipped with a WARN log. Non-loadable bundles do not abort
+ * the load of remaining bundles.
  */
 @Slf4j
 public class TrustFrameworkBundleLoader {
 
   private static final String BUNDLE_PATTERN = "classpath:trustframeworks/*/framework.yaml";
+  private static final String FILESYSTEM_BUNDLE_PATTERN = "file:%s/*/framework.yaml";
+  private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+  };
   private static final YAMLMapper YAML_MAPPER = YAMLMapper.builder()
-      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .build();
+
+  private final String overridePath;
+
+  /**
+   * Constructs a loader with a filesystem override path.
+   *
+   * @param overridePath path to a directory containing bundle subdirectories; blank or {@code null} disables override
+   */
+  public TrustFrameworkBundleLoader(String overridePath) {
+    this.overridePath = overridePath;
+  }
+
+  /**
+   * Constructs a loader with no filesystem override path (classpath-only).
+   */
+  public TrustFrameworkBundleLoader() {
+    this(null);
+  }
+
+  /**
+   * Scans the classpath for {@code trustframeworks/<bundleId>/framework.yaml} files and loads each as a bundle.
+   *
+   * <p>If an override path is configured and exists, each filesystem bundle is applied as either an
+   * <em>overlay</em> (deep-merge onto a classpath bundle with the same {@code id}) or an <em>add</em>
+   * (appended as a new bundle when no classpath bundle with that {@code id} exists).
+   *
+   * <p>Overlay semantics: nested maps are recursively merged with filesystem keys winning at the leaf level;
+   * scalars are replaced when the filesystem provides a value; lists are replaced wholesale.
+   * Sibling files ({@code ontology.ttl}, {@code shapes.ttl}) are inherited from the classpath bundle when
+   * the filesystem directory does not supply its own copy.
+   *
+   * <p>Non-loadable bundles are skipped with a warning; they do not abort the load of remaining bundles.
+   */
+  public List<TrustFrameworkBundle> load() throws IOException {
+    var resolver = new PathMatchingResourcePatternResolver();
+    Resource[] classpathYamls = resolver.getResources(BUNDLE_PATTERN);
+    var byId = new LinkedHashMap<String, TrustFrameworkBundle>();
+    for (Resource yaml : classpathYamls) {
+      try {
+        var bundle = loadBundle(yaml);
+        byId.put(bundle.config().id(), bundle);
+      } catch (Exception e) {
+        log.warn("Skipping bundle at '{}' — failed to load: {}", yaml.getDescription(), e.getMessage());
+      }
+    }
+    int classpathCount = byId.size();
+    if (classpathCount == 0) {
+      log.warn("No trust-framework bundles loaded from classpath — catalogue may not function correctly");
+    } else {
+      log.info("Loaded {} trust-framework bundle(s) from classpath", classpathCount);
+    }
+    applyFilesystemOverrides(resolver, byId, classpathCount);
+    return new ArrayList<>(byId.values());
+  }
+
+  private void applyFilesystemOverrides(PathMatchingResourcePatternResolver resolver,
+                                        LinkedHashMap<String, TrustFrameworkBundle> byId, int classpathCount)
+      throws IOException {
+    if (overridePath == null || overridePath.isBlank()) {
+      return;
+    }
+    var overrideDir = new File(overridePath);
+    if (!overrideDir.exists() || !overrideDir.isDirectory()) {
+      log.warn("Trust-framework override path '{}' does not exist or is not a directory — skipping", overridePath);
+      return;
+    }
+    var pattern = String.format(FILESYSTEM_BUNDLE_PATTERN, overridePath);
+    Resource[] fsYamls = resolver.getResources(pattern);
+    int overlayCount = 0;
+    int addedCount = 0;
+    for (Resource yaml : fsYamls) {
+      try {
+        Map<String, Object> fsMap;
+        try (var stream = yaml.getInputStream()) {
+          fsMap = YAML_MAPPER.readValue(stream, MAP_TYPE);
+        }
+        Object rawId = fsMap.get("id");
+        if (rawId == null || rawId.toString().isBlank()) {
+          log.warn("Skipping override at '{}' — missing 'id' field", yaml.getDescription());
+          continue;
+        }
+        String id = rawId.toString();
+        TrustFrameworkBundle existing = byId.get(id);
+        if (existing != null) {
+          Map<String, Object> baseMap = YAML_MAPPER.convertValue(existing.config(), MAP_TYPE);
+          Map<String, Object> merged = deepMerge(baseMap, fsMap);
+          FrameworkBundleConfig mergedConfig = YAML_MAPPER.convertValue(merged, FrameworkBundleConfig.class);
+          var fsOntology = loadSibling(yaml, "ontology.ttl");
+          var fsShapes = loadSibling(yaml, "shapes.ttl");
+          var ontology = fsOntology != null ? fsOntology : existing.ontology();
+          var shapes = fsShapes != null ? fsShapes : existing.shapes();
+          byId.put(id, new TrustFrameworkBundle(mergedConfig, ontology, shapes));
+          overlayCount++;
+        } else {
+          var bundle = loadBundle(yaml);
+          byId.put(bundle.config().id(), bundle);
+          addedCount++;
+        }
+      } catch (Exception e) {
+        log.warn("Skipping override at '{}' — failed: {}", yaml.getDescription(), e.getMessage());
+      }
+    }
+    log.info("Trust-framework bundles loaded — classpath={}, overlay={}, added={}, total={}, overridePath={}",
+        classpathCount, overlayCount, addedCount, byId.size(), overridePath);
+  }
 
   /**
    * Scans the classpath for {@code trustframeworks/<bundleId>/framework.yaml} files and loads each as a bundle.
    * Non-loadable bundles are skipped with a warning; they do not abort the load of remaining bundles.
+   *
+   * @deprecated Use {@link #load()} instead.
    */
+  @Deprecated
   public List<TrustFrameworkBundle> loadFromClasspath() throws IOException {
-    var resolver = new PathMatchingResourcePatternResolver();
-    Resource[] yamls = resolver.getResources(BUNDLE_PATTERN);
-    return loadBundles(yamls);
+    return load();
   }
 
   /**
@@ -91,5 +217,35 @@ public class TrustFrameworkBundleLoader {
       log.warn("Could not load '{}' alongside '{}': {}", filename, yamlResource.getFilename(), e.getMessage());
       return null;
     }
+  }
+
+  /**
+   * Produces a new map by deep-merging {@code patch} onto {@code base}.
+   *
+   * <p>Merge rules:
+   * <ul>
+   *   <li>If both values for a key are {@link Map}s, the values are recursively merged.</li>
+   *   <li>In all other cases (scalar, list, null, or type mismatch), the patch value wins.</li>
+   * </ul>
+   * Neither input map is mutated.
+   *
+   * @param base  the map providing default values
+   * @param patch the map whose values take precedence
+   * @return a new map containing the merged result
+   */
+  @SuppressWarnings("unchecked") // safe: both values are verified to be Map<String,Object> before cast
+  private static Map<String, Object> deepMerge(Map<String, Object> base, Map<String, Object> patch) {
+    var result = new LinkedHashMap<>(base);
+    for (Map.Entry<String, Object> entry : patch.entrySet()) {
+      String key = entry.getKey();
+      Object patchValue = entry.getValue();
+      Object baseValue = result.get(key);
+      if (baseValue instanceof Map && patchValue instanceof Map) {
+        result.put(key, deepMerge((Map<String, Object>) baseValue, (Map<String, Object>) patchValue));
+      } else {
+        result.put(key, patchValue);
+      }
+    }
+    return result;
   }
 }

--- a/fc-service-core/src/main/resources/trustframeworks/mock-2026/framework.yaml
+++ b/fc-service-core/src/main/resources/trustframeworks/mock-2026/framework.yaml
@@ -1,10 +1,8 @@
-# Mock Trust Framework bundle — for local development and integration testing only
-#
-# This bundle is intentionally minimal: no ontology, no SHACL shapes.
-# validation_type is "shacl" so the bundle is indexed by TrustFrameworkRegistry,
-# but there are no shape files to validate against.
-#
-# serviceUrl should be overridden per environment (e.g. WireMock container in compose).
+# Mock Trust Framework bundle
+# This bundle IS the "call a GXDCH compliance service" code path; it targets a WireMock stub
+# in local-dev and BDD environments (driven by @uses.compliance-mock scenarios).
+# This bundle remains as the permanent
+# local-dev / BDD compliance-stub path. No ontology or SHACL shapes: intentionally minimal.
 
 id: mock-2026
 family: mock

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/GaiaXBundleBootTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/GaiaXBundleBootTest.java
@@ -23,7 +23,7 @@ class GaiaXBundleBootTest {
   private static final String GX_LEGAL_PERSON = "https://w3id.org/gaia-x/2511#LegalPerson";
 
   private List<TrustFrameworkBundle> loadBundles() throws IOException {
-    return new TrustFrameworkBundleLoader().loadFromClasspath();
+    return new TrustFrameworkBundleLoader().load();
   }
 
   @Test

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleLoaderTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleLoaderTest.java
@@ -16,9 +16,12 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 
@@ -162,6 +165,257 @@ class TrustFrameworkBundleLoaderTest {
     assertThatThrownBy(() -> loader.loadBundle(yamlResource))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("id");
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Filesystem override tests (load())
+  // ──────────────────────────────────────────────────────────────────
+
+  private static final String CLASSPATH_BUNDLE_ID = "gaia-x-2511";
+  private static final String OVERRIDE_TRUST_ANCHOR_URL = "https://override.example.com/trustanchor";
+  private static final String NEW_BUNDLE_ID = "custom-framework-test";
+
+  @Test
+  void load_overridePathBlank_returnsClasspathBundlesOnly() throws IOException {
+    var loaderNoOverride = new TrustFrameworkBundleLoader("");
+
+    var bundles = loaderNoOverride.load();
+
+    assertThat(bundles)
+        .as("blank override path must return classpath bundles unchanged")
+        .anyMatch(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()));
+    assertThat(bundles)
+        .as("no extra bundles should be injected when override path is blank")
+        .noneMatch(b -> NEW_BUNDLE_ID.equals(b.config().id()));
+  }
+
+  @Test
+  void load_overridePathPointsToBundleWithSameId_overridesClasspathBundle(@TempDir Path tempDir) throws IOException {
+    String overrideYaml = "id: " + CLASSPATH_BUNDLE_ID + "\n"
+        + "family: gaia-x\n"
+        + "namespace: \"https://w3id.org/gaia-x/2511#\"\n"
+        + "validation_type: shacl\n"
+        + "properties:\n"
+        + "  trust_anchor_url: \"" + OVERRIDE_TRUST_ANCHOR_URL + "\"\n";
+    Path bundleDir = tempDir.resolve(CLASSPATH_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), overrideYaml);
+
+    var loaderWithOverride = new TrustFrameworkBundleLoader(tempDir.toString());
+
+    var bundles = loaderWithOverride.load();
+
+    var overridden = bundles.stream()
+        .filter(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()))
+        .findFirst();
+    assertThat(overridden)
+        .as("bundle with id '" + CLASSPATH_BUNDLE_ID + "' must be present after override")
+        .isPresent();
+    assertThat(overridden.get().config().properties().get("trust_anchor_url"))
+        .as("trust_anchor_url must match the filesystem override, not the classpath default")
+        .isEqualTo(OVERRIDE_TRUST_ANCHOR_URL);
+  }
+
+  @Test
+  void load_overridePathPointsToBundleWithNewId_addsBundle(@TempDir Path tempDir) throws IOException {
+    String newBundleYaml = "id: " + NEW_BUNDLE_ID + "\n"
+        + "family: custom\n"
+        + "namespace: \"https://example.com/custom#\"\n"
+        + "validation_type: shacl\n";
+    Path bundleDir = tempDir.resolve(NEW_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), newBundleYaml);
+
+    var loaderWithOverride = new TrustFrameworkBundleLoader(tempDir.toString());
+
+    var bundles = loaderWithOverride.load();
+
+    assertThat(bundles)
+        .as("new bundle id must appear in the returned list")
+        .anyMatch(b -> NEW_BUNDLE_ID.equals(b.config().id()));
+    assertThat(bundles.stream().filter(b -> NEW_BUNDLE_ID.equals(b.config().id())).count())
+        .as("new bundle must appear exactly once")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void load_overridePathDoesNotExist_logsWarningAndReturnsClasspathOnly() throws IOException {
+    var logs = startCapturingLogs(TrustFrameworkBundleLoader.class);
+    String nonExistentPath = "/tmp/nonexistent-trust-override-" + System.nanoTime();
+    var loaderBadPath = new TrustFrameworkBundleLoader(nonExistentPath);
+
+    var bundles = loaderBadPath.load();
+
+    assertThat(bundles)
+        .as("classpath bundles must still be returned when override path does not exist")
+        .anyMatch(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()));
+    assertThat(logs.list)
+        .as("a WARN must be logged when the override directory does not exist")
+        .anyMatch(e -> e.getLevel() == Level.WARN
+            && e.getFormattedMessage().contains(nonExistentPath));
+  }
+
+  // ──────────────────────────────────────────────────────────────────
+  // Overlay semantics tests (load() — introduced with deep-merge support)
+  // ──────────────────────────────────────────────────────────────────
+
+  private static final String CLASSPATH_NAMESPACE = "https://w3id.org/gaia-x/2511#";
+  private static final String CLASSPATH_TRUST_ANCHOR_URL =
+      "https://registry.lab.gaia-x.eu/v1/api/trustAnchor/chain/file";
+  private static final String OVERLAY_TRUST_ANCHOR_URL = "https://did-server/api/trustAnchor/chain/file";
+  private static final String OVERLAY_CUSTOM_FLAG_KEY = "custom_flag";
+  private static final String OVERLAY_CUSTOM_FLAG_VALUE = "yes";
+  private static final String OVERLAY_NAMESPACE = "https://example.org/overlay-test#";
+
+  @Test
+  void load_overlayPatchesOnlyProperties_mergesIntoClasspathBase(@TempDir Path tempDir) throws IOException {
+    // Arrange: filesystem bundle provides only id + one property
+    String overlayYaml = "id: " + CLASSPATH_BUNDLE_ID + "\n"
+        + "properties:\n"
+        + "  trust_anchor_url: \"" + OVERLAY_TRUST_ANCHOR_URL + "\"\n";
+    Path bundleDir = tempDir.resolve(CLASSPATH_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), overlayYaml);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert
+    var bundle = bundles.stream()
+        .filter(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(bundle.config().properties().get("trust_anchor_url"))
+        .as("filesystem override must win for trust_anchor_url")
+        .isEqualTo(OVERLAY_TRUST_ANCHOR_URL);
+    assertThat(bundle.config().namespace())
+        .as("namespace must be inherited from classpath bundle")
+        .isEqualTo(CLASSPATH_NAMESPACE);
+    assertThat(bundle.config().roles())
+        .as("roles must be inherited from classpath bundle")
+        .containsKey("Participant");
+  }
+
+  @Test
+  void load_overlayAddsNewPropertyKey_preservesExistingProperties(@TempDir Path tempDir) throws IOException {
+    // Arrange: overlay adds a new property key while keeping existing keys intact
+    String overlayYaml = "id: " + CLASSPATH_BUNDLE_ID + "\n"
+        + "properties:\n"
+        + "  " + OVERLAY_CUSTOM_FLAG_KEY + ": \"" + OVERLAY_CUSTOM_FLAG_VALUE + "\"\n";
+    Path bundleDir = tempDir.resolve(CLASSPATH_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), overlayYaml);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert
+    var bundle = bundles.stream()
+        .filter(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(bundle.config().properties())
+        .as("new property key from overlay must be present")
+        .containsEntry(OVERLAY_CUSTOM_FLAG_KEY, OVERLAY_CUSTOM_FLAG_VALUE);
+    assertThat(bundle.config().properties())
+        .as("original classpath property must be preserved when not overridden")
+        .containsKey("trust_anchor_url");
+    assertThat(bundle.config().properties().get("trust_anchor_url"))
+        .as("classpath trust_anchor_url must be unchanged when overlay does not touch it")
+        .isEqualTo(CLASSPATH_TRUST_ANCHOR_URL);
+  }
+
+  @Test
+  void load_overlayWithDifferentScalarField_overridesClasspathValue(@TempDir Path tempDir) throws IOException {
+    // Arrange: overlay changes a top-level scalar (namespace) only
+    String overlayYaml = "id: " + CLASSPATH_BUNDLE_ID + "\n"
+        + "namespace: \"" + OVERLAY_NAMESPACE + "\"\n";
+    Path bundleDir = tempDir.resolve(CLASSPATH_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), overlayYaml);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert
+    var bundle = bundles.stream()
+        .filter(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(bundle.config().namespace())
+        .as("namespace must be replaced by the overlay value")
+        .isEqualTo(OVERLAY_NAMESPACE);
+  }
+
+  @Test
+  void load_overlayMissingId_isSkippedWithWarning(@TempDir Path tempDir) throws IOException {
+    // Arrange: filesystem YAML has properties but no id field
+    String noIdYaml = "properties:\n  trust_anchor_url: \"https://should-be-ignored.example.com\"\n";
+    Path bundleDir = tempDir.resolve("no-id-bundle");
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), noIdYaml);
+    var logs = startCapturingLogs(TrustFrameworkBundleLoader.class);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert
+    assertThat(bundles)
+        .as("classpath bundles must be returned unchanged when overlay has no id")
+        .anyMatch(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()));
+    assertThat(logs.list)
+        .as("a WARN must be logged mentioning the missing id")
+        .anyMatch(e -> e.getLevel() == ch.qos.logback.classic.Level.WARN
+            && e.getFormattedMessage().contains("id"));
+  }
+
+  @Test
+  void load_overlayWithoutSiblingFiles_inheritsClasspathSiblings(@TempDir Path tempDir) throws IOException {
+    // Arrange: overlay dir has only framework.yaml; gaia-x-2511 classpath bundle ships ontology.ttl + shapes.ttl
+    String overlayYaml = "id: " + CLASSPATH_BUNDLE_ID + "\n"
+        + "properties:\n"
+        + "  trust_anchor_url: \"" + OVERLAY_TRUST_ANCHOR_URL + "\"\n";
+    Path bundleDir = tempDir.resolve(CLASSPATH_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), overlayYaml);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert: ontology and shapes must be non-null (inherited from classpath gaia-x-2511 bundle)
+    var bundle = bundles.stream()
+        .filter(b -> CLASSPATH_BUNDLE_ID.equals(b.config().id()))
+        .findFirst()
+        .orElseThrow();
+    assertThat(bundle.ontology())
+        .as("ontology must be inherited from classpath bundle when overlay provides no ontology.ttl")
+        .isNotNull();
+    assertThat(bundle.shapes())
+        .as("shapes must be inherited from classpath bundle when overlay provides no shapes.ttl")
+        .isNotNull();
+  }
+
+  @Test
+  void load_filesystemNewId_stillAddsAsFullBundle(@TempDir Path tempDir) throws IOException {
+    // Arrange: filesystem bundle has a brand-new id not present in the classpath
+    String newBundleYaml = "id: " + NEW_BUNDLE_ID + "\n"
+        + "family: custom\n"
+        + "namespace: \"https://example.com/custom#\"\n"
+        + "validation_type: shacl\n";
+    Path bundleDir = tempDir.resolve(NEW_BUNDLE_ID);
+    Files.createDirectories(bundleDir);
+    Files.writeString(bundleDir.resolve("framework.yaml"), newBundleYaml);
+
+    // Act
+    var bundles = new TrustFrameworkBundleLoader(tempDir.toString()).load();
+
+    // Assert
+    assertThat(bundles)
+        .as("new bundle id must appear in the returned list")
+        .anyMatch(b -> NEW_BUNDLE_ID.equals(b.config().id()));
+    assertThat(bundles.stream().filter(b -> NEW_BUNDLE_ID.equals(b.config().id())).count())
+        .as("new bundle must appear exactly once")
+        .isEqualTo(1);
   }
 
   // ──────────────────────────────────────────────────────────────────

--- a/fc-service-server/src/main/resources/application.yml
+++ b/fc-service-server/src/main/resources/application.yml
@@ -167,6 +167,11 @@ federated-catalogue:
   # Env: FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS=gaia-x
   # Per-framework verification config (e.g. trust anchor URL) lives in the bundle, not here.
   enabled-trust-frameworks: ""
+  trust-frameworks:
+    # Path to a directory of filesystem bundle subdirectories that override (by id) or extend the classpath bundles.
+    # Filesystem bundles with a matching id replace the classpath bundle; new ids are appended.
+    # Env: FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH=/path/to/trustframeworks
+    override-path: "${FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH:}"
   verification:
     http-timeout: 3000
 


### PR DESCRIPTION
## 🚀 Summary

Trust-framework bundles can now be customised or added at deployment time without rebuilding the JAR. A new filesystem override directory is scanned alongside the classpath; entries whose `id` matches a classpath bundle deep-merge onto the classpath base, so an overlay only needs to declare the fields it changes. The Docker dev stack uses this to redirect the Gaia-X bundle's trust anchor URL at the internal `did-server` mock, and to wire a `mock-2026` bundle's compliance `service_url` at a new WireMock-based compliance-service stub — unblocking the trust-anchor and compliance verification paths in BDD tests, which previously failed because the JAR-baked URLs pointed at unreachable public Gaia-X infrastructure.

This change is part of the Enhancement of XFSC Federated Catalogue. Details (permalink):

https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

## ✅ What's Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

1. Rebuild and start the strict dev stack:
   ```bash
   cd federated-catalogue
   mvn clean install -DskipTests -Dcheckstyle.skip
   cd docker
   docker compose -f docker-compose.yml -f docker-compose.strict.yml --env-file dev.env up -d --build --force-recreate server
   ```
2. Confirm the override loaded — `docker logs fc-server | grep -i "trust-framework bundles loaded"` should report `overlay=2` (or similar) and reference the override path.
3. Run the cat-integration-tests BDD suite. The four previously-failing trust-anchor / compliance scenarios (signed-VP upload under strict config, valid-signature verify, validatorDids under strict, and Gaia-X-with-valid-trust-anchor accepted) should pass.
4. Unit-level: `mvn -pl fc-service-core test -Dtest=TrustFrameworkBundleLoaderTest` (15 tests, all green) covers blank/missing/new-id/overlay/sibling-inheritance paths.

## 🔍 Related Issues

#125 

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] I've updated documentation if necessary: https://github.com/eclipse-xfsc/docs/compare/main...federated-catalogue-enhancements-2026:docs:merge-to-upstream/CAT-FR-CO-03_part-3_external-trust-framework-bundle-overrides?expand=1
- [x] My changes follow the project's coding style
