### PR TITLE
Enhancement [CAT-FR-AU-01]: per-role trust-framework toggles

### DIFF
--- a/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
@@ -78,6 +78,8 @@ $(document).ready(function() {
               .attr('data-url',     data.serviceUrl || '')
               .attr('data-version', data.apiVersion || '')
               .attr('data-timeout', data.timeoutSeconds || 30)
+              .attr('data-enabled', data.enabled ? 'true' : 'false')
+              .attr('data-bundles', JSON.stringify(data.bundles || []))
               .append('<i class="bi bi-gear"></i>')
               .prop('outerHTML');
           }
@@ -104,12 +106,102 @@ $(document).ready(function() {
     // Config button handler
     $('#tfTable').on('click', '.tf-config', function() {
       var $btn = $(this);
+      var familyEnabled = $btn.data('enabled') === 'true' || $btn.data('enabled') === true;
+      var bundles = $btn.data('bundles') || [];
+      if (typeof bundles === 'string') {
+        try { bundles = JSON.parse(bundles); } catch(e) { bundles = []; }
+      }
+
       $('#tfConfigId').val($btn.data('id'));
       $('#tfServiceUrl').val($btn.data('url'));
       $('#tfApiVersion').val($btn.data('version'));
       $('#tfTimeout').val($btn.data('timeout'));
+
+      // Render role checkboxes
+      var $container = $('#tfRolesContainer').empty();
+      $('#tfRoleErrorBanner').hide();
+      var multiBundle = bundles.length > 1;
+      bundles.forEach(function(bundle) {
+        var roles = bundle.roles || {};
+        Object.keys(roles).forEach(function(roleName) {
+          var roleEnabled = roles[roleName];
+          var inputId = 'role-' + bundle.id + '-' + roleName;
+          var $check = $('<div class="form-check">').append(
+            $('<input>', {
+              type: 'checkbox',
+              class: 'form-check-input tf-role-toggle',
+              id: inputId,
+              'data-bundle': bundle.id,
+              'data-role': roleName
+            })
+              .prop('checked', roleEnabled)
+              .prop('disabled', !familyEnabled),
+            $('<label>', {
+              class: 'form-check-label' + (!familyEnabled ? ' text-muted' : ''),
+              for: inputId,
+              title: 'When disabled, this role and all its OWL subclasses reject credentials with HTTP 400.',
+              'data-bs-toggle': 'tooltip'
+            }).append(
+              document.createTextNode(roleName + ' '),
+              multiBundle
+                ? $('<small class="text-muted">').text('(' + bundle.id + ')')
+                : $()
+            )
+          );
+          $container.append($check);
+        });
+      });
+
+      // Initialize Bootstrap tooltips for the newly rendered labels
+      $container.find('[data-bs-toggle="tooltip"]').each(function() {
+        new bootstrap.Tooltip(this);
+      });
+
+      $('#tfConfigModal').data('familyEnabled', familyEnabled);
+      recomputeAllDisabledWarning(familyEnabled);
       new bootstrap.Modal('#tfConfigModal').show();
     });
+
+    // Role toggle change handler
+    $('#tfConfigModal').on('change', '.tf-role-toggle', function() {
+      var $cb = $(this);
+      var bundleId = $cb.data('bundle');
+      var roleName = $cb.data('role');
+      var enabled = $cb.is(':checked');
+
+      $.ajax({
+        url: '/admin/trust-frameworks/' + encodeURIComponent(bundleId)
+          + '/roles/' + encodeURIComponent(roleName)
+          + '/enabled?enabled=' + enabled,
+        type: 'PUT',
+        success: function() {
+          $('#tfRoleErrorBanner').hide();
+          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+        },
+        error: function() {
+          $cb.prop('checked', !enabled);
+          // Recompute the all-disabled warning after the checkbox revert so it
+          // reflects the current (reverted) state rather than the failed toggle.
+          // Reproduction: disable the last enabled role → server returns 5xx →
+          // checkbox reverts to checked but warning remained visible (stale state).
+          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+          var $banner = $('#tfRoleErrorBanner');
+          $banner.text('Failed to update role "' + roleName + '". Please try again.').show();
+          clearTimeout($banner.data('hideTimer'));
+          $banner.data('hideTimer', setTimeout(function() { $banner.hide(); }, 5000));
+        }
+      });
+    });
+
+    function recomputeAllDisabledWarning(familyEnabled) {
+      if (!familyEnabled) {
+        $('#tfRolesAllDisabledWarning').hide();
+        return;
+      }
+      var allUnchecked = $('#tfRolesContainer .tf-role-toggle:checked').length === 0
+        && $('#tfRolesContainer .tf-role-toggle').length > 0;
+      $('#tfRolesAllDisabledWarning').toggle(allUnchecked);
+    }
 
     // Config save handler
     $('#tfConfigSave').on('click', function() {

--- a/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
@@ -40,6 +40,13 @@
                             <label for="tfTimeout" class="form-label">Timeout (seconds)</label>
                             <input type="number" class="form-control" id="tfTimeout" min="1" max="300" value="30">
                         </div>
+                        <hr>
+                        <h6>Roles</h6>
+                        <div id="tfRoleErrorBanner" class="alert alert-danger" style="display:none"></div>
+                        <div id="tfRolesAllDisabledWarning" class="alert alert-warning" style="display:none">
+                            All roles are disabled — this bundle is enabled but cannot resolve any credentials.
+                        </div>
+                        <div id="tfRolesContainer"></div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleState.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleState.java
@@ -1,0 +1,62 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Persists the enabled/disabled state of a single role within a trust framework bundle.
+ *
+ * <p>Absence of a row for a given {@code (frameworkId, roleName)} pair means the role is enabled
+ * by default. Only rows with {@code enabled = false} (or explicit {@code true} overrides written
+ * by the service) are stored here.
+ *
+ * <p>{@code frameworkId} is the registry bundle profile ID (e.g. {@code gaia-x-2511}).
+ * {@code roleName} is the role name declared in the bundle's {@code framework.yaml}
+ * (e.g. {@code Participant}).
+ */
+@Entity
+@Table(name = "trust_framework_role_states")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrustFrameworkRoleState {
+
+  @EmbeddedId
+  private TrustFrameworkRoleStateId id;
+
+  @Column(name = "enabled", nullable = false)
+  private boolean enabled;
+
+  /**
+   * Convenience constructor.
+   *
+   * @param frameworkId registry bundle profile ID
+   * @param roleName    role name from the bundle's roles map
+   * @param enabled     whether this role is enabled
+   */
+  public TrustFrameworkRoleState(String frameworkId, String roleName, boolean enabled) {
+    this.id = new TrustFrameworkRoleStateId(frameworkId, roleName);
+    this.enabled = enabled;
+  }
+
+  /**
+   * Returns the bundle profile ID component of the composite key.
+   */
+  public String getFrameworkId() {
+    return id.getFrameworkId();
+  }
+
+  /**
+   * Returns the role name component of the composite key.
+   */
+  public String getRoleName() {
+    return id.getRoleName();
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateId.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateId.java
@@ -1,0 +1,31 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Composite primary key for {@link TrustFrameworkRoleState}.
+ *
+ * <p>{@code frameworkId} is the registry bundle profile ID (e.g. {@code gaia-x-2511});
+ * {@code roleName} is the role name as declared in the bundle's {@code framework.yaml}
+ * (e.g. {@code Participant}).
+ */
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrustFrameworkRoleStateId implements Serializable {
+
+  @Column(name = "framework_id", length = 255, nullable = false)
+  private String frameworkId;
+
+  @Column(name = "role_name", length = 255, nullable = false)
+  private String roleName;
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateRepository.java
@@ -1,0 +1,52 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for per-role enabled state of trust framework bundles.
+ *
+ * <p>Absence of a row means the role is enabled by default (interpreted in the service layer).
+ * This repository stores only rows that have been explicitly written via
+ * {@link eu.xfsc.fc.core.service.trustframework.TrustFrameworkService#setRoleEnabled}.
+ */
+public interface TrustFrameworkRoleStateRepository
+    extends JpaRepository<TrustFrameworkRoleState, TrustFrameworkRoleStateId> {
+
+  /**
+   * Finds the persisted state row for a specific bundle profile ID and role name.
+   * Returns empty when no explicit state has been written (default = enabled).
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @return the state row, or empty if absent
+   */
+  Optional<TrustFrameworkRoleState> findByIdFrameworkIdAndIdRoleName(
+      String frameworkId, String roleName);
+
+  /**
+   * Returns all explicitly persisted state rows for the given bundle profile ID.
+   * Roles absent from this list are enabled by default.
+   *
+   * @param frameworkId registry bundle profile ID
+   * @return list of state rows; never null
+   */
+  List<TrustFrameworkRoleState> findByIdFrameworkId(String frameworkId);
+
+  /**
+   * Convenience alias for {@link #findByIdFrameworkId(String)}.
+   */
+  default List<TrustFrameworkRoleState> findByFrameworkId(String frameworkId) {
+    return findByIdFrameworkId(frameworkId);
+  }
+
+  /**
+   * Convenience alias for looking up a single role state by bundle profile ID and role name.
+   */
+  default Optional<TrustFrameworkRoleState> findByFrameworkIdAndRoleName(
+      String frameworkId, String roleName) {
+    return findByIdFrameworkIdAndIdRoleName(frameworkId, roleName);
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
@@ -5,10 +5,14 @@ import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileCo
 
 import java.io.StringReader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -79,7 +83,7 @@ public class TrustFrameworkRegistry {
    * @param bundles the list of bundles to register
    */
   public TrustFrameworkRegistry(List<TrustFrameworkBundle> bundles) {
-    this.bundleIndex = new HashMap<>();
+    this.bundleIndex = new LinkedHashMap<>();
     this.typeIndex = new HashMap<>();
     var active = new java.util.HashSet<String>();
     for (TrustFrameworkBundle bundle : bundles) {
@@ -137,9 +141,12 @@ public class TrustFrameworkRegistry {
 
   /**
    * Returns every bundle that was registered at construction time, whether active or deferred.
+   * The iteration order matches the order in which bundles were registered (i.e. the order of
+   * the {@code bundles} list passed to the constructor); duplicate IDs are skipped on first
+   * occurrence.
    * Modifications to the returned collection will not affect the registry's internal state.
    *
-   * @return immutable collection of all registered bundles; never null
+   * @return immutable collection of all registered bundles in registration order; never null
    */
   public Collection<TrustFrameworkBundle> getAllBundles() {
     return List.copyOf(bundleIndex.values());
@@ -215,16 +222,19 @@ public class TrustFrameworkRegistry {
   }
 
   /**
-   * Returns the set of effective role names declared in the bundle associated with the given profile ID.
+   * Returns an ordered, unmodifiable set of effective role names declared in the bundle associated with the given profile ID.
+   * The returned set preserves the declaration order from the bundle YAML configuration.
    * If no bundle is registered under the profile ID, returns an empty set.
    *
    * @param profileId the ID of the profile to look up
-   * @return a set of role names declared in the bundle, or an empty set if no bundle is registered under the profile ID
+   * @return an ordered unmodifiable set of role names declared in the bundle, or an empty set if no bundle is registered under the profile ID
    */
-  public Set<String> getEffectiveRoles(String profileId) {
-    return bundleIndex.containsKey(profileId)
-        ? Set.copyOf(bundleIndex.get(profileId).config().roles().keySet())
-        : Set.of();
+  public SequencedSet<String> getEffectiveRoles(String profileId) {
+    if (!bundleIndex.containsKey(profileId)) {
+      return Collections.unmodifiableSequencedSet(new LinkedHashSet<>());
+    }
+    return Collections.unmodifiableSequencedSet(
+        new LinkedHashSet<>(bundleIndex.get(profileId).config().roles().keySet()));
   }
 
   /**

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
@@ -3,11 +3,18 @@ package eu.xfsc.fc.core.service.trustframework;
 import eu.xfsc.fc.core.dao.trustframework.TrustFramework;
 import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkMapper;
 import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRepository;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleState;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateId;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateRepository;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrustFrameworkService {
 
   private final TrustFrameworkRepository trustFrameworkRepository;
+  private final TrustFrameworkRoleStateRepository roleStateRepository;
+  private final TrustFrameworkRegistry trustFrameworkRegistry;
 
   /**
    * Returns true if the trust framework identified by the given family ID has its enabled
@@ -87,5 +96,98 @@ public class TrustFrameworkService {
       trustFrameworkRepository.save(entity);
       return TrustFrameworkMapper.toConfig(entity);
     });
+  }
+
+  /**
+   * Returns true if the named role in the given bundle profile is enabled.
+   * Absence of a persisted state row means the role is enabled by default.
+   *
+   * <p><strong>Bundle-off dominance:</strong> when the bundle's family is
+   * disabled in persistence, this method returns {@code true} regardless of the role's
+   * persisted state. The role-toggle layer has no effect while the bundle is off — rejection
+   * is handled by the bundle-disabled pathway in the caller. This prevents a double-rejection
+   * and makes role-toggle state semantically inert for disabled bundles.
+   *
+   * <p>This method does not validate that the bundle or role is registered —
+   * call sites that need validation should use {@link #setRoleEnabled} or
+   * {@link #getRoleStates}, which both throw on unknown input.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @return true if enabled (including default when no row exists, or when bundle family is
+   *         disabled), false if explicitly disabled and the bundle family is enabled
+   */
+  @Transactional(readOnly = true)
+  public boolean isRoleEnabled(String frameworkId, String roleName) {
+    // Bundle-off dominance: if the bundle's family is disabled, the role-toggle is bypassed.
+    // Unknown frameworkId → no bundle → no family to look up → fall through to role-state check.
+    boolean familyDisabled = trustFrameworkRegistry.getBundle(frameworkId)
+        .map(bundle -> bundle.config().family())
+        .flatMap(trustFrameworkRepository::findById)
+        .map(tf -> !tf.isEnabled())
+        .orElse(false);
+    if (familyDisabled) {
+      return true;
+    }
+    return roleStateRepository.findByFrameworkIdAndRoleName(frameworkId, roleName)
+        .map(TrustFrameworkRoleState::isEnabled)
+        .orElse(true);
+  }
+
+  /**
+   * Persists the enabled/disabled state for a named role in the given bundle profile.
+   * Creates or updates the state row (upsert). Validates that the bundle and role both
+   * exist in the registry before writing.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @param enabled     new enabled state
+   * @throws NotFoundException when the bundle profile ID or the role name is not registered
+   */
+  @Transactional
+  public void setRoleEnabled(String frameworkId, String roleName, boolean enabled) {
+    if (trustFrameworkRegistry.getBundle(frameworkId).isEmpty()) {
+      throw new NotFoundException("Trust framework bundle not found in registry: " + frameworkId);
+    }
+    SequencedSet<String> knownRoles = trustFrameworkRegistry.getEffectiveRoles(frameworkId);
+    if (!knownRoles.contains(roleName)) {
+      throw new NotFoundException(
+          "Role '%s' not declared in bundle '%s'".formatted(roleName, frameworkId));
+    }
+    var id = new TrustFrameworkRoleStateId(frameworkId, roleName);
+    var state = roleStateRepository.findById(id)
+        .map(existing -> {
+          existing.setEnabled(enabled);
+          return existing;
+        })
+        .orElseGet(() -> new TrustFrameworkRoleState(frameworkId, roleName, enabled));
+    roleStateRepository.save(state);
+  }
+
+  /**
+   * Returns the full map of role name → effective enabled state for all roles declared in the
+   * given bundle. Merges persisted overrides with the default-true for absent rows.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @return map of role name → effective enabled state; never null; preserves declaration order
+   * @throws NotFoundException when the bundle profile ID is not registered in the registry
+   */
+  @Transactional(readOnly = true)
+  public Map<String, Boolean> getRoleStates(String frameworkId) {
+    if (trustFrameworkRegistry.getBundle(frameworkId).isEmpty()) {
+      throw new NotFoundException("Trust framework bundle not found in registry: " + frameworkId);
+    }
+    SequencedSet<String> knownRoles = trustFrameworkRegistry.getEffectiveRoles(frameworkId);
+    // Index persisted overrides by role name for O(1) lookup
+    Map<String, Boolean> persisted = roleStateRepository.findByFrameworkId(frameworkId).stream()
+        .collect(Collectors.toMap(
+            TrustFrameworkRoleState::getRoleName,
+            TrustFrameworkRoleState::isEnabled));
+
+    Map<String, Boolean> result = new LinkedHashMap<>();
+    for (String role : knownRoles) {
+      result.put(role, persisted.getOrDefault(role, true));
+    }
+    return result;
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
@@ -563,7 +563,8 @@ public class CredentialVerificationStrategy implements RdfIngestionStrategy {
             ? schemaStore.getCompositeSchema(SchemaStore.SchemaType.ONTOLOGY)
             : null;
     ResolvedRole result = ClaimValidator.resolveSubjectRole(
-        getStreamManager(), credential.toJson(), trustFrameworkRegistry, compositeOntology);
+        getStreamManager(), credential.toJson(), trustFrameworkRegistry, compositeOntology,
+        trustFrameworkService::isRoleEnabled);
     log.debug("resolveRole; format: {}, got role: {}", format, result);
     return result;
   }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,6 +33,7 @@ import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.shared.impl.JenaParameters;
 import org.apache.jena.vocabulary.RDF;
 
+import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.QueryException;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.RdfClaim;
@@ -45,6 +47,14 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ClaimValidator {
+
+  /**
+   * Message template for role-toggle rejection. Used in {@link ClientException} when a resolved
+   * role is explicitly disabled.
+   * Arguments (in order): {@code frameworkProfileId}, {@code role}.
+   */
+  static final String ROLE_DISABLED_MSG = "Trust framework role '%s/%s' is disabled";
+
     // Stored to temporarily deviate from the standard Jena behavior of parsing
     // literals
 	// don't see how it can work in multithreaded scenario!
@@ -184,10 +194,15 @@ public class ClaimValidator {
    * @param subject           JSON-LD credential string whose {@code credentialSubject} type is inspected
    * @param registry          the active trust-framework registry
    * @param compositeOntology union ontology to use as fallback; may be {@code null}
+   * @param isRoleEnabled     predicate {@code (bundleId, roleName) -> enabled}; when it returns
+   *                          {@code false} for the matched role a {@link ClientException} is thrown
    * @return the first resolved role, or {@link ResolvedRole#UNKNOWN} when no framework claims the type
+   * @throws ClientException when the matched role is disabled according to {@code isRoleEnabled}
    */
   public static ResolvedRole resolveSubjectRole(StreamManager sm, String subject,
-                                                TrustFrameworkRegistry registry, ContentAccessor compositeOntology) {
+                                                TrustFrameworkRegistry registry,
+                                                ContentAccessor compositeOntology,
+                                                BiPredicate<String, String> isRoleEnabled) {
         try {
           Model data = ModelFactory.createDefaultModel();
           RDFParser.create()
@@ -207,14 +222,20 @@ public class ClaimValidator {
               String typeUri = rdfNode.asResource().getURI();
               ResolvedRole role = registry.resolveRole(typeUri);
               if (role.isResolved()) {
+                if (!isRoleEnabled.test(role.frameworkProfileId(), role.role())) {
+                  throw new ClientException(
+                      ROLE_DISABLED_MSG.formatted(role.frameworkProfileId(), role.role()));
+                }
                 return role;
               }
               unresolved.add(typeUri);
             }
           }
           if (compositeOntology != null && !unresolved.isEmpty()) {
-            return resolveViaOntology(unresolved, registry, compositeOntology);
+            return resolveViaOntology(unresolved, registry, compositeOntology, isRoleEnabled);
           }
+        } catch (ClientException ce) {
+          throw ce;
         } catch (Exception e) {
           log.debug("resolveSubjectRole.error: {}", e.getMessage());
         }
@@ -222,7 +243,9 @@ public class ClaimValidator {
   }
 
   private static ResolvedRole resolveViaOntology(List<String> typeUris,
-                                                 TrustFrameworkRegistry registry, ContentAccessor compositeOntology) {
+                                                 TrustFrameworkRegistry registry,
+                                                 ContentAccessor compositeOntology,
+                                                 BiPredicate<String, String> isRoleEnabled) {
     OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM_MICRO_RULE_INF);
         model.read(new StringReader(compositeOntology.getContentAsString()), null, Lang.TURTLE.getName());
     for (TrustFrameworkBundle bundle : registry.getActiveBundles()) {
@@ -239,6 +262,10 @@ public class ClaimValidator {
         for (String typeUri : typeUris) {
           for (String rootUri : rootUris) {
             if (isSubclassOf(typeUri, rootUri, model)) {
+              if (!isRoleEnabled.test(resolved.frameworkProfileId(), resolved.role())) {
+                throw new ClientException(
+                    ROLE_DISABLED_MSG.formatted(resolved.frameworkProfileId(), resolved.role()));
+              }
               return resolved;
             }
           }

--- a/fc-service-core/src/main/resources/liquibase/changesets/017-trust-framework-role-states.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/017-trust-framework-role-states.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="nowak" id="2026-05-20-trust-framework-role-states">
+        <comment>
+            Per-role enabled/disabled state for trust framework bundles.
+            Absence of a row means enabled=true (default). No seed rows — the existing
+            gaia-x seed row in trust_frameworks is unaffected; all its roles remain enabled
+            by default without needing explicit rows here.
+        </comment>
+
+        <createTable tableName="trust_framework_role_states">
+            <column name="framework_id" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_tf_role_states" nullable="false"/>
+            </column>
+            <column name="role_name" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_tf_role_states" nullable="false"/>
+            </column>
+            <column name="enabled" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -20,4 +20,5 @@
     <include file="changesets/014-provenance-credentials.xml" relativeToChangelogFile="true" />
     <include file="changesets/015-validation-result-outdated.xml" relativeToChangelogFile="true" />
     <include file="changesets/016-content-kind.xml" relativeToChangelogFile="true" />
+    <include file="changesets/017-trust-framework-role-states.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TestTrustFrameworkConstants.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TestTrustFrameworkConstants.java
@@ -6,38 +6,53 @@ package eu.xfsc.fc.core.service.trustframework;
  * <p>These identifiers are test-scoped because they encode specific profile IDs, client-type
  * strings, and service URLs that are only relevant to integration tests. Production code resolves
  * these values from classpath bundle YAML; they must not be inlined in production source.
+ *
+ * <p>Visibility is public for all constants to avoid unnecessary adjustments when scope changes.
  */
-class TestTrustFrameworkConstants {
+public class TestTrustFrameworkConstants {
 
   /**
    * Profile ID of the built-in Gaia-X Loire 2511 bundle.
    */
-  static final String PROFILE_GAIA_X_2511 = "gaia-x-2511";
+  public static final String PROFILE_GAIA_X_2511 = "gaia-x-2511";
+
+  /**
+   * Trust framework family names.
+   */
+  public static final String TFW_FAMILY_GAIA_X = "gaia-x";
 
   /**
    * Client-type string identifying the generic REST + JWT-VC compliance client.
    */
-  static final String CLIENT_TYPE_JWT_VC = "jwt-vc-compliance";
+  public static final String CLIENT_TYPE_JWT_VC = "jwt-vc-compliance";
 
   /**
    * Canonical base URL of the live GXDCH Loire compliance service.
    */
-  static final String GXDCH_LOIRE_SERVICE_URL = "https://compliance.gaia-x.eu/v2";
+  public static final String GXDCH_LOIRE_SERVICE_URL = "https://compliance.gaia-x.eu/v2";
 
   /**
    * Compliance endpoint path used by the Gaia-X Loire / GXDCH deployment.
    */
-  static final String GXDCH_LOIRE_COMPLIANCE_PATH = "/api/credential-offers/standard-compliance";
+  public static final String GXDCH_LOIRE_COMPLIANCE_PATH = "/api/credential-offers/standard-compliance";
 
   /**
    * API version string for the GXDCH Loire v2 compliance protocol.
    */
-  static final String API_VERSION_V2 = "v2";
+  public static final String API_VERSION_V2 = "v2";
 
   /**
    * Expected per-request timeout in seconds for the Loire compliance client.
    */
-  static final int TIMEOUT_SECONDS = 30;
+  public static final int TIMEOUT_SECONDS = 30;
+
+  /**
+   * Roles known to be declared in the default gaia-x bundle (from framework.yaml).
+   */
+  public static final String TFW_ROLE_PARTICIPANT = "Participant";
+  public static final String TFW_ROLE_DIGITAL_SERVICE_OFFERING = "DigitalServiceOffering";
+  public static final String TFW_ROLE_SERVICE_OFFERING = "ServiceOffering";
+  public static final String TFW_ROLE_RESOURCE = "Resource";
 
   private TestTrustFrameworkConstants() {
   }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistryTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistryTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,52 +15,52 @@ import org.junit.jupiter.api.Test;
 
 class TrustFrameworkRegistryTest {
 
-  // Minimal ontology: Participant as a root class, no subclasses declared.
+  // Minimal ontology: RoleA as a root class, no subclasses declared.
   private static final String MINIMAL_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
-      gx:Participant a owl:Class .
+      ex:RoleA a owl:Class .
       """;
 
-  // Ontology with declared subclass: LegalPerson rdfs:subClassOf Participant.
+  // Ontology with declared subclass: RoleASub rdfs:subClassOf RoleA.
   private static final String SUBCLASS_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      gx:LegalPerson a owl:Class ; rdfs:subClassOf gx:Participant .
+      ex:RoleA a owl:Class .
+      ex:RoleASub a owl:Class ; rdfs:subClassOf ex:RoleA .
       """;
 
-  // Ontology where DigitalServiceOffering is NOT a subclass of ServiceOffering (gx-2511 reality).
-  private static final String DSO_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+  // Ontology where RoleBAlt is NOT a subclass of RoleB (framework reality in Gaia-x Loire 2511 ontology).
+  private static final String SIBLING_ROLE_ONTOLOGY = """
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
-      gx:ServiceOffering a owl:Class .
-      gx:DigitalServiceOffering a owl:Class .
+      ex:RoleB a owl:Class .
+      ex:RoleBAlt a owl:Class .
       """;
 
-  // Ontology with 2-hop subclass chain: PrivateLegalPerson → LegalPerson → Participant.
+  // Ontology with 2-hop subclass chain: RoleASubSub → RoleASub → RoleA.
   private static final String TWO_HOP_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      gx:LegalPerson a owl:Class ; rdfs:subClassOf gx:Participant .
-      gx:PrivateLegalPerson a owl:Class ; rdfs:subClassOf gx:LegalPerson .
+      ex:RoleA a owl:Class .
+      ex:RoleASub a owl:Class ; rdfs:subClassOf ex:RoleA .
+      ex:RoleASubSub a owl:Class ; rdfs:subClassOf ex:RoleASub .
       """;
 
-  // Ontology that includes an anonymous (blank-node) subclass of Participant.
+  // Ontology that includes an anonymous (blank-node) subclass of RoleA.
   private static final String BLANK_NODE_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      [] rdfs:subClassOf gx:Participant .
+      ex:RoleA a owl:Class .
+      [] rdfs:subClassOf ex:RoleA .
       """;
 
   private static TrustFrameworkBundle shaclBundle(String profileId, String namespace,
                                                   Map<String, RoleConfig> roles, String ontologyTtl) {
-    var config = new FrameworkBundleConfig(profileId, "gaia-x", namespace, ValidationType.SHACL, roles, Map.of());
+    var config = new FrameworkBundleConfig(profileId, "test-family", namespace, ValidationType.SHACL, roles, Map.of());
     var ontology = new eu.xfsc.fc.core.pojo.ContentAccessorDirect(ontologyTtl);
     return new TrustFrameworkBundle(config, ontology, null);
   }
@@ -79,79 +80,95 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void resolveRole_rootUri_returnsResolvedRole() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/Participant"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleA"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
   @Test
   void resolveRole_subclassOfRoot_returnsResolvedRole() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, SUBCLASS_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SUBCLASS_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    // gx:LegalPerson rdfs:subClassOf gx:Participant — must resolve to Participant
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/LegalPerson"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    // ex:RoleASub rdfs:subClassOf ex:RoleA — must resolve to RoleA
+    assertThat(registry.resolveRole("https://example.org/test/RoleASub"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
-  // additionalRoots: DigitalServiceOffering is NOT a subclass of ServiceOffering in OWL
-  // but is covered via additionalRoots in RoleConfig (gx-2511 workaround)
+  // additionalRoots: RoleBAlt is NOT a subclass of RoleB in OWL
+  // but is covered via additionalRoots in RoleConfig (framework workaround)
   @Test
   void resolveRole_additionalRoot_returnsResolvedRole() {
-    var roles = Map.of("ServiceOffering", new RoleConfig(
-        List.of("https://w3id.org/gaia-x/DigitalServiceOffering"), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, DSO_ONTOLOGY);
+    var roles = Map.of("RoleB", new RoleConfig(
+        List.of("https://example.org/test/RoleBAlt"), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SIBLING_ROLE_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/DigitalServiceOffering"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "ServiceOffering"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleBAlt"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleB"));
   }
 
   @Test
   void resolveRole_2hopSubclassOfRoot_returnsResolvedRole() {
-    // gx:PrivateLegalPerson rdfs:subClassOf gx:LegalPerson rdfs:subClassOf gx:Participant
+    // ex:RoleASubSub rdfs:subClassOf ex:RoleASub rdfs:subClassOf ex:RoleA
     // OWL_MEM_MICRO_RULE_INF infers the transitive closure — both hops must be covered
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, TWO_HOP_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, TWO_HOP_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/PrivateLegalPerson"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleASubSub"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
   @Test
   void resolveRole_firstBundleWinsOnRootUriConflict() {
     // Same root URI claimed by two bundles — first registration must win (putIfAbsent semantics)
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle1 = shaclBundle("framework-a", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
-    var bundle2 = shaclBundle("framework-b", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle1 = shaclBundle("framework-a", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
+    var bundle2 = shaclBundle("framework-b", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle1, bundle2));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/Participant"))
-        .isEqualTo(new ResolvedRole("framework-a", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleA"))
+        .isEqualTo(new ResolvedRole("framework-a", "RoleA"));
   }
 
   // bundle index methods
   @Test
   void getActiveBundles_returnsAllLoadedBundles() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
     assertThat(registry.getActiveBundles()).containsExactly(bundle);
   }
 
   @Test
+  void getAllBundles_preservesRegistrationOrder() {
+    // Three bundles with profile IDs intentionally not in lexicographic order, so a HashMap-backed
+    // index would shuffle them. Iteration must follow input list order.
+    var bundleZ = shaclBundle("z-framework", "https://example.org/z/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+    var bundleA = shaclBundle("a-framework", "https://example.org/a/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+    var bundleM = shaclBundle("m-framework", "https://example.org/m/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+
+    var registry = new TrustFrameworkRegistry(List.of(bundleZ, bundleA, bundleM));
+
+    assertThat(registry.getAllBundles()).containsExactly(bundleZ, bundleA, bundleM);
+  }
+
+  @Test
   void getActiveBundles_returnsImmutableSnapshot() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
     assertThatThrownBy(() -> registry.getActiveBundles().clear())
@@ -160,10 +177,10 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void getBundle_knownProfileId_returnsBundle() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.getBundle("gaia-x-2511")).contains(bundle);
+    assertThat(registry.getBundle("test-framework")).contains(bundle);
   }
 
   @Test
@@ -175,10 +192,10 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void isFrameworkEnabled_knownBundle_returnsTrue() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.isFrameworkEnabled("gaia-x-2511")).isTrue();
+    assertThat(registry.isFrameworkEnabled("test-framework")).isTrue();
   }
 
   @Test
@@ -191,13 +208,13 @@ class TrustFrameworkRegistryTest {
   @Test
   void getEffectiveRoles_knownBundle_returnsRoleNames() {
     var roles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+        "RoleA", new RoleConfig(List.of(), List.of()),
+        "RoleB", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.getEffectiveRoles("gaia-x-2511"))
-        .containsExactlyInAnyOrder("Participant", "ServiceOffering");
+    assertThat(registry.getEffectiveRoles("test-framework"))
+        .containsExactlyInAnyOrder("RoleA", "RoleB");
   }
 
   @Test
@@ -208,12 +225,34 @@ class TrustFrameworkRegistryTest {
   }
 
   @Test
-  void getEffectiveRoles_returnsImmutableSnapshot() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+  void getEffectiveRoles_preservesDeclarationOrder() {
+    // LinkedHashMap fixes the input declaration order; Map.of() would scramble it.
+    // Generic role names — the registry must not assume any framework-specific vocabulary.
+    var roles = new LinkedHashMap<String, RoleConfig>();
+    roles.put("RoleC", new RoleConfig(List.of(), List.of()));
+    roles.put("RoleA", new RoleConfig(List.of(), List.of()));
+    roles.put("RoleB", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles,
+        """
+            @prefix ex: <https://example.org/test/> .
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            ex:RoleA a owl:Class .
+            ex:RoleB a owl:Class .
+            ex:RoleC a owl:Class .
+            """);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThatThrownBy(() -> registry.getEffectiveRoles("gaia-x-2511").add("fake"))
+    assertThat(registry.getEffectiveRoles("test-framework"))
+        .containsExactly("RoleC", "RoleA", "RoleB");
+  }
+
+  @Test
+  void getEffectiveRoles_returnsImmutableSnapshot() {
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
+    var registry = new TrustFrameworkRegistry(List.of(bundle));
+
+    assertThatThrownBy(() -> registry.getEffectiveRoles("test-framework").add("fake"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -249,12 +288,12 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_duplicateBundleId_keepsFirstBundle() {
     // Two bundles with the same ID — first registration wins; second is ignored
-    var bundle1 = shaclBundle("gaia-x-2511", "https://namespace-a.org/", Map.of(), MINIMAL_ONTOLOGY);
-    var bundle2 = shaclBundle("gaia-x-2511", "https://namespace-b.org/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle1 = shaclBundle("test-framework", "https://namespace-a.org/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle2 = shaclBundle("test-framework", "https://namespace-b.org/", Map.of(), MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle1, bundle2));
 
-    assertThat(registry.getBundle("gaia-x-2511").get().config().namespace())
+    assertThat(registry.getBundle("test-framework").get().config().namespace())
         .isEqualTo("https://namespace-a.org/");
   }
 
@@ -262,10 +301,10 @@ class TrustFrameworkRegistryTest {
   void constructor_nullAdditionalRoot_doesNotThrow() {
     // A null entry in additionalRoots (e.g. from malformed YAML) must be skipped, not NPE
     var rolesWithNull = new HashMap<String, RoleConfig>();
-    rolesWithNull.put("Participant", new RoleConfig(
-        new ArrayList<>(Arrays.asList(null, "https://w3id.org/gaia-x/Participant")),
+    rolesWithNull.put("RoleA", new RoleConfig(
+        new ArrayList<>(Arrays.asList(null, "https://example.org/test/RoleA")),
         List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", rolesWithNull, MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", rolesWithNull, MINIMAL_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -274,8 +313,8 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_blankNodeSubclass_doesNotThrow() {
     // An anonymous (blank-node) subclass in the ontology must be skipped, not NPE
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, BLANK_NODE_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, BLANK_NODE_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -308,9 +347,9 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_uriWithInjectionCharacter_doesNotThrow() {
     // A URI containing '>' in additionalRoots must not break SPARQL query construction
-    var roles = Map.of("ServiceOffering", new RoleConfig(
+    var roles = Map.of("RoleB", new RoleConfig(
         List.of("https://example.org/bad>uri"), List.of()));
-    var bundle = shaclBundle("test", "https://example.org/", roles, DSO_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SIBLING_ROLE_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -319,7 +358,7 @@ class TrustFrameworkRegistryTest {
   @Test
   void getActiveBundles_excludesDeferredBundles() {
     // SHACL bundle is active; JSON_SCHEMA bundle is deferred — getActiveBundles() must exclude deferred
-    var active = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var active = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var deferred = jsonSchemaBundle("untp-v1");
     var registry = new TrustFrameworkRegistry(List.of(active, deferred));
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkServiceRoleStateTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkServiceRoleStateTest.java
@@ -1,0 +1,253 @@
+package eu.xfsc.fc.core.service.trustframework;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import eu.xfsc.fc.core.config.DatabaseConfig;
+import eu.xfsc.fc.core.config.TrustFrameworkRegistryConfig;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateRepository;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.security.SecurityAuditorAware;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+
+/**
+ * Integration tests for per-role enabled state.
+ *
+ * <p>Tests verify behavior through the public service interface only. The embedded Zonky
+ * Postgres database runs the full Liquibase migration, so persisted state survives across
+ * method calls within a test and is cleaned up in {@link #cleanUp()}.
+ *
+ * <p>{@code frameworkId} values here are registry profile IDs (e.g. {@code gaia-x-2511}),
+ * NOT family IDs — role state is keyed by the bundle's profile ID because roles are
+ * declared per bundle, and validation is performed against the registry.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {
+    TrustFrameworkServiceRoleStateTest.TestConfig.class,
+    DatabaseConfig.class,
+    SecurityAuditorAware.class,
+    TrustFrameworkRegistryConfig.class,
+    TrustFrameworkService.class,
+})
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+class TrustFrameworkServiceRoleStateTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class TestConfig {
+  }
+
+  /**
+   * Registry profile ID of the built-in Gaia-X 2511 bundle.
+   * Roles in this bundle: Participant, ServiceOffering, Resource.
+   */
+  private static final String BUNDLE_GAIA_X_2511 = "gaia-x-2511";
+
+  /** Unknown bundle — not present in the registry. */
+  private static final String UNKNOWN_BUNDLE = "no-such-bundle";
+
+  @Autowired
+  private TrustFrameworkService service;
+
+  @Autowired
+  private TrustFrameworkRoleStateRepository roleStateRepo;
+
+  /** Family ID as stored in the {@code trust_frameworks} table (the DB row key). */
+  private static final String FAMILY_GAIA_X = "gaia-x";
+
+  @AfterEach
+  void cleanUp() {
+    roleStateRepo.deleteAll();
+    // Restore the family to the Liquibase-seeded default (disabled) so tests are order-independent.
+    service.setEnabled(FAMILY_GAIA_X, false);
+  }
+
+  @Test
+  void isRoleEnabled_noRowPersisted_returnsTrue() {
+    // Family must be enabled, otherwise bundle-off dominance short-circuits to true
+    // and the role-state lookup path is never exercised.
+    service.setEnabled(FAMILY_GAIA_X, true);
+
+    // No explicit state row → absence means enabled by default
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void isRoleEnabled_afterSetFalse_returnsFalse() {
+    // Role-toggle is only effective when the bundle family is enabled.
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isFalse();
+  }
+
+  @Test
+  void isRoleEnabled_afterSetTrue_returnsTrue() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, true);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_oneRole_doesNotAffectOtherRole() {
+    // Family must be enabled, otherwise bundle-off dominance short-circuits to true
+    // and the role-state lookup path is never exercised.
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    // ServiceOffering was not touched — must still read as default true
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_calledTwice_upserts() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, true);
+
+    // Exactly one row (upsert, not two inserts)
+    assertThat(roleStateRepo.findByFrameworkId(BUNDLE_GAIA_X_2511)).hasSize(1);
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_unknownBundle_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.setRoleEnabled(UNKNOWN_BUNDLE, TFW_ROLE_PARTICIPANT, false))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void setRoleEnabled_unknownRole_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.setRoleEnabled(BUNDLE_GAIA_X_2511, "NoSuchRole", false))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void getRoleStates_noExplicitState_allRolesReturnedAsTrue() {
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    // All roles from the registry bundle must appear, all defaulting to true
+    assertThat(states).isNotEmpty();
+    assertThat(states).containsKeys(TFW_ROLE_PARTICIPANT, TFW_ROLE_SERVICE_OFFERING);
+    assertThat(states).allSatisfy((role, enabled) -> assertThat(enabled).isTrue());
+  }
+
+  @Test
+  void getRoleStates_withOneRoleDisabled_reflectsOverride() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    assertThat(states).containsEntry(TFW_ROLE_PARTICIPANT, false);
+    assertThat(states).containsEntry(TFW_ROLE_SERVICE_OFFERING, true);
+  }
+
+  @Test
+  void getRoleStates_preservesYamlDeclarationOrder() {
+    // gaia-x-2511 framework.yaml declares roles in the order:
+    //   Participant, ServiceOffering, Resource
+    // The returned LinkedHashMap must iterate in that exact order so the UI can render
+    // role-toggle rows deterministically.
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    assertThat(states).containsExactly(
+        Map.entry(TFW_ROLE_PARTICIPANT, true),
+        Map.entry(TFW_ROLE_SERVICE_OFFERING, true),
+        Map.entry(TFW_ROLE_RESOURCE, true));
+  }
+
+  @Test
+  void getRoleStates_unknownBundle_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.getRoleStates(UNKNOWN_BUNDLE))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void setRoleEnabled_persistsAcrossRepositoryRead() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    // Verify the row via repository (one row, correct field values)
+    var rows = roleStateRepo.findByFrameworkId(BUNDLE_GAIA_X_2511);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getFrameworkId()).isEqualTo(BUNDLE_GAIA_X_2511);
+    assertThat(rows.get(0).getRoleName()).isEqualTo(TFW_ROLE_PARTICIPANT);
+    assertThat(rows.get(0).isEnabled()).isFalse();
+  }
+
+  /**
+   * When the family bundle is disabled AND the role is explicitly disabled,
+   * {@code isRoleEnabled} must return {@code true}: the role-toggle layer is bypassed
+   * because bundle-off already blocks all resolution through that bundle.
+   * The caller (ClaimValidator) will receive a bundle-disabled rejection separately;
+   * the role-toggle must not add a second rejection on top.
+   */
+  @Test
+  void isRoleEnabled_bundleDisabled_roleExplicitlyDisabled_returnsTrueBypassingRoleCheck() {
+    // DB seed has gaia-x enabled=false (Liquibase default) — no need to call setEnabled here
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING, false);
+
+    // Bundle-off dominates: role-toggle check is bypassed → returns true
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isTrue();
+  }
+
+  /**
+   * When the family bundle is disabled and no role row exists (default-true),
+   * {@code isRoleEnabled} must still return {@code true} (bundle-off dominates).
+   */
+  @Test
+  void isRoleEnabled_bundleDisabled_noRoleRow_returnsTrueBypassingRoleCheck() {
+    // DB seed has gaia-x enabled=false — bundle is off, no role row set
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  /**
+   * When the family bundle is enabled and the role is explicitly disabled,
+   * {@code isRoleEnabled} must return {@code false} — normal role-toggle behavior.
+   */
+  @Test
+  void isRoleEnabled_bundleEnabled_roleDisabled_returnsFalse() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING, false);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isFalse();
+  }
+
+  /**
+   * When the family bundle is enabled and no role row exists,
+   * {@code isRoleEnabled} must return {@code true} — default-true semantics apply.
+   */
+  @Test
+  void isRoleEnabled_bundleEnabled_noRoleRow_returnsTrue() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  /**
+   * For a framework ID that is not known to the registry,
+   * {@code isRoleEnabled} must return {@code true} — preserve existing caller semantics.
+   */
+  @Test
+  void isRoleEnabled_unknownFrameworkId_returnsTrue() {
+    assertThat(service.isRoleEnabled(UNKNOWN_BUNDLE, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireTypeResolutionTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireTypeResolutionTest.java
@@ -8,6 +8,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_DIGITAL_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_FAMILY_GAIA_X;
 
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +41,10 @@ import eu.xfsc.fc.core.util.ClaimValidator;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LoireTypeResolutionTest {
 
+  /** All roles enabled — passed to {@link eu.xfsc.fc.core.util.ClaimValidator#resolveSubjectRole}
+   *  so existing tests are unaffected by the new mandatory predicate parameter. */
+  private static final BiPredicate<String, String> ALL_ENABLED = (b, r) -> true;
+
   private static final String PROFILE_ID = "gaia-x-2511";
   private static final String NAMESPACE = "https://w3id.org/gaia-x/2511#";
 
@@ -55,30 +66,28 @@ class LoireTypeResolutionTest {
 
     // 2511 roles — mirrors the production gaia-x-2511 bundle
     Map<String, RoleConfig> loireRoles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(
-            List.of(NAMESPACE + "DigitalServiceOffering"), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig loireConfig = new FrameworkBundleConfig(
-        PROFILE_ID, "gaia-x", NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
     loireRegistry = new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(loireConfig, gx2511Ontology, null)));
 
     // Legacy gax-core roles — intentionally different namespace
     Map<String, RoleConfig> legacyRoles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(List.of(), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig legacyConfig = new FrameworkBundleConfig(
-        "gaia-x-legacy", "gaia-x", "https://w3id.org/gaia-x/core#",
+        "gaia-x-legacy", TFW_FAMILY_GAIA_X, "https://w3id.org/gaia-x/core#",
         ValidationType.SHACL, legacyRoles, Map.of());
     legacyRegistry = new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(legacyConfig, gx2511Ontology, null)));
   }
-
-  // ==================== 2511 type resolution (Loire path) ====================
 
   @Test
   @DisplayName("gx:LegalPerson resolves to Participant via 2511 ontology")
@@ -86,9 +95,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#LegalPerson");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Participant"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
         "gx:LegalPerson → gx:Participant → gx:GaiaXEntity; should resolve to Participant");
   }
 
@@ -98,9 +107,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#DigitalServiceOffering");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "ServiceOffering"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
         "gx:DigitalServiceOffering is a sibling of gx:ServiceOffering; resolves via additionalRoots");
   }
 
@@ -110,9 +119,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#DataProduct");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "ServiceOffering"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
         "gx:DataProduct rdfs:subClassOf gx:DigitalServiceOffering; traversal from DSO root reaches DataProduct");
   }
 
@@ -122,9 +131,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#VirtualResource");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Resource"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_RESOURCE), result,
         "gx:VirtualResource rdfs:subClassOf gx:Resource; should resolve to Resource");
   }
 
@@ -134,12 +143,10 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/SomeOtherType");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(), "Type not in the 2511 hierarchy should return UNKNOWN");
   }
-
-  // ==================== Namespace isolation ====================
 
   @Test
   @DisplayName("2511 type returns UNKNOWN when legacy (gax-core) registry is used — hierarchies disconnected")
@@ -147,14 +154,12 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#LegalPerson");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, legacyRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, legacyRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(),
         "gx:2511#LegalPerson is not a subclass of gax-core:Participant; "
             + "disconnected hierarchies must not cross-resolve");
   }
-
-  // ==================== Composite ontology slow path ====================
 
   private static final String COMPOSITE_ONTOLOGY_TTL = """
       @prefix gx: <https://w3id.org/gaia-x/2511#> .
@@ -172,9 +177,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/CustomParticipant");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, compositeOntology);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, compositeOntology, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Participant"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
         "Custom subclass absent from boot index should resolve via composite ontology");
   }
 
@@ -185,23 +190,22 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/CustomParticipant");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(),
         "Custom subclass absent from boot index with no ontology fallback should return UNKNOWN");
   }
 
-  // ==================== Helpers ====================
 
   private TrustFrameworkRegistry buildRootsOnlyRegistry() {
     Map<String, RoleConfig> roles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(
-            List.of(NAMESPACE + "DigitalServiceOffering"), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig config = new FrameworkBundleConfig(
-        PROFILE_ID, "gaia-x", NAMESPACE, ValidationType.SHACL, roles, Map.of());
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, roles, Map.of());
     return new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(config, null, null)));
   }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RoleToggleResolutionTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RoleToggleResolutionTest.java
@@ -1,0 +1,194 @@
+package eu.xfsc.fc.core.service.verification;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_FAMILY_GAIA_X;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_DIGITAL_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import org.apache.jena.riot.system.stream.StreamManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.trustframework.FrameworkBundleConfig;
+import eu.xfsc.fc.core.service.trustframework.ResolvedRole;
+import eu.xfsc.fc.core.service.trustframework.RoleConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.ValidationType;
+import eu.xfsc.fc.core.util.ClaimValidator;
+
+/**
+ * Tests for role-toggle enforcement in {@link ClaimValidator#resolveSubjectRole}.
+ *
+ * <p>Verifies that a disabled role (predicate returns false) causes a {@link ClientException}
+ * on both direct registry hits and ontology-subclass-walk hits, while enabled roles resolve
+ * normally (including the default-true predicate used for backward compatibility).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RoleToggleResolutionTest {
+
+  private static final String PROFILE_ID = "gaia-x-2511";
+  private static final String NAMESPACE   = "https://w3id.org/gaia-x/2511#";
+
+  /** Predicate that disables every role — used for disabled-role tests. */
+  private static final BiPredicate<String, String> ALL_DISABLED = (bundleId, roleName) -> false;
+
+  /** Predicate that enables every role — backward-compat baseline. */
+  private static final BiPredicate<String, String> ALL_ENABLED  = (bundleId, roleName) -> true;
+
+  /** Predicate that disables only "Participant". */
+  private static final BiPredicate<String, String> PARTICIPANT_DISABLED =
+      (bundleId, roleName) -> !(TFW_ROLE_PARTICIPANT.equals(roleName));
+
+  private TrustFrameworkRegistry loireRegistry;
+  private TrustFrameworkRegistry rootsOnlyRegistry;
+  private ContentAccessorDirect  compositeOntology;
+  private StreamManager          streamManager;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    String ttlPath = "Schema-Tests/gx-2511-test-ontology.ttl";
+    ContentAccessorDirect gx2511Ontology;
+    try (InputStream is = getClass().getClassLoader().getResourceAsStream(ttlPath)) {
+      if (is == null) {
+        throw new IllegalStateException("Test resource not found: " + ttlPath);
+      }
+      gx2511Ontology = new ContentAccessorDirect(
+          new String(is.readAllBytes(), StandardCharsets.UTF_8));
+    }
+    streamManager = StreamManager.get().clone();
+
+    Map<String, RoleConfig> loireRoles = Map.of(
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
+    );
+    FrameworkBundleConfig loireConfig = new FrameworkBundleConfig(
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
+    loireRegistry = new TrustFrameworkRegistry(
+        List.of(new TrustFrameworkBundle(loireConfig, gx2511Ontology, null)));
+
+    // roots-only (no boot-time ontology) — forces composite-ontology slow path
+    Map<String, RoleConfig> rootsOnlyRoles = Map.of(
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
+    );
+    FrameworkBundleConfig rootsOnlyConfig = new FrameworkBundleConfig(
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, rootsOnlyRoles, Map.of());
+    rootsOnlyRegistry = new TrustFrameworkRegistry(
+        List.of(new TrustFrameworkBundle(rootsOnlyConfig, null, null)));
+
+    compositeOntology = new ContentAccessorDirect("""
+        @prefix gx: <%s> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <https://example.com/> .
+
+        ex:CustomParticipant rdfs:subClassOf gx:Participant .
+        """.formatted(NAMESPACE));
+  }
+
+  @Test
+  @DisplayName("Direct match on disabled role throws ClientException")
+  void resolveSubjectRole_directMatch_disabledRole_throwsClientException() {
+    String credential = buildCredential(NAMESPACE + "LegalPerson");
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, loireRegistry, null, ALL_DISABLED),
+        "A disabled role direct match must throw ClientException (HTTP 400)");
+  }
+
+  @Test
+  @DisplayName("additionalRoots match on disabled role throws ClientException")
+  void resolveSubjectRole_additionalRootsMatch_disabledRole_throwsClientException() {
+    // gx:DigitalServiceOffering is indexed via additionalRoots, not namespace+roleName
+    String credential = buildCredential(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING);
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, loireRegistry, null, ALL_DISABLED),
+        "A disabled role matched via additionalRoots must throw ClientException");
+  }
+
+  @Test
+  @DisplayName("Ontology subclass walk on disabled role throws ClientException")
+  void resolveSubjectRole_ontologyWalk_disabledRole_throwsClientException() {
+    // ex:CustomParticipant is not in the boot index; only resolvable via composite ontology
+    String credential = buildCredential("https://example.com/CustomParticipant");
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, rootsOnlyRegistry, compositeOntology, ALL_DISABLED),
+        "A disabled role matched via ontology subclass walk must throw ClientException");
+  }
+
+  @Test
+  @DisplayName("Enabled role in same bundle resolves normally when another role is disabled")
+  void resolveSubjectRole_enabledRole_whileOtherRoleDisabled_resolvesNormally() {
+    // PARTICIPANT_DISABLED disables only TFW_ROLE_PARTICIPANT; TFW_ROLE_SERVICE_OFFERING remains enabled
+    String credential = buildCredential(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING);
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, PARTICIPANT_DISABLED);
+
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
+        "ServiceOffering must resolve normally even when Participant is disabled");
+  }
+
+  @Test
+  @DisplayName("Default-true predicate (all-enabled) resolves Participant normally")
+  void resolveSubjectRole_allEnabled_resolvesPrimaryRoleNormally() {
+    String credential = buildCredential(NAMESPACE + "LegalPerson");
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, ALL_ENABLED);
+
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
+        "With all roles enabled the predicate must not interfere with normal resolution");
+  }
+
+  @Test
+  @DisplayName("Unknown type returns UNKNOWN regardless of predicate")
+  void resolveSubjectRole_unknownType_returnsUnknown() {
+    String credential = buildCredential("https://example.com/SomeOtherType");
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, ALL_ENABLED);
+
+    assertFalse(result.isResolved(),
+        "Type not in any registered bundle should still return UNKNOWN");
+  }
+
+  private static String buildCredential(String subjectTypeUri) {
+    return """
+        {
+          "@context": {
+            "cred": "https://www.w3.org/2018/credentials#",
+            "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"}
+          },
+          "credentialSubject": {
+            "@type": ["%s"],
+            "@id": "did:web:subject.example.com"
+          }
+        }
+        """.formatted(subjectTypeUri);
+  }
+}

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
@@ -1,17 +1,22 @@
 package eu.xfsc.fc.server.service;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import eu.xfsc.fc.api.generated.model.TrustFrameworkBundleEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 import eu.xfsc.fc.server.config.AdminDashboardConfig;
 import eu.xfsc.fc.server.generated.controller.TrustFrameworkAdminApiDelegate;
@@ -32,6 +37,7 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
 
   private final TrustFrameworkService trustFrameworkService;
+  private final TrustFrameworkRegistry trustFrameworkRegistry;
   private final AdminDashboardConfig adminDashboardConfig;
 
   @Value("${federated-catalogue.enabled-trust-frameworks:}")
@@ -74,6 +80,12 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
   }
 
   @Override
+  public ResponseEntity<Void> setTrustFrameworkRoleEnabled(String bundleId, String roleName, Boolean enabled) {
+    trustFrameworkService.setRoleEnabled(bundleId, roleName, enabled);
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
   public ResponseEntity<Void> updateTrustFrameworkConfig(String id,
       TrustFrameworkConfigUpdate config) {
     int timeoutSeconds = config.getTimeoutSeconds() != null ? config.getTimeoutSeconds() : DEFAULT_TIMEOUT_SECONDS;
@@ -93,7 +105,30 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
     entry.setTimeoutSeconds(config.timeoutSeconds());
     entry.setEnabled(config.enabled());
     entry.setConnected(checkConnectivity(config));
+    entry.setBundles(buildBundleEntries(config.id()));
     return entry;
+  }
+
+  /**
+   * Builds a list of {@link TrustFrameworkBundleEntry} for each bundle belonging to the given
+   * family, carrying the per-bundle role enabled states so the UI can address role-toggle PUTs
+   * by the correct bundle profile ID.
+   *
+   * @param familyId trust framework family identifier (e.g. {@code gaia-x})
+   * @return list of bundle entries in registry order; empty if no bundles belong to the family
+   */
+  private List<TrustFrameworkBundleEntry> buildBundleEntries(String familyId) {
+    List<TrustFrameworkBundleEntry> result = new ArrayList<>();
+    for (TrustFrameworkBundle bundle : trustFrameworkRegistry.getAllBundles()) {
+      if (!familyId.equals(bundle.config().family())) {
+        continue;
+      }
+      TrustFrameworkBundleEntry bundleEntry = new TrustFrameworkBundleEntry();
+      bundleEntry.setId(bundle.config().id());
+      bundleEntry.setRoles(trustFrameworkService.getRoleStates(bundle.config().id()));
+      result.add(bundleEntry);
+    }
+    return result;
   }
 
   private boolean checkConnectivity(TrustFrameworkConfig config) {

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
@@ -3,6 +3,7 @@ package eu.xfsc.fc.server.controller;
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,5 +150,85 @@ public class TrustFrameworkAdminControllerTest {
         .andExpect(jsonPath("$[0].serviceUrl").value("https://new.example.com"))
         .andExpect(jsonPath("$[0].apiVersion").value("v2"))
         .andExpect(jsonPath("$[0].timeoutSeconds").value(60));
+  }
+  
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_knownBundleAndRole_returns200() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "false")
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    // Reset to default
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_unknownBundle_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/nonexistent-bundle/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message", notNullValue()));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_unknownRole_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/UnknownRole/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message", notNullValue()));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_missingEnabledParam_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void setTrustFrameworkRoleEnabled_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void setTrustFrameworkRoleEnabled_wrongRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void getTrustFrameworks_includesBundlesField() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].bundles", hasSize(1)))
+        .andExpect(jsonPath("$[0].bundles[0].id").value("gaia-x-2511"))
+        .andExpect(jsonPath("$[0].bundles[0].roles.Participant").value(true))
+        .andExpect(jsonPath("$[0].bundles[0].roles.ServiceOffering").value(true))
+        .andExpect(jsonPath("$[0].bundles[0].roles.Resource").value(true));
   }
 }

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -684,6 +684,22 @@ components:
         enabled:
           type: boolean
           description: Whether this framework is active
+        bundles:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrustFrameworkBundleEntry'
+          description: Per-bundle role states for this trust framework family.
+    TrustFrameworkBundleEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Bundle profile ID (e.g. gaia-x-2511)
+        roles:
+          type: object
+          additionalProperties:
+            type: boolean
+          description: Per-role enabled state for this bundle, keyed by role name.
     TrustFrameworkConfigUpdate:
       type: object
       properties:
@@ -1331,6 +1347,43 @@ paths:
       responses:
         '200':
           description: Framework enabled state updated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /admin/trust-frameworks/{bundleId}/roles/{roleName}/enabled:
+    put:
+      tags:
+        - TrustFrameworkAdmin
+      summary: Toggle a single role's enabled state within a trust-framework bundle
+      operationId: setTrustFrameworkRoleEnabled
+      security:
+        - jwt: []
+      parameters:
+        - name: bundleId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: roleName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: enabled
+          in: query
+          required: true
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Role enabled state updated
+        '400':
+          $ref: '#/components/responses/ClientError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':


### PR DESCRIPTION
## 🚀 Summary

Implements the CAT-FR-AU-01 slice "per-role activation/deactivation within an active trust-framework bundle", including registry direct matches, `additional_roots`, and OWL-derived subclasses. Adds an admin REST endpoint, extends the existing trust-framework GET response, and surfaces the toggles in the bundle-config modal of the demo portal.

This change is part of the Enhancement of XFSC Federated Catalogue. Details can be found here (permalink):
https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

> configuring whether all assets should be instances of a certain type, and, if so, what type(s),
i.e., a generalization of what, in the old hard-coding of the Gaia-X Trust Framework (cf. CAT-
FR-CO-01) was called “trust framework base classes” (Gaia-X Participant and Service
Offering according to [FC.CCF.SRS], later, in the implementation, extended by Gaia-X
Resource).

Currently these "types" are named "Roles" but that is suspect to be changed back to (TrustFrameworkBaseClass/BaseClass) for better compatibility with the original concept.

## ✅ What's Changed

- [x] Feature implemented
- [x] Documentation updated (OpenAPI spec extended; story file in `design-documents/Backlog/048…`)
- [x] Tests added (unit tests for service + resolver, controller tests for admin endpoint, no JS test harness — see PR comment)
- [x] Code formatted and linted

## 🧪 How to Test

1. Bring up the dev stack: `cd docker && ./dev.sh up`.
2. Open the admin portal at `http://localhost:8080/.../pages/admin/trust-frameworks.html`. Click the gear icon on the Gaia-X row.
3. The modal should now show a **Roles** section with one checkbox per role (Participant / ServiceOffering / Resource for `gaia-x-2511`). All checked by default.
4. Uncheck `ServiceOffering`. The change is sent immediately as `PUT /admin/trust-frameworks/gaia-x-2511/roles/ServiceOffering/enabled?enabled=false`.
5. Try uploading a credential whose subject is `https://w3id.org/gaia-x/2511#ServiceOffering` → expect HTTP 400 with message `Trust framework role 'gaia-x-2511/ServiceOffering' is disabled`.
6. Try uploading a credential whose subject is `https://w3id.org/gaia-x/2511#DigitalServiceOffering` (`additional_root` of ServiceOffering) → expect HTTP 400.
7. Upload a `Participant` credential → expect HTTP 201 (other role still active).
8. Re-check ServiceOffering and replay step 5 → expect HTTP 201.
9. Uncheck **all** role checkboxes while bundle is enabled → an `alert-warning` should appear inside the modal.
10. Restart the stack → role-toggle state persists.

Unit tests (`mvn -pl fc-service-core,fc-service-server test`) cover all of the above plus the bundle-off dominance edge case.

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] I've updated documentation if necessary
- [x] My changes follow the project's coding style