### PR TITLE
Enhancement [CAT-FR-AU-01] Framework Bundle Toggle

### DIFF
--- a/docker/dev-fuseki.env
+++ b/docker/dev-fuseki.env
@@ -32,10 +32,17 @@ DB_PASS=postgres
 DB_URL=jdbc:postgresql://postgres:5432/fed_cat
 
 ### GRAPH STORE PROPERTIES ###
+# Bootstrap default — overridden at boot by admin_config[graphstore.preferred.backend]
+# once an admin has used the "Switch Backend" action. Valid values: fuseki, neo4j, none.
 GRAPH_STORE_IMPL=fuseki
-GRAPH_STORE_URI=http://fuseki:3030/ds
-GRAPH_STORE_USER=
-GRAPH_STORE_PASSWORD=admin
+# Fuseki connection (used at runtime by the Fuseki adapter and by the pre-flight probe).
+GRAPH_STORE_FUSEKI_URI=http://fuseki:3030/ds
+GRAPH_STORE_FUSEKI_PASSWORD=admin
+# Neo4j connection (used by both the neo4j container's NEO4J_AUTH and the Neo4j adapter,
+# and by the pre-flight probe when targeting Neo4j). Single source of truth.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=neo12345
 
 ### NATS PROPERTIES ###
 NATS_URL=nats://nats:4222

--- a/docker/dev.env
+++ b/docker/dev.env
@@ -9,7 +9,7 @@ FC_DEMO_PORTAL_DOCKER_TARGET="fc-demo-portal"
 # Run ./dev.sh build first to create the JARs locally.
 FC_DOCKERFILE="Dockerfile.dev"
 
-### KEYCLOCK PROPERTIES ###
+### KEYCLOAK PROPERTIES ###
 PORT_KEYCLOAK=8080
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
@@ -33,10 +33,17 @@ DB_PASS=postgres
 DB_URL=jdbc:postgresql://postgres:5432/fed_cat
 
 ### GRAPH STORE PROPERTIES ###
-GRAPH_STORE_IMPL=neo4j
-GRAPH_STORE_URI=bolt://neo4j:7687
-GRAPH_STORE_USER=neo4j
-GRAPH_STORE_PASSWORD=neo12345
+# Bootstrap default — overridden at boot by admin_config[graphstore.preferred.backend]
+# once an admin has used the "Switch Backend" action. Valid values: fuseki, neo4j, none.
+GRAPH_STORE_IMPL=fuseki
+# Fuseki connection (used at runtime by the Fuseki adapter and by the pre-flight probe).
+GRAPH_STORE_FUSEKI_URI=http://fuseki:3030/ds
+GRAPH_STORE_FUSEKI_PASSWORD=admin
+# Neo4j connection (used by both the neo4j container's NEO4J_AUTH and the Neo4j adapter,
+# and by the pre-flight probe when targeting Neo4j). Single source of truth.
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=neo12345
 
 ### NATS PROPERTIES ###
 NATS_URL=nats://nats:4222

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -101,26 +101,29 @@ services:
       - "gaia-x"
 
 
-# Optional: Fuseki SPARQL-star backend. Uncomment when using GRAPH_STORE_IMPL=fuseki (e.g. dev-fuseki.env).
-# Not needed for neo4j or none backends.
-#  fuseki:
-#    container_name: "fuseki"
-#    image: docker.io/stain/jena-fuseki
-#    environment:
-#      ADMIN_PASSWORD: "${GRAPH_STORE_PASSWORD}"
-#      FUSEKI_DATASET_1: "ds"
-#      JVM_ARGS: "-Xmx1g"
-#    ports:
-#      - "3330:3030"
-#    networks:
-#      - "gaia-x"
-#    restart: unless-stopped
-#    healthcheck:
-#      test: wget --no-verbose --tries=1 --spider http://localhost:3030/ds || exit 1
-#      interval: 20s
-#      timeout: 5s
-#      retries: 5
-#      start_period: 30s
+  # Fuseki SPARQL-star backend. Always present so the admin "Switch Backend" action
+  # can pre-flight either backend regardless of which one is currently active. Cost:
+  # ~1 GB JVM heap idle.
+  fuseki:
+    container_name: "fuseki"
+    image: docker.io/secoresearch/fuseki:5.5.0
+    environment:
+      ADMIN_PASSWORD: "${GRAPH_STORE_FUSEKI_PASSWORD:-admin}"
+      FUSEKI_DATASET_1: "ds"
+      JVM_ARGS: "-Xmx1g"
+      ENABLE_UPDATE: "true"
+      ENABLE_DATA_WRITE: "true"
+    ports:
+      - "3330:3030"
+    networks:
+      - "gaia-x"
+    restart: unless-stopped
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://localhost:3030/ds || exit 1
+      interval: 20s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   # Local trust environment for signature verification. Serves three roles:
   #   1. DID resolution:    /.well-known/did.json        (did:web:did-server → public key JWK)
@@ -151,14 +154,25 @@ services:
       KEYCLOAK_CREDENTIALS_SECRET: "${FC_CLIENT_SECRET}"
       KEYCLOAK_ADMIN_CONSOLE_URL: "${KEYCLOAK_ADMIN_CONSOLE_URL}"
       SPRING_DATASOURCE_URL: "${DB_URL}"
-      GRAPHSTORE_URI: "${GRAPH_STORE_URI}"
-      GRAPHSTORE_USER: "${GRAPH_STORE_USER}"
-      GRAPHSTORE_PASSWORD: "${GRAPH_STORE_PASSWORD}"
-      GRAPHSTORE_IMPL: "${GRAPH_STORE_IMPL}"
-      # Spring Data Neo4j autoconfiguration
-      SPRING_NEO4J_URI: "${GRAPH_STORE_URI}"
-      SPRING_NEO4J_AUTHENTICATION_USERNAME: "${GRAPH_STORE_USER}"
-      SPRING_NEO4J_AUTHENTICATION_PASSWORD: "${GRAPH_STORE_PASSWORD}"
+      # Cold-boot fallback only. After the first admin "Switch Backend" action,
+      # admin_config[graphstore.preferred.backend] takes precedence — this env
+      # var only seeds the first boot before any persisted preference exists.
+      GRAPHSTORE_IMPL: "${GRAPH_STORE_IMPL:-fuseki}"
+      # Per-backend URIs — both are read at runtime so the pre-flight probe in
+      # GraphDatabaseAdminService can verify the target before the operator persists
+      # a switch. The Neo4j URI also seeds Spring Data Neo4j autoconfig below.
+      GRAPHSTORE_NEO4J_URI: "${NEO4J_URI:-bolt://neo4j:7687}"
+      GRAPHSTORE_FUSEKI_URI: "${GRAPH_STORE_FUSEKI_URI:-http://fuseki:3030/ds}"
+      # Neo4j credentials — single source of truth, also read by the neo4j service
+      # above for NEO4J_AUTH. The fc-graphdb-neo4j adapter reads these via the
+      # graphstore.user / graphstore.password properties.
+      GRAPHSTORE_USER: "${NEO4J_USER:-neo4j}"
+      GRAPHSTORE_PASSWORD: "${NEO4J_PASSWORD:-neo12345}"
+      # Spring Data Neo4j autoconfiguration — independent of which graph backend is
+      # active so Neo4j-specific autoconfig stays consistent.
+      SPRING_NEO4J_URI: "${NEO4J_URI:-bolt://neo4j:7687}"
+      SPRING_NEO4J_AUTHENTICATION_USERNAME: "${NEO4J_USER:-neo4j}"
+      SPRING_NEO4J_AUTHENTICATION_PASSWORD: "${NEO4J_PASSWORD:-neo12345}"
       PUBLISHER_IMPL: nats
       PUBLISHER_URL: ${NATS_URL}
       SUBSCRIBER_IMPL: none
@@ -197,8 +211,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      neo4j:
-        condition: service_healthy
+      # Graph backends are started in parallel but not gated — fc-server tolerates a
+      # temporarily-unavailable graph store at boot (logs a warning and starts). The
+      # pre-flight probe in GraphDatabaseAdminService is the real gate, before the
+      # operator persists a switch.
       nats:
         condition: service_healthy
       did-server:

--- a/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
+++ b/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
@@ -3,6 +3,7 @@ package eu.xfsc.fc.demo.controller;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +21,7 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.AdminStats;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
@@ -134,5 +136,19 @@ public class AdminController {
       @RequestBody Map<String, String> body,
       @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
     return adminClient.switchGraphDatabase(body.get("backend"), authorizedClient);
+  }
+
+  /** Trigger a graph rebuild over the current backend. */
+  @PostMapping("/graph/rebuild")
+  public ResponseEntity<RebuildStatus> triggerGraphRebuild(
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    return adminClient.triggerGraphRebuild(authorizedClient);
+  }
+
+  /** Poll graph rebuild progress. */
+  @GetMapping("/graph/rebuild/status")
+  public RebuildStatus getGraphRebuildStatus(
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    return adminClient.getGraphRebuildStatus(authorizedClient);
   }
 }

--- a/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
+++ b/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
@@ -7,24 +7,24 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import eu.xfsc.fc.api.generated.model.AdminHealthStatus;
+import eu.xfsc.fc.api.generated.model.AdminStats;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
-import eu.xfsc.fc.api.generated.model.AdminStats;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
-import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
 import eu.xfsc.fc.client.AdminClient;
 import lombok.RequiredArgsConstructor;
 
@@ -78,22 +78,15 @@ public class AdminController {
     return adminClient.getTrustFrameworks(authorizedClient);
   }
 
-  /** Toggle a trust framework's enabled state. */
-  @PutMapping("/trust-frameworks/{id}/enabled")
-  public void setTrustFrameworkEnabled(
+  /**
+   * Partially update a trust framework.
+   */
+  @PatchMapping("/trust-frameworks/{id}")
+  public void patchTrustFramework(
       @PathVariable("id") String id,
-      @RequestParam("enabled") boolean enabled,
+      @RequestBody TrustFrameworkPatch patch,
       @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
-    adminClient.setTrustFrameworkEnabled(id, enabled, authorizedClient);
-  }
-
-  /** Update a trust framework's configuration. */
-  @PutMapping("/trust-frameworks/{id}")
-  public void updateTrustFrameworkConfig(
-      @PathVariable("id") String id,
-      @RequestBody TrustFrameworkConfigUpdate config,
-      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
-    adminClient.updateTrustFrameworkConfig(id, config, authorizedClient);
+    adminClient.patchTrustFramework(id, patch, authorizedClient);
   }
 
   // --- Schema Validation ---
@@ -105,13 +98,15 @@ public class AdminController {
     return adminClient.getSchemaValidation(authorizedClient);
   }
 
-  /** Toggle a schema validation module. */
-  @PutMapping("/schema-validation/modules/{type}")
-  public void setSchemaModuleEnabled(
+  /**
+   * Partially update a schema validation module.
+   */
+  @PatchMapping("/schema-validation/modules/{type}")
+  public void patchSchemaModule(
       @PathVariable("type") String type,
-      @RequestParam("enabled") boolean enabled,
+      @RequestBody SchemaModulePatch patch,
       @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
-    adminClient.setSchemaModuleEnabled(type, enabled, authorizedClient);
+    adminClient.patchSchemaModule(type, patch, authorizedClient);
   }
 
   /** List uploaded ontologies and their per-role subclass contributions. */

--- a/fc-demo-portal/src/main/resources/static/js/admin-graphdb.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-graphdb.js
@@ -1,6 +1,8 @@
 $(document).ready(function() {
 
   var currentBackend = '';
+  var currentClaimCount = 0;
+  var rebuildPollHandle = null;
 
   $.ajax({
     url: '/admin/me', type: 'GET',
@@ -9,41 +11,67 @@ $(document).ready(function() {
       loadStatus();
     },
     error: function() {
-      $('#admin-content').html('<div class="alert alert-danger">Access denied.</div>');
+      $('#admin-content').html('<div class="alert alert-danger">Access denied.</div>').show();
     }
   });
 
+  function showError(msg) {
+    $('#errorBanner').text(msg).removeClass('d-none');
+  }
+
+  function clearError() {
+    $('#errorBanner').addClass('d-none').text('');
+  }
+
   function loadStatus() {
-    $.getJSON('/admin/graph-database', function(data) {
-      currentBackend = data.activeBackend || 'UNKNOWN';
-      $('#activeBackend').text(currentBackend);
+    clearError();
+    $.ajax({
+      url: '/admin/graph-database',
+      type: 'GET',
+      success: function(data) {
+        currentBackend = data.activeBackend || 'UNKNOWN';
+        currentClaimCount = typeof data.claimCount === 'number' ? data.claimCount : 0;
+        $('#activeBackend').text(currentBackend);
 
-      if (data.connected) {
-        $('#connectionStatus').removeClass('bg-secondary bg-danger').addClass('bg-success').text('Connected');
-      } else {
-        $('#connectionStatus').removeClass('bg-secondary bg-success').addClass('bg-danger').text('Disconnected');
+        if (data.connected) {
+          $('#connectionStatus').removeClass('bg-secondary bg-danger').addClass('bg-success').text('Connected');
+        } else {
+          $('#connectionStatus').removeClass('bg-secondary bg-success').addClass('bg-danger').text('Disconnected');
+        }
+
+        $('#claimCount').text(currentClaimCount >= 0 ? currentClaimCount.toLocaleString() : 'N/A');
+        $('#versionInfo').text(data.version || '-');
+
+        $('.backend-radio').prop('checked', false);
+        $('.backend-radio[value="' + currentBackend + '"]').prop('checked', true);
+        $('#switchBtn').prop('disabled', true);
+
+        if (data.rebuildNeeded) {
+          var count = typeof data.rdfAssetCount === 'number' ? data.rdfAssetCount : 0;
+          var summary = count === 1
+            ? '1 RDF asset is ready to be re-indexed.'
+            : count.toLocaleString() + ' RDF assets are ready to be re-indexed.';
+          $('#rebuildAssetSummary').text(summary);
+          $('#rebuildBanner').removeClass('d-none');
+        } else {
+          $('#rebuildBanner').addClass('d-none');
+        }
+
+        $('#rebuildBtn').prop('disabled', currentBackend === 'NONE');
+      },
+      error: function(xhr) {
+        showError('Failed to load graph database status: ' + (xhr.responseJSON?.message || xhr.status));
+        $('#activeBackend').text('Error');
+        $('#connectionStatus').removeClass('bg-secondary bg-success').addClass('bg-danger').text('Error');
       }
-
-      $('#claimCount').text(data.claimCount >= 0 ? data.claimCount.toLocaleString() : 'N/A');
-      $('#versionInfo').text(data.version || '-');
-
-      // Set current backend radio
-      $('.backend-radio').prop('checked', false);
-      $('.backend-radio[value="' + currentBackend + '"]').prop('checked', true);
-      $('#switchBtn').prop('disabled', true);
-    }).fail(function() {
-      $('#activeBackend').text('Error');
-      $('#connectionStatus').removeClass('bg-secondary bg-success').addClass('bg-danger').text('Error');
     });
   }
 
-  // Radio change — enable switch button if different from current
   $('.backend-radio').on('change', function() {
     var selected = $('input[name="backend"]:checked').val();
     $('#switchBtn').prop('disabled', selected === currentBackend);
   });
 
-  // Switch button — show modal
   $('#switchBtn').on('click', function() {
     var selected = $('input[name="backend"]:checked').val();
     $('#modalCurrentBackend').text(currentBackend);
@@ -51,24 +79,95 @@ $(document).ready(function() {
     new bootstrap.Modal('#confirmSwitchModal').show();
   });
 
-  // Confirm switch
   $('#confirmSwitchBtn').on('click', function() {
     var selected = $('input[name="backend"]:checked').val();
+    clearError();
     $.ajax({
       url: '/admin/graph-database/switch',
       type: 'POST',
       contentType: 'application/json',
       data: JSON.stringify({ backend: selected }),
-      success: function(data) {
+      success: function() {
         bootstrap.Modal.getInstance(document.getElementById('confirmSwitchModal')).hide();
-        alert(data.message || 'Backend switch requested. Restart the server.');
         loadStatus();
       },
       error: function(xhr) {
-        var msg = xhr.responseJSON ? xhr.responseJSON.message : 'Failed to switch backend.';
-        alert(msg);
+        bootstrap.Modal.getInstance(document.getElementById('confirmSwitchModal')).hide();
+        var msg = xhr.responseJSON?.message || xhr.responseJSON?.detail || 'Failed to switch backend.';
+        showError(msg);
       }
     });
   });
+
+  $('#rebuildBtn').on('click', function() {
+    if (currentClaimCount > 0) {
+      $('#modalClaimCount').text(currentClaimCount.toLocaleString());
+      new bootstrap.Modal('#confirmRebuildModal').show();
+    } else {
+      startRebuild();
+    }
+  });
+
+  $('#confirmRebuildBtn').on('click', function() {
+    bootstrap.Modal.getInstance(document.getElementById('confirmRebuildModal')).hide();
+    startRebuild();
+  });
+
+  function startRebuild() {
+    clearError();
+    $('#rebuildBtn').prop('disabled', true).text('Starting…');
+    $.ajax({
+      url: '/admin/graph/rebuild',
+      type: 'POST',
+      success: function(data) {
+        $('#rebuildBtn').text('Running…');
+        $('#rebuildProgress').text(formatRebuildStatus(data));
+        startRebuildPoll();
+      },
+      error: function(xhr) {
+        $('#rebuildBtn').prop('disabled', false).text('Start rebuild');
+        showError('Failed to start rebuild: ' + (xhr.responseJSON?.message || xhr.status));
+      }
+    });
+  }
+
+  function startRebuildPoll() {
+    if (rebuildPollHandle) {
+      return;
+    }
+    rebuildPollHandle = setInterval(function() {
+      $.ajax({
+        url: '/admin/graph/rebuild/status',
+        type: 'GET',
+        success: function(data) {
+          $('#rebuildProgress').text(formatRebuildStatus(data));
+          if (!data.running) {
+            clearInterval(rebuildPollHandle);
+            rebuildPollHandle = null;
+            $('#rebuildBtn').prop('disabled', false).text('Start rebuild');
+            loadStatus();
+          }
+        },
+        error: function() {
+          // keep polling — transient errors are common during rebuild
+        }
+      });
+    }, 2000);
+  }
+
+  function formatRebuildStatus(s) {
+    if (!s) return '';
+    var parts = [];
+    if (typeof s.processed === 'number' && typeof s.total === 'number') {
+      parts.push(s.processed + ' / ' + s.total + ' assets');
+    }
+    if (typeof s.percentComplete === 'number') {
+      parts.push(s.percentComplete + '%');
+    }
+    if (s.failed) parts.push('failed: ' + (s.errorMessage || 'unknown error'));
+    else if (s.running) parts.push('running');
+    else if (s.complete) parts.push('done');
+    return parts.join(' · ');
+  }
 
 });

--- a/fc-demo-portal/src/main/resources/static/js/admin-schema-validation.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-schema-validation.js
@@ -266,6 +266,8 @@ $(document).ready(function() {
       $('#admin-content').html($alert.prop('outerHTML'));
     });
 
+    var MERGE_PATCH_JSON = 'application/merge-patch+json';
+
     // Module toggle handler — bound on both tables; the closest enclosing
     // table is resolved per click so the right DataTable instance is invalidated.
     $('#svValidatorTable, #svOwlTable').on('change', '.sv-toggle', function() {
@@ -275,9 +277,10 @@ $(document).ready(function() {
       var $table = $toggle.closest('table');
 
       $.ajax({
-        url: '/admin/schema-validation/modules/' + encodeURIComponent(type)
-          + '?enabled=' + enabled,
-        type: 'PUT',
+        url: '/admin/schema-validation/modules/' + encodeURIComponent(type),
+        type: 'PATCH',
+        contentType: MERGE_PATCH_JSON,
+        data: JSON.stringify({enabled: enabled}),
         success: function() {
           // Re-render the row so renderSchemaCount picks up the new enabled state
           // and the badge styling reflects whether stored schemas are consulted.

--- a/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
@@ -1,8 +1,11 @@
 $(document).ready(function() {
 
-  // Admin access check
+  var ADMIN_ME_URL    = '/admin/me';
+  var TF_API_BASE     = '/admin/trust-frameworks';
+  var MERGE_PATCH_JSON = 'application/merge-patch+json';
+
   $.ajax({
-    url: '/admin/me',
+    url: ADMIN_ME_URL,
     type: 'GET',
     success: function() {
       $('#admin-content').show();
@@ -14,13 +17,13 @@ $(document).ready(function() {
   });
 
   function loadTrustFrameworks() {
-    var table = $('#tfTable').DataTable({
+    $('#tfTable').DataTable({
       ajax: {
-        url: '/admin/trust-frameworks',
+        url: TF_API_BASE,
         dataSrc: function(json) {
           return json || [];
         },
-        error: function(xhr) {
+        error: function() {
           $('#admin-content').html(
             '<div class="alert alert-danger">Failed to load trust frameworks.</div>');
         }
@@ -49,14 +52,16 @@ $(document).ready(function() {
             return '<code>' + $('<span>').text(data).html() + '</code>';
           }
         },
-        { data: 'serviceUrl', render: $.fn.dataTable.render.text() },
         {
-          data: 'connected',
+          data: 'bundles',
+          orderable: false,
           render: function(data) {
-            if (data) {
-              return '<span class="badge bg-success">Connected</span>';
+            if (!data || data.length === 0) {
+              return '';
             }
-            return '<span class="badge bg-danger">Disconnected</span>';
+            return data.map(function(bundle) {
+              return '<code>' + $('<span>').text(bundle.id).html() + '</code>';
+            }).join(', ');
           }
         },
         {
@@ -73,11 +78,8 @@ $(document).ready(function() {
           data: null,
           orderable: false,
           render: function(data) {
-            return $('<button>', { class: 'btn btn-sm btn-outline-secondary tf-config' })
+            return $('<button>', { class: 'btn btn-sm btn-outline-secondary tf-roles' })
               .attr('data-id',      data.id)
-              .attr('data-url',     data.serviceUrl || '')
-              .attr('data-version', data.apiVersion || '')
-              .attr('data-timeout', data.timeoutSeconds || 30)
               .attr('data-enabled', data.enabled ? 'true' : 'false')
               .attr('data-bundles', JSON.stringify(data.bundles || []))
               .append('<i class="bi bi-gear"></i>')
@@ -87,15 +89,16 @@ $(document).ready(function() {
       ]
     });
 
-    // Toggle handler
     $('#tfTable').on('change', '.tf-toggle', function() {
       var $toggle = $(this);
       var id = $toggle.data('id');
       var enabled = $toggle.is(':checked');
 
       $.ajax({
-        url: '/admin/trust-frameworks/' + encodeURIComponent(id) + '/enabled?enabled=' + enabled,
-        type: 'PUT',
+        url: TF_API_BASE + '/' + encodeURIComponent(id),
+        type: 'PATCH',
+        contentType: MERGE_PATCH_JSON,
+        data: JSON.stringify({enabled: enabled}),
         error: function() {
           $toggle.prop('checked', !enabled);
           alert('Failed to update trust framework status.');
@@ -103,21 +106,14 @@ $(document).ready(function() {
       });
     });
 
-    // Config button handler
-    $('#tfTable').on('click', '.tf-config', function() {
+    $('#tfTable').on('click', '.tf-roles', function() {
       var $btn = $(this);
       var familyEnabled = $btn.data('enabled') === 'true' || $btn.data('enabled') === true;
       var bundles = $btn.data('bundles') || [];
       if (typeof bundles === 'string') {
-        try { bundles = JSON.parse(bundles); } catch(e) { bundles = []; }
+        try { bundles = JSON.parse(bundles); } catch (e) { bundles = []; }
       }
 
-      $('#tfConfigId').val($btn.data('id'));
-      $('#tfServiceUrl').val($btn.data('url'));
-      $('#tfApiVersion').val($btn.data('version'));
-      $('#tfTimeout').val($btn.data('timeout'));
-
-      // Render role checkboxes
       var $container = $('#tfRolesContainer').empty();
       $('#tfRoleErrorBanner').hide();
       var multiBundle = bundles.length > 1;
@@ -152,7 +148,6 @@ $(document).ready(function() {
         });
       });
 
-      // Initialize Bootstrap tooltips for the newly rendered labels
       $container.find('[data-bs-toggle="tooltip"]').each(function() {
         new bootstrap.Tooltip(this);
       });
@@ -162,7 +157,6 @@ $(document).ready(function() {
       new bootstrap.Modal('#tfConfigModal').show();
     });
 
-    // Role toggle change handler
     $('#tfConfigModal').on('change', '.tf-role-toggle', function() {
       var $cb = $(this);
       var bundleId = $cb.data('bundle');
@@ -170,20 +164,17 @@ $(document).ready(function() {
       var enabled = $cb.is(':checked');
 
       $.ajax({
-        url: '/admin/trust-frameworks/' + encodeURIComponent(bundleId)
-          + '/roles/' + encodeURIComponent(roleName)
-          + '/enabled?enabled=' + enabled,
-        type: 'PUT',
+        url: TF_API_BASE + '/' + encodeURIComponent(bundleId)
+          + '/roles/' + encodeURIComponent(roleName),
+        type: 'PATCH',
+        contentType: MERGE_PATCH_JSON,
+        data: JSON.stringify({enabled: enabled}),
         success: function() {
           $('#tfRoleErrorBanner').hide();
           recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
         },
         error: function() {
           $cb.prop('checked', !enabled);
-          // Recompute the all-disabled warning after the checkbox revert so it
-          // reflects the current (reverted) state rather than the failed toggle.
-          // Reproduction: disable the last enabled role → server returns 5xx →
-          // checkbox reverts to checked but warning remained visible (stale state).
           recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
           var $banner = $('#tfRoleErrorBanner');
           $banner.text('Failed to update role "' + roleName + '". Please try again.').show();
@@ -202,45 +193,6 @@ $(document).ready(function() {
         && $('#tfRolesContainer .tf-role-toggle').length > 0;
       $('#tfRolesAllDisabledWarning').toggle(allUnchecked);
     }
-
-    // Config save handler
-    $('#tfConfigSave').on('click', function() {
-      var id = $('#tfConfigId').val();
-      var serviceUrl = $('#tfServiceUrl').val().trim();
-
-      if (serviceUrl) {
-        try {
-          var parsed = new URL(serviceUrl);
-          if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-            alert('Service URL must use http or https protocol.');
-            return;
-          }
-        } catch (e) {
-          alert('Service URL is not a valid URI.');
-          return;
-        }
-      }
-
-      var config = {
-        serviceUrl: serviceUrl,
-        apiVersion: $('#tfApiVersion').val(),
-        timeoutSeconds: parseInt($('#tfTimeout').val()) || 30
-      };
-
-      $.ajax({
-        url: '/admin/trust-frameworks/' + encodeURIComponent(id),
-        type: 'PUT',
-        contentType: 'application/json',
-        data: JSON.stringify(config),
-        success: function() {
-          bootstrap.Modal.getInstance(document.getElementById('tfConfigModal')).hide();
-          table.ajax.reload();
-        },
-        error: function() {
-          alert('Failed to save trust framework configuration.');
-        }
-      });
-    });
   }
 
 });

--- a/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
@@ -78,6 +78,8 @@ $(document).ready(function() {
               .attr('data-url',     data.serviceUrl || '')
               .attr('data-version', data.apiVersion || '')
               .attr('data-timeout', data.timeoutSeconds || 30)
+              .attr('data-enabled', data.enabled ? 'true' : 'false')
+              .attr('data-bundles', JSON.stringify(data.bundles || []))
               .append('<i class="bi bi-gear"></i>')
               .prop('outerHTML');
           }
@@ -104,12 +106,102 @@ $(document).ready(function() {
     // Config button handler
     $('#tfTable').on('click', '.tf-config', function() {
       var $btn = $(this);
+      var familyEnabled = $btn.data('enabled') === 'true' || $btn.data('enabled') === true;
+      var bundles = $btn.data('bundles') || [];
+      if (typeof bundles === 'string') {
+        try { bundles = JSON.parse(bundles); } catch(e) { bundles = []; }
+      }
+
       $('#tfConfigId').val($btn.data('id'));
       $('#tfServiceUrl').val($btn.data('url'));
       $('#tfApiVersion').val($btn.data('version'));
       $('#tfTimeout').val($btn.data('timeout'));
+
+      // Render role checkboxes
+      var $container = $('#tfRolesContainer').empty();
+      $('#tfRoleErrorBanner').hide();
+      var multiBundle = bundles.length > 1;
+      bundles.forEach(function(bundle) {
+        var roles = bundle.roles || {};
+        Object.keys(roles).forEach(function(roleName) {
+          var roleEnabled = roles[roleName];
+          var inputId = 'role-' + bundle.id + '-' + roleName;
+          var $check = $('<div class="form-check">').append(
+            $('<input>', {
+              type: 'checkbox',
+              class: 'form-check-input tf-role-toggle',
+              id: inputId,
+              'data-bundle': bundle.id,
+              'data-role': roleName
+            })
+              .prop('checked', roleEnabled)
+              .prop('disabled', !familyEnabled),
+            $('<label>', {
+              class: 'form-check-label' + (!familyEnabled ? ' text-muted' : ''),
+              for: inputId,
+              title: 'When disabled, this role and all its OWL subclasses reject credentials with HTTP 400.',
+              'data-bs-toggle': 'tooltip'
+            }).append(
+              document.createTextNode(roleName + ' '),
+              multiBundle
+                ? $('<small class="text-muted">').text('(' + bundle.id + ')')
+                : $()
+            )
+          );
+          $container.append($check);
+        });
+      });
+
+      // Initialize Bootstrap tooltips for the newly rendered labels
+      $container.find('[data-bs-toggle="tooltip"]').each(function() {
+        new bootstrap.Tooltip(this);
+      });
+
+      $('#tfConfigModal').data('familyEnabled', familyEnabled);
+      recomputeAllDisabledWarning(familyEnabled);
       new bootstrap.Modal('#tfConfigModal').show();
     });
+
+    // Role toggle change handler
+    $('#tfConfigModal').on('change', '.tf-role-toggle', function() {
+      var $cb = $(this);
+      var bundleId = $cb.data('bundle');
+      var roleName = $cb.data('role');
+      var enabled = $cb.is(':checked');
+
+      $.ajax({
+        url: '/admin/trust-frameworks/' + encodeURIComponent(bundleId)
+          + '/roles/' + encodeURIComponent(roleName)
+          + '/enabled?enabled=' + enabled,
+        type: 'PUT',
+        success: function() {
+          $('#tfRoleErrorBanner').hide();
+          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+        },
+        error: function() {
+          $cb.prop('checked', !enabled);
+          // Recompute the all-disabled warning after the checkbox revert so it
+          // reflects the current (reverted) state rather than the failed toggle.
+          // Reproduction: disable the last enabled role → server returns 5xx →
+          // checkbox reverts to checked but warning remained visible (stale state).
+          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+          var $banner = $('#tfRoleErrorBanner');
+          $banner.text('Failed to update role "' + roleName + '". Please try again.').show();
+          clearTimeout($banner.data('hideTimer'));
+          $banner.data('hideTimer', setTimeout(function() { $banner.hide(); }, 5000));
+        }
+      });
+    });
+
+    function recomputeAllDisabledWarning(familyEnabled) {
+      if (!familyEnabled) {
+        $('#tfRolesAllDisabledWarning').hide();
+        return;
+      }
+      var allUnchecked = $('#tfRolesContainer .tf-role-toggle:checked').length === 0
+        && $('#tfRolesContainer .tf-role-toggle').length > 0;
+      $('#tfRolesAllDisabledWarning').toggle(allUnchecked);
+    }
 
     // Config save handler
     $('#tfConfigSave').on('click', function() {

--- a/fc-demo-portal/src/main/resources/static/js/admin-users.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-users.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
   var IFRAME_LOAD_TIMEOUT_MS = 5000;
 
-  // AC-3: check admin access before loading content
+  // check admin access before loading content
   $.ajax({
     url: '/admin/me',
     type: 'GET',

--- a/fc-demo-portal/src/main/resources/static/pages/admin/graphdb.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/graphdb.html
@@ -5,6 +5,8 @@
 <div class="container-fluid mt-2">
     <div id="admin-content" style="display:none">
 
+        <div id="errorBanner" class="alert alert-danger d-none" role="alert"></div>
+
         <!-- Status card -->
         <div class="card mb-3">
             <div class="card-header"><h6 class="mb-0">Current Status</h6></div>
@@ -34,10 +36,10 @@
         <div class="card mb-3">
             <div class="card-header"><h6 class="mb-0">Switch Backend</h6></div>
             <div class="card-body">
-                <div class="alert alert-warning mb-3">
-                    <i class="bi bi-exclamation-triangle me-2"></i>
-                    Switching the graph database backend requires a server restart
-                    and re-indexing of all stored assets.
+                <div class="alert alert-info mb-3">
+                    <i class="bi bi-info-circle me-2"></i>
+                    Switches take effect immediately on the running server. The target
+                    backend must be reachable now — unreachable backends are rejected.
                 </div>
                 <div class="form-check mb-2">
                     <input class="form-check-input backend-radio" type="radio" name="backend" id="backendNeo4j" value="NEO4J">
@@ -55,7 +57,28 @@
             </div>
         </div>
 
-        <!-- Confirmation modal -->
+        <!-- Rebuild graph -->
+        <div class="card mb-3">
+            <div class="card-header"><h6 class="mb-0">Rebuild Graph</h6></div>
+            <div class="card-body">
+                <div id="rebuildBanner" class="alert alert-warning d-none" role="alert">
+                    <i class="bi bi-exclamation-triangle me-2"></i>
+                    <span>
+                        The active graph has no claims yet.
+                        <span id="rebuildAssetSummary"></span>
+                    </span>
+                </div>
+                <p class="text-muted small mb-2">
+                    Re-indexes active RDF assets into the active graph backend. Use after a
+                    backend switch, after a fresh deploy, or when assets and graph claims have
+                    drifted out of sync.
+                </p>
+                <button class="btn btn-warning" id="rebuildBtn">Start rebuild</button>
+                <span id="rebuildProgress" class="ms-2 small text-muted"></span>
+            </div>
+        </div>
+
+        <!-- Confirm-switch modal -->
         <div class="modal" id="confirmSwitchModal" tabindex="-1">
             <div class="modal-dialog">
                 <div class="modal-content">
@@ -67,14 +90,35 @@
                         <p>Switch from <strong id="modalCurrentBackend">-</strong>
                            to <strong id="modalNewBackend">-</strong>?</p>
                         <ul class="text-muted">
-                            <li>Server restart required</li>
-                            <li>Graph database will be empty until rebuild</li>
-                            <li>Existing queries may need adjustment</li>
+                            <li>The target backend is probed before the switch is applied.</li>
+                            <li>The change takes effect immediately on this running server.</li>
+                            <li>The new graph store starts empty — rebuild from active RDF assets if needed.</li>
                         </ul>
                     </div>
                     <div class="modal-footer">
                         <button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                         <button class="btn btn-warning" id="confirmSwitchBtn">Confirm Switch</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Confirm-rebuild modal (shown only when the active graph already has claims) -->
+        <div class="modal" id="confirmRebuildModal" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Confirm Rebuild</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p>The active graph has <strong id="modalClaimCount">-</strong> claims.
+                           Rebuild will re-index from active RDF assets and replace existing claims.</p>
+                        <p class="text-muted small mb-0">This can take time depending on asset count and backend.</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button class="btn btn-warning" id="confirmRebuildBtn">Confirm Rebuild</button>
                     </div>
                 </div>
             </div>

--- a/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
@@ -40,6 +40,13 @@
                             <label for="tfTimeout" class="form-label">Timeout (seconds)</label>
                             <input type="number" class="form-control" id="tfTimeout" min="1" max="300" value="30">
                         </div>
+                        <hr>
+                        <h6>Roles</h6>
+                        <div id="tfRoleErrorBanner" class="alert alert-danger" style="display:none"></div>
+                        <div id="tfRolesAllDisabledWarning" class="alert alert-warning" style="display:none">
+                            All roles are disabled — this bundle is enabled but cannot resolve any credentials.
+                        </div>
+                        <div id="tfRolesContainer"></div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>

--- a/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
@@ -9,39 +9,22 @@
             <thead>
             <tr>
                 <th>Name</th>
-                <th>Framework ID</th>
-                <th>Service URL</th>
-                <th>Status</th>
+                <th>Family ID</th>
+                <th>Profiles</th>
                 <th>Active</th>
-                <th>Config</th>
+                <th>Roles</th>
             </tr>
             </thead>
         </table>
 
-        <!-- Config Modal -->
         <div class="modal" id="tfConfigModal" tabindex="-1">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title">Trust Framework Configuration</h5>
+                        <h5 class="modal-title">Trust Framework Roles</h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <input type="hidden" id="tfConfigId">
-                        <div class="mb-3">
-                            <label for="tfServiceUrl" class="form-label">Service URL</label>
-                            <input type="url" class="form-control" id="tfServiceUrl" placeholder="https://...">
-                        </div>
-                        <div class="mb-3">
-                            <label for="tfApiVersion" class="form-label">API Version</label>
-                            <input type="text" class="form-control" id="tfApiVersion" placeholder="e.g. 22.10">
-                        </div>
-                        <div class="mb-3">
-                            <label for="tfTimeout" class="form-label">Timeout (seconds)</label>
-                            <input type="number" class="form-control" id="tfTimeout" min="1" max="300" value="30">
-                        </div>
-                        <hr>
-                        <h6>Roles</h6>
                         <div id="tfRoleErrorBanner" class="alert alert-danger" style="display:none"></div>
                         <div id="tfRolesAllDisabledWarning" class="alert alert-warning" style="display:none">
                             All roles are disabled — this bundle is enabled but cannot resolve any credentials.
@@ -49,8 +32,7 @@
                         <div id="tfRolesContainer"></div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <button type="button" class="btn btn-primary" id="tfConfigSave">Save</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
                     </div>
                 </div>
             </div>

--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/EmbeddedFusekiConfig.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/EmbeddedFusekiConfig.java
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
-@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('test') && '${graphstore.impl}'.equals('fuseki')")
+@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('test')")
 public class EmbeddedFusekiConfig {
 
     @Bean(destroyMethod = "stop")

--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/FusekiGraphDbConfig.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/FusekiGraphDbConfig.java
@@ -13,12 +13,15 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
-@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime') && '${graphstore.impl}'.equals('fuseki')")
+@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime')")
 public class FusekiGraphDbConfig {
 
-    @Value("${graphstore.uri}")
+    @Value("${graphstore.fuseki.uri:${graphstore.uri}}")
     private String uri;
-        
+
+    // RDFConnectionFuseki does not open a socket at construction; the first request
+    // touches the HTTP endpoint. No connect-on-build means an unreachable Fuseki at
+    // boot does not crash the JVM in routing mode.
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
     public RDFConnection rdfConnection() {

--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
@@ -27,7 +27,6 @@ import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.sparql.core.ResultBinding;
 import org.apache.jena.system.Txn;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +43,6 @@ import java.util.regex.Pattern;
 @Slf4j
 @Component
 @Transactional
-@ConditionalOnProperty(value = "graphstore.impl", havingValue = "fuseki")
 public class SparqlGraphStore implements GraphStore {
 
     private static final String PROP_CREDENTIAL_SUBJECT = "https://www.w3.org/2018/credentials#credentialSubject";
@@ -60,7 +58,11 @@ public class SparqlGraphStore implements GraphStore {
 
     private final ClaimValidator claimValidator;
 
-    @Autowired
+    // required = false so the adapter can be wired in test contexts that do not
+    // import an embedded Fuseki (RDFConnection bean absent). Calls into this
+    // adapter when rdfConnection is null will fail at runtime; the routing layer
+    // is expected to keep a Fuseki-less deployment from selecting FUSEKI as active.
+    @Autowired(required = false)
     private RDFConnection rdfConnection;
 
     public SparqlGraphStore() {
@@ -83,6 +85,9 @@ public class SparqlGraphStore implements GraphStore {
     /** {@inheritDoc} */
     @Override
     public boolean isHealthy() {
+        if (rdfConnection == null) {
+            return false;
+        }
         try {
             Txn.calculateRead(rdfConnection, () -> {
                 try (QueryExecution qe = rdfConnection.newQuery()

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/EmbeddedNeo4JConfig.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/EmbeddedNeo4JConfig.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 @Slf4j
 @Configuration
-@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('test') && '${graphstore.impl}'.equals('neo4j')")
+@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('test')")
 //@EnableAutoConfiguration
 public class EmbeddedNeo4JConfig {
 

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/GraphDbConfig.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/GraphDbConfig.java
@@ -5,48 +5,35 @@ import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Logging;
-import org.neo4j.driver.Result;
-import org.neo4j.driver.Session;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
-@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime') && '${graphstore.impl}'.equals('neo4j')")
+@ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime')")
 public class GraphDbConfig {
 
-    @Value("${graphstore.uri}")
+    @Value("${graphstore.neo4j.uri:${graphstore.uri}}")
     private String uri;
     @Value("${graphstore.user}")
     private String user;
     @Value("${graphstore.password}")
     private String password;
 
+    // @Lazy + no eager session.run() — the Neo4j driver does not open a TCP connection at
+    // construction; it only connects on first session(). n10s schema bootstrap was moved
+    // out of this factory into Neo4jGraphStore.ensureInitialized() so that an unreachable
+    // Neo4j container at boot does not crash the JVM in routing mode.
     @Bean(destroyMethod = "close")
+    @Lazy
     public Driver driver() {
         Config config = Config.builder().withLogging(Logging.slf4j()).build();
-        Driver driver = GraphDatabase.driver(uri, AuthTokens.basic(user, password), config);
-        Session session = driver.session();
-        Result result = session.run("CALL gds.graph.exists('neo4j');");
-        if (result.hasNext()) {
-            org.neo4j.driver.Record record = result.next();
-            org.neo4j.driver.Value value = record.get("exists");
-            if (value != null && value.asBoolean()) {
-                log.info("Graph already loaded");
-                return driver;
-            }
-            if (!session.run("CALL n10s.graphconfig.show();").hasNext()) {
-                session.run("CALL n10s.graphconfig.init({handleVocabUris:'MAP',handleMultival:'ARRAY',multivalPropList:['https://w3id.org/gaia-x/2511#claimsGraphUri']});");
-                session.run("CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
-                log.info("n10s.graphconfig.init() not called second time.");
-            }
-        }
-        log.info("n10 procedure and Constraints are loaded successfully");
-        return driver;
+        return GraphDatabase.driver(uri, AuthTokens.basic(user, password), config);
     }
 
 }

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
@@ -23,7 +23,6 @@ import org.neo4j.driver.internal.InternalNode;
 import org.neo4j.driver.internal.InternalRelationship;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,8 +39,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@Transactional // not sure it is correct annotation 
-@ConditionalOnProperty(value = "graphstore.impl", havingValue = "neo4j")
+@Transactional // not sure it is correct annotation
 public class Neo4jGraphStore implements GraphStore {
 
     private static final String queryInsert = "CALL n10s.rdf.import.inline($payload, \"N-Triples\");"; 
@@ -50,9 +48,14 @@ public class Neo4jGraphStore implements GraphStore {
     private static final String queryUpdate = "MATCH (n) WHERE $uri IN n.claimsGraphUri\n" +
                                               "SET n.claimsGraphUri = [g IN n.claimsGraphUri WHERE g <> $uri];";
     
-    @Autowired
+    // required = false so the adapter can be wired in test contexts that do not
+    // import an embedded Neo4j (Driver bean absent). Calls into this adapter when
+    // driver is null will fail at runtime; the routing layer is expected to keep
+    // a Neo4j-less deployment from selecting NEO4J as active.
+    @Autowired(required = false)
     private Driver driver;
     private final ClaimValidator claimValidator;
+    private volatile boolean schemaInitialized;
 
     @Value("${graphstore.timeout-marker:timeout}")
     private String timeoutMarker;
@@ -65,6 +68,37 @@ public class Neo4jGraphStore implements GraphStore {
     public Neo4jGraphStore() {
         super();
         this.claimValidator = new ClaimValidator();
+    }
+
+    /**
+     * Ensures the n10s graphconfig and uniqueness constraint exist on the target Neo4j
+     * instance. Runs at most once per JVM (guarded by a double-checked volatile flag) and
+     * is invoked from every read/write entry point so an unreachable Neo4j at boot does
+     * not crash the JVM in routing mode — the schema bootstrap happens on first real use.
+     */
+    private void ensureInitialized() {
+        if (schemaInitialized) {
+            return;
+        }
+        synchronized (this) {
+            if (schemaInitialized) {
+                return;
+            }
+            try (Session session = driver.session()) {
+                Result result = session.run("CALL n10s.graphconfig.show();");
+                if (result.hasNext()) {
+                    log.info("Graph already configured (n10s graphconfig present)");
+                } else {
+                    // multivalPropList lists both Gaia-X namespaces — Tagus (service#) and Loire (2511#) —
+                    // so a Loire credential's claimsGraphUri is treated as multi-valued regardless of which
+                    // namespace the issuer used.
+                    session.run("CALL n10s.graphconfig.init({handleVocabUris:'MAP',handleMultival:'ARRAY',multivalPropList:['http://w3id.org/gaia-x/service#claimsGraphUri','https://w3id.org/gaia-x/2511#claimsGraphUri']});");
+                    session.run("CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
+                    log.info("n10s graphconfig initialized and constraints created");
+                }
+            }
+            schemaInitialized = true;
+        }
     }
 
     /** {@inheritDoc} */
@@ -82,8 +116,12 @@ public class Neo4jGraphStore implements GraphStore {
     /** {@inheritDoc} */
     @Override
     public boolean isHealthy() {
+        if (driver == null) {
+            return false;
+        }
         try {
             driver.verifyConnectivity();
+            ensureInitialized();
             return true;
         } catch (Exception e) {
             log.warn("Neo4j connectivity check failed", e);
@@ -94,6 +132,7 @@ public class Neo4jGraphStore implements GraphStore {
     /** {@inheritDoc} */
     @Override
     public long getClaimCount() {
+        ensureInitialized();
         try (Session session = driver.session()) {
             Result result = session.run(
                 "MATCH (n) WHERE n.claimsGraphUri IS NOT NULL RETURN count(n) AS cnt");
@@ -107,6 +146,7 @@ public class Neo4jGraphStore implements GraphStore {
     /** {@inheritDoc} */
     @Override
     public long getRDFAssetCountInGraph() {
+        ensureInitialized();
         try (Session session = driver.session()) {
             Result result = session.run(
                 "MATCH (n) WHERE n.claimsGraphUri IS NOT NULL "
@@ -124,6 +164,7 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public void addClaims(List<RdfClaim> claimList, String credentialSubject) {
         if (!claimList.isEmpty()) {
+            ensureInitialized();
             try (Session session = driver.session()) {
                 Pair<String, Set<String>> props = claimValidator.resolveClaims(claimList, credentialSubject);
                 if (!props.getRight().isEmpty()) {
@@ -140,6 +181,7 @@ public class Neo4jGraphStore implements GraphStore {
      */
     @Override
     public void deleteClaims(String credentialSubject) {
+        ensureInitialized();
         Map<String, Object> params = Map.of("uri", credentialSubject);
         try (Session session = driver.session()) {
             Result rsDelete = session.run(queryDelete, params);
@@ -157,6 +199,7 @@ public class Neo4jGraphStore implements GraphStore {
    */
     @Override
     public void deleteValidationResultClaims(String resultIri) {
+        ensureInitialized();
         try (Session session = driver.session()) {
             Result rs = session.run("MATCH (n {uri: $uri}) DETACH DELETE n", Map.of("uri", resultIri));
             log.debug("deleteValidationResultClaims; deleted: {}", rs.consume());
@@ -174,6 +217,7 @@ public class Neo4jGraphStore implements GraphStore {
             throw new UnsupportedOperationException(query.getQueryLanguage() + " query language is not supported yet");
         }
 
+        ensureInitialized();
         TransactionConfig transactionConfig = TransactionConfig.builder()
                 .withTimeout(Duration.ofSeconds(query.getTimeout()))
                 .build();

--- a/fc-service-api/src/main/java/eu/xfsc/fc/api/FcMediaTypes.java
+++ b/fc-service-api/src/main/java/eu/xfsc/fc/api/FcMediaTypes.java
@@ -1,0 +1,27 @@
+package eu.xfsc.fc.api;
+
+import org.springframework.http.MediaType;
+
+/**
+ * Wire-format media types specific to the Federated Catalogue API.
+ *
+ * <p>Mirrors Spring's pattern of exposing both the {@link MediaType} instance and its
+ * {@link String} value, so callers can pick the form their API needs (annotations and
+ * MockMvc {@code .contentType(String)} use the string; WebClient and similar use the
+ * {@code MediaType}).
+ */
+public final class FcMediaTypes {
+
+  /**
+   * Merge-patch content type per RFC 7396.
+   */
+  public static final String MERGE_PATCH_JSON_VALUE = "application/merge-patch+json";
+
+  /**
+   * {@link MediaType} form of {@link #MERGE_PATCH_JSON_VALUE}.
+   */
+  public static final MediaType MERGE_PATCH_JSON = MediaType.valueOf(MERGE_PATCH_JSON_VALUE);
+
+  private FcMediaTypes() {
+  }
+}

--- a/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
+++ b/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
@@ -15,10 +15,11 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
-import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
 
 /**
  * Client for Admin API endpoints.
@@ -57,34 +58,40 @@ public class AdminClient extends ServiceClient {
             authorizedClient);
     }
 
-    /** Toggles a trust framework's enabled state. */
-    public void setTrustFrameworkEnabled(String id, boolean enabled,
+  /**
+   * Applies a merge-patch to the identified trust framework. Only fields present in the patch
+   * are modified; absent fields are left unchanged.
+   *
+   * @param id               trust framework family identifier
+   * @param patch            fields to update
+   * @param authorizedClient OAuth2 client for bearer token
+   */
+  public void patchTrustFramework(String id, TrustFrameworkPatch patch,
         OAuth2AuthorizedClient authorizedClient) {
-        doPut("/admin/trust-frameworks/{id}/enabled", "",
-            Map.of("id", id), Map.of("enabled", enabled), Void.class, authorizedClient);
-    }
+        doPatch("/admin/trust-frameworks/{id}", patch, Map.of("id", id), Void.class, authorizedClient);
+  }
 
-    /** Updates a trust framework's configuration. */
-    public void updateTrustFrameworkConfig(String id, TrustFrameworkConfigUpdate config,
-        OAuth2AuthorizedClient authorizedClient) {
-        doPut("/admin/trust-frameworks/{id}", config,
-            Map.of("id", id), null, Void.class, authorizedClient);
-    }
-
-    /** Gets schema validation module status. */
+  /** Gets schema validation module status. */
     public SchemaValidationStatus getSchemaValidation(OAuth2AuthorizedClient authorizedClient) {
         return doGet("/admin/schema-validation", Map.of(), null,
             SchemaValidationStatus.class, authorizedClient);
     }
 
-    /** Toggles a schema validation module. */
-    public void setSchemaModuleEnabled(String type, boolean enabled,
-        OAuth2AuthorizedClient authorizedClient) {
-        doPut("/admin/schema-validation/modules/{type}", "",
-            Map.of("type", type), Map.of("enabled", enabled), Void.class, authorizedClient);
+    /**
+     * Applies a merge-patch to the identified schema validation module. Only fields present in
+     * the patch are modified; absent fields are left unchanged.
+     *
+     * @param type             module type (SHACL, JSON_SCHEMA, XML_SCHEMA, OWL)
+     * @param patch            fields to update
+     * @param authorizedClient OAuth2 client for bearer token
+     */
+    public void patchSchemaModule(String type, SchemaModulePatch patch,
+                                  OAuth2AuthorizedClient authorizedClient) {
+        doPatch("/admin/schema-validation/modules/{type}", patch,
+            Map.of("type", type), Void.class, authorizedClient);
     }
 
-    /** Lists uploaded ontologies and their per-role subclass contributions. */
+  /** Lists uploaded ontologies and their per-role subclass contributions. */
     public OntologyImpactList getOntologyImpact(OAuth2AuthorizedClient authorizedClient) {
         return doGet("/admin/schema-validation/ontologies", Map.of(), null,
             OntologyImpactList.class, authorizedClient);

--- a/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
+++ b/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -13,6 +15,7 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
@@ -101,5 +104,35 @@ public class AdminClient extends ServiceClient {
         return doPost("/admin/graph-database/switch",
             Map.of("backend", backend), Map.of(), null,
             GraphDatabaseSwitchResult.class, authorizedClient);
+    }
+
+  /**
+   * Triggers an asynchronous rebuild of the active graph backend.
+   *
+   * <p>The status code carries the outcome: {@code 202 ACCEPTED} when a fresh rebuild
+   * was started, {@code 409 CONFLICT} when a rebuild was already running. Both
+   * responses share the same {@link RebuildStatus} body so callers can inspect
+   * current progress without a follow-up call.
+   *
+   * @return the rebuild status together with the originating HTTP status
+   */
+  public ResponseEntity<RebuildStatus> triggerGraphRebuild(OAuth2AuthorizedClient authorizedClient) {
+    try {
+      RebuildStatus body = doPost("/admin/graph/rebuild", Map.of(), Map.of(), null,
+          RebuildStatus.class, authorizedClient);
+      return ResponseEntity.accepted().body(body);
+    } catch (ExternalServiceException ex) {
+      if (ex.getStatus() != null && ex.getStatus().value() == HttpStatus.CONFLICT.value()) {
+        RebuildStatus body = mapper.convertValue(ex.getDetails(), RebuildStatus.class);
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+      }
+      throw ex;
+    }
+    }
+
+    /** Polls graph rebuild progress. */
+    public RebuildStatus getGraphRebuildStatus(OAuth2AuthorizedClient authorizedClient) {
+        return doGet("/admin/graph/rebuild/status", Map.of(), null,
+            RebuildStatus.class, authorizedClient);
     }
 }

--- a/fc-service-client/src/main/java/eu/xfsc/fc/client/ServiceClient.java
+++ b/fc-service-client/src/main/java/eu/xfsc/fc/client/ServiceClient.java
@@ -40,17 +40,27 @@ public abstract class ServiceClient {
                 configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON));
             })
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .filter(ExchangeFilterFunction.ofResponseProcessor(response -> {
-            	if (response.statusCode().isError()) {
-            		return response.bodyToMono(Map.class)
-            				.flatMap(map -> Mono.error(new ExternalServiceException(response.statusCode(), map)));
-            	}
-            	return Mono.just(response);
-            }));
-        if (jwt != null) {
-            builder = builder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwt);
-        }
-        this.client = builder.build();
+            .filter(errorPropagationFilter());
+      if (jwt != null) {
+        builder = builder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwt);
+      }
+      this.client = builder.build();
+    }
+
+  /**
+   * Exchange filter that converts any 4xx/5xx response into an
+   * {@link ExternalServiceException} carrying the parsed response body. Exposed so
+   * test {@code WebClient}s can wire the same body-preserving error handling that the
+   * production constructor uses.
+   */
+  public static ExchangeFilterFunction errorPropagationFilter() {
+    return ExchangeFilterFunction.ofResponseProcessor(response -> {
+      if (response.statusCode().isError()) {
+        return response.bodyToMono(Map.class)
+            .flatMap(map -> Mono.error(new ExternalServiceException(response.statusCode(), map)));
+      }
+      return Mono.just(response);
+    });
     }
 
     public ServiceClient(String baseUrl, WebClient client) {

--- a/fc-service-client/src/main/java/eu/xfsc/fc/client/ServiceClient.java
+++ b/fc-service-client/src/main/java/eu/xfsc/fc/client/ServiceClient.java
@@ -17,6 +17,8 @@ import org.springframework.web.util.UriBuilder;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import eu.xfsc.fc.api.FcMediaTypes;
+
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import java.net.URI;
@@ -194,6 +196,50 @@ public abstract class ServiceClient {
             .uri(uriBuilder -> buildUri(uriBuilder, path, pathParams, queryParams))
             .bodyValue(body)
             .attributes(oauth2AuthorizedClient(authorizedClient))
+            .retrieve()
+            .bodyToMono(reType)
+            .block();
+    }
+
+  /**
+   * Sends a PATCH request with the given body using {@code application/merge-patch+json}.
+   *
+   * @param path       URI template (supports Spring-style path variables)
+   * @param body       request payload; serialised to JSON
+   * @param pathParams path variable substitutions
+   * @param reType     expected response body type
+   * @return deserialized response body, or {@code null} for {@code Void}
+   */
+  protected <T> T doPatch(String path, Object body, Map<String, Object> pathParams, Class<T> reType) {
+    return client
+        .patch()
+        .uri(uriBuilder -> buildUri(uriBuilder, path, pathParams, null))
+        .contentType(FcMediaTypes.MERGE_PATCH_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(reType)
+        .block();
+  }
+
+  /**
+   * Sends a PATCH request with the given body using {@code application/merge-patch+json},
+   * attaching the supplied OAuth2 authorized client for token propagation.
+   *
+   * @param path             URI template (supports Spring-style path variables)
+   * @param body             request payload; serialised to JSON
+   * @param pathParams       path variable substitutions
+   * @param reType           expected response body type
+   * @param authorizedClient OAuth2 client used to obtain the bearer token
+   * @return deserialized response body, or {@code null} for {@code Void}
+   */
+  protected <T> T doPatch(String path, Object body, Map<String, Object> pathParams, Class<T> reType,
+                          OAuth2AuthorizedClient authorizedClient) {
+    return client
+        .patch()
+        .uri(uriBuilder -> buildUri(uriBuilder, path, pathParams, null))
+        .contentType(FcMediaTypes.MERGE_PATCH_JSON)
+        .bodyValue(body)
+        .attributes(oauth2AuthorizedClient(authorizedClient))
             .retrieve()
             .bodyToMono(reType)
             .block();

--- a/fc-service-client/src/test/java/eu/xfsc/fc/client/AdminClientTest.java
+++ b/fc-service-client/src/test/java/eu/xfsc/fc/client/AdminClientTest.java
@@ -1,0 +1,82 @@
+package eu.xfsc.fc.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import eu.xfsc.fc.api.generated.model.RebuildStatus;
+import reactor.core.publisher.Mono;
+
+/**
+ * Tests for {@link AdminClient}. Focused on the rebuild-trigger path — the OpenAPI
+ * advertises a {@code 409} response with a {@link RebuildStatus} body so callers can
+ * see current progress when a rebuild is already running. The SDK must surface that
+ * body and status code, not throw it away.
+ */
+class AdminClientTest {
+
+  private static final String CONFLICT_BODY = """
+      {
+        "running": true,
+        "percentComplete": 42,
+        "processed": 21,
+        "total": 50
+      }
+      """;
+
+  @Test
+  void triggerGraphRebuild_serverReturns409_surfacesStatusAndBody() {
+    ExchangeFunction stub = request -> Mono.just(ClientResponse.create(HttpStatus.CONFLICT)
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .body(CONFLICT_BODY)
+        .build());
+    WebClient webClient = WebClient.builder()
+        .filter(ServiceClient.errorPropagationFilter())
+        .exchangeFunction(stub)
+        .build();
+    AdminClient client = new AdminClient("http://test", webClient);
+
+    ResponseEntity<RebuildStatus> response = client.triggerGraphRebuild(null);
+
+    assertEquals(HttpStatus.CONFLICT, response.getStatusCode(),
+        "409 status must survive through to the caller");
+    RebuildStatus body = response.getBody();
+    assertEquals(Boolean.TRUE, body.getRunning(),
+        "RebuildStatus body must be deserialized and exposed on the conflict response");
+    assertEquals(21L, body.getProcessed());
+    assertEquals(50L, body.getTotal());
+  }
+
+  @Test
+  void triggerGraphRebuild_serverReturns202_surfacesStatusAndBody() {
+    String acceptedBody = """
+        {
+          "running": true,
+          "percentComplete": 0,
+          "processed": 0,
+          "total": 50
+        }
+        """;
+    ExchangeFunction stub = request -> Mono.just(ClientResponse.create(HttpStatus.ACCEPTED)
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .body(acceptedBody)
+        .build());
+    WebClient webClient = WebClient.builder()
+        .filter(ServiceClient.errorPropagationFilter())
+        .exchangeFunction(stub)
+        .build();
+    AdminClient client = new AdminClient("http://test", webClient);
+
+    ResponseEntity<RebuildStatus> response = client.triggerGraphRebuild(null);
+
+    assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
+    assertEquals(Boolean.TRUE, response.getBody().getRunning());
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetRepositoryCustomImpl.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/assets/AssetRepositoryCustomImpl.java
@@ -69,6 +69,11 @@ public class AssetRepositoryCustomImpl implements AssetRepositoryCustom {
     if (filter.getHashes() != null) {
       queryBuilder.addClause("asset_hash in (?)", "hashes", filter.getHashes());
     }
+    if (filter.getContentKinds() != null) {
+      List<String> kindNames = filter.getContentKinds().stream()
+          .map(Enum::name).collect(Collectors.toList());
+      queryBuilder.addClause("content_kind in (?)", "contentKinds", kindNames);
+    }
 
     String query = queryBuilder.buildCountQuery();
     SqlParameterSource sps = new AssetQueryParameterSource(queryBuilder);

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleState.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleState.java
@@ -1,0 +1,62 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Persists the enabled/disabled state of a single role within a trust framework bundle.
+ *
+ * <p>Absence of a row for a given {@code (frameworkId, roleName)} pair means the role is enabled
+ * by default. Only rows with {@code enabled = false} (or explicit {@code true} overrides written
+ * by the service) are stored here.
+ *
+ * <p>{@code frameworkId} is the registry bundle profile ID (e.g. {@code gaia-x-2511}).
+ * {@code roleName} is the role name declared in the bundle's {@code framework.yaml}
+ * (e.g. {@code Participant}).
+ */
+@Entity
+@Table(name = "trust_framework_role_states")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrustFrameworkRoleState {
+
+  @EmbeddedId
+  private TrustFrameworkRoleStateId id;
+
+  @Column(name = "enabled", nullable = false)
+  private boolean enabled;
+
+  /**
+   * Convenience constructor.
+   *
+   * @param frameworkId registry bundle profile ID
+   * @param roleName    role name from the bundle's roles map
+   * @param enabled     whether this role is enabled
+   */
+  public TrustFrameworkRoleState(String frameworkId, String roleName, boolean enabled) {
+    this.id = new TrustFrameworkRoleStateId(frameworkId, roleName);
+    this.enabled = enabled;
+  }
+
+  /**
+   * Returns the bundle profile ID component of the composite key.
+   */
+  public String getFrameworkId() {
+    return id.getFrameworkId();
+  }
+
+  /**
+   * Returns the role name component of the composite key.
+   */
+  public String getRoleName() {
+    return id.getRoleName();
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateId.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateId.java
@@ -1,0 +1,31 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import java.io.Serializable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Composite primary key for {@link TrustFrameworkRoleState}.
+ *
+ * <p>{@code frameworkId} is the registry bundle profile ID (e.g. {@code gaia-x-2511});
+ * {@code roleName} is the role name as declared in the bundle's {@code framework.yaml}
+ * (e.g. {@code Participant}).
+ */
+@Embeddable
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrustFrameworkRoleStateId implements Serializable {
+
+  @Column(name = "framework_id", length = 255, nullable = false)
+  private String frameworkId;
+
+  @Column(name = "role_name", length = 255, nullable = false)
+  private String roleName;
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkRoleStateRepository.java
@@ -1,0 +1,52 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for per-role enabled state of trust framework bundles.
+ *
+ * <p>Absence of a row means the role is enabled by default (interpreted in the service layer).
+ * This repository stores only rows that have been explicitly written via
+ * {@link eu.xfsc.fc.core.service.trustframework.TrustFrameworkService#setRoleEnabled}.
+ */
+public interface TrustFrameworkRoleStateRepository
+    extends JpaRepository<TrustFrameworkRoleState, TrustFrameworkRoleStateId> {
+
+  /**
+   * Finds the persisted state row for a specific bundle profile ID and role name.
+   * Returns empty when no explicit state has been written (default = enabled).
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @return the state row, or empty if absent
+   */
+  Optional<TrustFrameworkRoleState> findByIdFrameworkIdAndIdRoleName(
+      String frameworkId, String roleName);
+
+  /**
+   * Returns all explicitly persisted state rows for the given bundle profile ID.
+   * Roles absent from this list are enabled by default.
+   *
+   * @param frameworkId registry bundle profile ID
+   * @return list of state rows; never null
+   */
+  List<TrustFrameworkRoleState> findByIdFrameworkId(String frameworkId);
+
+  /**
+   * Convenience alias for {@link #findByIdFrameworkId(String)}.
+   */
+  default List<TrustFrameworkRoleState> findByFrameworkId(String frameworkId) {
+    return findByIdFrameworkId(frameworkId);
+  }
+
+  /**
+   * Convenience alias for looking up a single role state by bundle profile ID and role name.
+   */
+  default Optional<TrustFrameworkRoleState> findByFrameworkIdAndRoleName(
+      String frameworkId, String roleName) {
+    return findByIdFrameworkIdAndIdRoleName(frameworkId, roleName);
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/AssetFilter.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/AssetFilter.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.pojo;
 
 import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.dao.assets.ContentKind;
 import java.time.Instant;
 import java.util.List;
 
@@ -68,6 +69,12 @@ public class AssetFilter {
    */
   @lombok.Setter
   private List<String> hashes;
+
+  /**
+   * Filter for the content kind of the asset (RDF or NON_RDF).
+   */
+  @lombok.Setter
+  private List<ContentKind> contentKinds;
 
   /**
    * The offset to start returning results when applying this filter.

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/DummyGraphStore.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/DummyGraphStore.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import eu.xfsc.fc.api.generated.model.QueryLanguage;
@@ -16,7 +15,6 @@ import eu.xfsc.fc.core.pojo.PaginatedResults;
 
 //@Slf4j
 @Component
-@ConditionalOnProperty(value = "graphstore.impl", havingValue = "none", matchIfMissing = true)
 public class DummyGraphStore implements GraphStore {
 
     @Override

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/GraphRebuildService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/graphdb/GraphRebuildService.java
@@ -1,6 +1,7 @@
 package eu.xfsc.fc.core.service.graphdb;
 
 import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.dao.assets.ContentKind;
 import eu.xfsc.fc.core.exception.GraphStoreDisabledException;
 import eu.xfsc.fc.core.pojo.GraphBackendType;
 import eu.xfsc.fc.core.pojo.AssetFilter;
@@ -65,6 +66,11 @@ public class GraphRebuildService {
         try {
           AssetFilter filter = new AssetFilter();
           filter.setStatuses(List.of(AssetStatus.ACTIVE));
+          // The rebuilder only adds claims for RDF-content assets; non-RDF assets are
+          // skipped inside addAssetToGraph. Counting RDF only here keeps `total` in
+          // sync with the work actually performed and with the rdfAssetCount field
+          // returned by GET /admin/graph-database.
+          filter.setContentKinds(List.of(ContentKind.RDF));
           filter.setLimit(0);
           filter.setOffset(0);
           long total = assetStore.getByFilter(filter, false, false).getTotalCount();

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistry.java
@@ -5,10 +5,14 @@ import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileCo
 
 import java.io.StringReader;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -79,7 +83,7 @@ public class TrustFrameworkRegistry {
    * @param bundles the list of bundles to register
    */
   public TrustFrameworkRegistry(List<TrustFrameworkBundle> bundles) {
-    this.bundleIndex = new HashMap<>();
+    this.bundleIndex = new LinkedHashMap<>();
     this.typeIndex = new HashMap<>();
     var active = new java.util.HashSet<String>();
     for (TrustFrameworkBundle bundle : bundles) {
@@ -137,9 +141,12 @@ public class TrustFrameworkRegistry {
 
   /**
    * Returns every bundle that was registered at construction time, whether active or deferred.
+   * The iteration order matches the order in which bundles were registered (i.e. the order of
+   * the {@code bundles} list passed to the constructor); duplicate IDs are skipped on first
+   * occurrence.
    * Modifications to the returned collection will not affect the registry's internal state.
    *
-   * @return immutable collection of all registered bundles; never null
+   * @return immutable collection of all registered bundles in registration order; never null
    */
   public Collection<TrustFrameworkBundle> getAllBundles() {
     return List.copyOf(bundleIndex.values());
@@ -215,16 +222,19 @@ public class TrustFrameworkRegistry {
   }
 
   /**
-   * Returns the set of effective role names declared in the bundle associated with the given profile ID.
+   * Returns an ordered, unmodifiable set of effective role names declared in the bundle associated with the given profile ID.
+   * The returned set preserves the declaration order from the bundle YAML configuration.
    * If no bundle is registered under the profile ID, returns an empty set.
    *
    * @param profileId the ID of the profile to look up
-   * @return a set of role names declared in the bundle, or an empty set if no bundle is registered under the profile ID
+   * @return an ordered unmodifiable set of role names declared in the bundle, or an empty set if no bundle is registered under the profile ID
    */
-  public Set<String> getEffectiveRoles(String profileId) {
-    return bundleIndex.containsKey(profileId)
-        ? Set.copyOf(bundleIndex.get(profileId).config().roles().keySet())
-        : Set.of();
+  public SequencedSet<String> getEffectiveRoles(String profileId) {
+    if (!bundleIndex.containsKey(profileId)) {
+      return Collections.unmodifiableSequencedSet(new LinkedHashSet<>());
+    }
+    return Collections.unmodifiableSequencedSet(
+        new LinkedHashSet<>(bundleIndex.get(profileId).config().roles().keySet()));
   }
 
   /**

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
@@ -3,11 +3,18 @@ package eu.xfsc.fc.core.service.trustframework;
 import eu.xfsc.fc.core.dao.trustframework.TrustFramework;
 import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkMapper;
 import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRepository;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleState;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateId;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateRepository;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedSet;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +30,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class TrustFrameworkService {
 
   private final TrustFrameworkRepository trustFrameworkRepository;
+  private final TrustFrameworkRoleStateRepository roleStateRepository;
+  private final TrustFrameworkRegistry trustFrameworkRegistry;
 
   /**
    * Returns true if the trust framework identified by the given family ID has its enabled
@@ -87,5 +96,98 @@ public class TrustFrameworkService {
       trustFrameworkRepository.save(entity);
       return TrustFrameworkMapper.toConfig(entity);
     });
+  }
+
+  /**
+   * Returns true if the named role in the given bundle profile is enabled.
+   * Absence of a persisted state row means the role is enabled by default.
+   *
+   * <p><strong>Bundle-off dominance:</strong> when the bundle's family is
+   * disabled in persistence, this method returns {@code true} regardless of the role's
+   * persisted state. The role-toggle layer has no effect while the bundle is off — rejection
+   * is handled by the bundle-disabled pathway in the caller. This prevents a double-rejection
+   * and makes role-toggle state semantically inert for disabled bundles.
+   *
+   * <p>This method does not validate that the bundle or role is registered —
+   * call sites that need validation should use {@link #setRoleEnabled} or
+   * {@link #getRoleStates}, which both throw on unknown input.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @return true if enabled (including default when no row exists, or when bundle family is
+   *         disabled), false if explicitly disabled and the bundle family is enabled
+   */
+  @Transactional(readOnly = true)
+  public boolean isRoleEnabled(String frameworkId, String roleName) {
+    // Bundle-off dominance: if the bundle's family is disabled, the role-toggle is bypassed.
+    // Unknown frameworkId → no bundle → no family to look up → fall through to role-state check.
+    boolean familyDisabled = trustFrameworkRegistry.getBundle(frameworkId)
+        .map(bundle -> bundle.config().family())
+        .flatMap(trustFrameworkRepository::findById)
+        .map(tf -> !tf.isEnabled())
+        .orElse(false);
+    if (familyDisabled) {
+      return true;
+    }
+    return roleStateRepository.findByFrameworkIdAndRoleName(frameworkId, roleName)
+        .map(TrustFrameworkRoleState::isEnabled)
+        .orElse(true);
+  }
+
+  /**
+   * Persists the enabled/disabled state for a named role in the given bundle profile.
+   * Creates or updates the state row (upsert). Validates that the bundle and role both
+   * exist in the registry before writing.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param roleName    role name from the bundle (e.g. {@code Participant})
+   * @param enabled     new enabled state
+   * @throws NotFoundException when the bundle profile ID or the role name is not registered
+   */
+  @Transactional
+  public void setRoleEnabled(String frameworkId, String roleName, boolean enabled) {
+    if (trustFrameworkRegistry.getBundle(frameworkId).isEmpty()) {
+      throw new NotFoundException("Trust framework bundle not found in registry: " + frameworkId);
+    }
+    SequencedSet<String> knownRoles = trustFrameworkRegistry.getEffectiveRoles(frameworkId);
+    if (!knownRoles.contains(roleName)) {
+      throw new NotFoundException(
+          "Role '%s' not declared in bundle '%s'".formatted(roleName, frameworkId));
+    }
+    var id = new TrustFrameworkRoleStateId(frameworkId, roleName);
+    var state = roleStateRepository.findById(id)
+        .map(existing -> {
+          existing.setEnabled(enabled);
+          return existing;
+        })
+        .orElseGet(() -> new TrustFrameworkRoleState(frameworkId, roleName, enabled));
+    roleStateRepository.save(state);
+  }
+
+  /**
+   * Returns the full map of role name → effective enabled state for all roles declared in the
+   * given bundle. Merges persisted overrides with the default-true for absent rows.
+   *
+   * @param frameworkId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @return map of role name → effective enabled state; never null; preserves declaration order
+   * @throws NotFoundException when the bundle profile ID is not registered in the registry
+   */
+  @Transactional(readOnly = true)
+  public Map<String, Boolean> getRoleStates(String frameworkId) {
+    if (trustFrameworkRegistry.getBundle(frameworkId).isEmpty()) {
+      throw new NotFoundException("Trust framework bundle not found in registry: " + frameworkId);
+    }
+    SequencedSet<String> knownRoles = trustFrameworkRegistry.getEffectiveRoles(frameworkId);
+    // Index persisted overrides by role name for O(1) lookup
+    Map<String, Boolean> persisted = roleStateRepository.findByFrameworkId(frameworkId).stream()
+        .collect(Collectors.toMap(
+            TrustFrameworkRoleState::getRoleName,
+            TrustFrameworkRoleState::isEnabled));
+
+    Map<String, Boolean> result = new LinkedHashMap<>();
+    for (String role : knownRoles) {
+      result.put(role, persisted.getOrDefault(role, true));
+    }
+    return result;
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialVerificationStrategy.java
@@ -563,7 +563,8 @@ public class CredentialVerificationStrategy implements RdfIngestionStrategy {
             ? schemaStore.getCompositeSchema(SchemaStore.SchemaType.ONTOLOGY)
             : null;
     ResolvedRole result = ClaimValidator.resolveSubjectRole(
-        getStreamManager(), credential.toJson(), trustFrameworkRegistry, compositeOntology);
+        getStreamManager(), credential.toJson(), trustFrameworkRegistry, compositeOntology,
+        trustFrameworkService::isRoleEnabled);
     log.debug("resolveRole; format: {}, got role: {}", format, result);
     return result;
   }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/VerificationConstants.java
@@ -31,6 +31,9 @@ public final class VerificationConstants {
    */
   public static final String GAIAX_CLAIMS_GRAPH_URI = "https://w3id.org/gaia-x/2511#claimsGraphUri";
 
+  // TODO: media types below are API/wire concerns, not verification-domain vocabulary.
+  // Move to eu.xfsc.fc.api.FcMediaTypes (alongside MERGE_PATCH_JSON).
+
   // W3C VC-JOSE-COSE media types (IANA-registered)
   public static final String MEDIA_TYPE_VC_JWT = "application/vc+jwt";
   public static final String MEDIA_TYPE_VP_JWT = "application/vp+jwt";

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/ClaimValidator.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -32,6 +33,7 @@ import org.apache.jena.riot.system.stream.StreamManager;
 import org.apache.jena.shared.impl.JenaParameters;
 import org.apache.jena.vocabulary.RDF;
 
+import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.QueryException;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.RdfClaim;
@@ -45,6 +47,14 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ClaimValidator {
+
+  /**
+   * Message template for role-toggle rejection. Used in {@link ClientException} when a resolved
+   * role is explicitly disabled.
+   * Arguments (in order): {@code frameworkProfileId}, {@code role}.
+   */
+  static final String ROLE_DISABLED_MSG = "Trust framework role '%s/%s' is disabled";
+
     // Stored to temporarily deviate from the standard Jena behavior of parsing
     // literals
 	// don't see how it can work in multithreaded scenario!
@@ -184,10 +194,15 @@ public class ClaimValidator {
    * @param subject           JSON-LD credential string whose {@code credentialSubject} type is inspected
    * @param registry          the active trust-framework registry
    * @param compositeOntology union ontology to use as fallback; may be {@code null}
+   * @param isRoleEnabled     predicate {@code (bundleId, roleName) -> enabled}; when it returns
+   *                          {@code false} for the matched role a {@link ClientException} is thrown
    * @return the first resolved role, or {@link ResolvedRole#UNKNOWN} when no framework claims the type
+   * @throws ClientException when the matched role is disabled according to {@code isRoleEnabled}
    */
   public static ResolvedRole resolveSubjectRole(StreamManager sm, String subject,
-                                                TrustFrameworkRegistry registry, ContentAccessor compositeOntology) {
+                                                TrustFrameworkRegistry registry,
+                                                ContentAccessor compositeOntology,
+                                                BiPredicate<String, String> isRoleEnabled) {
         try {
           Model data = ModelFactory.createDefaultModel();
           RDFParser.create()
@@ -207,14 +222,20 @@ public class ClaimValidator {
               String typeUri = rdfNode.asResource().getURI();
               ResolvedRole role = registry.resolveRole(typeUri);
               if (role.isResolved()) {
+                if (!isRoleEnabled.test(role.frameworkProfileId(), role.role())) {
+                  throw new ClientException(
+                      ROLE_DISABLED_MSG.formatted(role.frameworkProfileId(), role.role()));
+                }
                 return role;
               }
               unresolved.add(typeUri);
             }
           }
           if (compositeOntology != null && !unresolved.isEmpty()) {
-            return resolveViaOntology(unresolved, registry, compositeOntology);
+            return resolveViaOntology(unresolved, registry, compositeOntology, isRoleEnabled);
           }
+        } catch (ClientException ce) {
+          throw ce;
         } catch (Exception e) {
           log.debug("resolveSubjectRole.error: {}", e.getMessage());
         }
@@ -222,7 +243,9 @@ public class ClaimValidator {
   }
 
   private static ResolvedRole resolveViaOntology(List<String> typeUris,
-                                                 TrustFrameworkRegistry registry, ContentAccessor compositeOntology) {
+                                                 TrustFrameworkRegistry registry,
+                                                 ContentAccessor compositeOntology,
+                                                 BiPredicate<String, String> isRoleEnabled) {
     OntModel model = ModelFactory.createOntologyModel(OntModelSpec.OWL_MEM_MICRO_RULE_INF);
         model.read(new StringReader(compositeOntology.getContentAsString()), null, Lang.TURTLE.getName());
     for (TrustFrameworkBundle bundle : registry.getActiveBundles()) {
@@ -239,6 +262,10 @@ public class ClaimValidator {
         for (String typeUri : typeUris) {
           for (String rootUri : rootUris) {
             if (isSubclassOf(typeUri, rootUri, model)) {
+              if (!isRoleEnabled.test(resolved.frameworkProfileId(), resolved.role())) {
+                throw new ClientException(
+                    ROLE_DISABLED_MSG.formatted(resolved.frameworkProfileId(), resolved.role()));
+              }
               return resolved;
             }
           }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -76,14 +76,18 @@ public class GraphRebuilder {
     AtomicInteger pendingTasks = new AtomicInteger(0);
     ExecutorService executorService = ProcessorUtils.createProcessors(threads, taskQueue, hash -> {
       Exception caught = null;
+      boolean processed = false;
       try {
-        addAssetToGraph(hash);
+        processed = addAssetToGraph(hash);
       } catch (Exception e) {
         log.error("Failed to add asset {} to graph", hash, e);
         caught = e;
       } finally {
         pendingTasks.decrementAndGet();
-        if (progressCallback != null) {
+        // Skip the progress tick for non-RDF assets that early-returned without
+        // doing any work — they are not counted in `total` either, so ticking
+        // here would push processed > total.
+        if (progressCallback != null && (processed || caught != null)) {
           progressCallback.accept(1, caught);
         }
       }
@@ -157,14 +161,20 @@ public class GraphRebuilder {
     }
   }
 
-    private void addAssetToGraph(String hash) throws Exception {
+    /**
+     * Processes one asset hash. Returns true when claims were extracted and pushed to
+     * the graph store, false when the asset was skipped (non-RDF — null contentAccessor).
+     * The caller uses the return value to decide whether to tick the progress counter.
+     */
+    private boolean addAssetToGraph(String hash) throws Exception {
     AssetMetadata assetMetaData = assetStore.getByHash(hash);
     if (assetMetaData.getContentAccessor() == null) {
-      return;
+      return false;
     }
         List<RdfClaim> claims = extractClaims(assetMetaData);
     claims = protectedNamespaceFilter.filterClaims(claims, "graph rebuild").claims();
     graphStore.addClaims(claims, assetMetaData.getId());
+    return true;
   }
 
     private List<RdfClaim> extractClaims(AssetMetadata assetMetaData) throws Exception {

--- a/fc-service-core/src/main/resources/liquibase/changesets/017-trust-framework-role-states.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/017-trust-framework-role-states.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="nowak" id="2026-05-20-trust-framework-role-states">
+        <comment>
+            Per-role enabled/disabled state for trust framework bundles.
+            Absence of a row means enabled=true (default). No seed rows — the existing
+            gaia-x seed row in trust_frameworks is unaffected; all its roles remain enabled
+            by default without needing explicit rows here.
+        </comment>
+
+        <createTable tableName="trust_framework_role_states">
+            <column name="framework_id" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_tf_role_states" nullable="false"/>
+            </column>
+            <column name="role_name" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_tf_role_states" nullable="false"/>
+            </column>
+            <column name="enabled" type="boolean" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/changesets/018-mock-trust-framework-seed.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/018-mock-trust-framework-seed.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="nowak" id="2026-05-21-mock-trust-framework-seed">
+        <comment>
+            Seeds the mock trust-framework family row. Starts disabled so operators can
+            activate it explicitly via the admin toggle endpoint. The mock-2026 bundle
+            carries its own service_url via the YAML bundle config.
+        </comment>
+
+        <insert tableName="trust_frameworks">
+            <column name="id" value="mock"/>
+            <column name="name" value="Mock Trust Framework"/>
+            <column name="enabled" valueBoolean="false"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -21,4 +21,5 @@
     <include file="changesets/015-validation-result-outdated.xml" relativeToChangelogFile="true" />
     <include file="changesets/016-content-kind.xml" relativeToChangelogFile="true" />
     <include file="changesets/017-trust-framework-role-states.xml" relativeToChangelogFile="true" />
+    <include file="changesets/018-mock-trust-framework-seed.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -20,4 +20,5 @@
     <include file="changesets/014-provenance-credentials.xml" relativeToChangelogFile="true" />
     <include file="changesets/015-validation-result-outdated.xml" relativeToChangelogFile="true" />
     <include file="changesets/016-content-kind.xml" relativeToChangelogFile="true" />
+    <include file="changesets/017-trust-framework-role-states.xml" relativeToChangelogFile="true" />
 </databaseChangeLog>

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TestTrustFrameworkConstants.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TestTrustFrameworkConstants.java
@@ -6,38 +6,53 @@ package eu.xfsc.fc.core.service.trustframework;
  * <p>These identifiers are test-scoped because they encode specific profile IDs, client-type
  * strings, and service URLs that are only relevant to integration tests. Production code resolves
  * these values from classpath bundle YAML; they must not be inlined in production source.
+ *
+ * <p>Visibility is public for all constants to avoid unnecessary adjustments when scope changes.
  */
-class TestTrustFrameworkConstants {
+public class TestTrustFrameworkConstants {
 
   /**
    * Profile ID of the built-in Gaia-X Loire 2511 bundle.
    */
-  static final String PROFILE_GAIA_X_2511 = "gaia-x-2511";
+  public static final String PROFILE_GAIA_X_2511 = "gaia-x-2511";
+
+  /**
+   * Trust framework family names.
+   */
+  public static final String TFW_FAMILY_GAIA_X = "gaia-x";
 
   /**
    * Client-type string identifying the generic REST + JWT-VC compliance client.
    */
-  static final String CLIENT_TYPE_JWT_VC = "jwt-vc-compliance";
+  public static final String CLIENT_TYPE_JWT_VC = "jwt-vc-compliance";
 
   /**
    * Canonical base URL of the live GXDCH Loire compliance service.
    */
-  static final String GXDCH_LOIRE_SERVICE_URL = "https://compliance.gaia-x.eu/v2";
+  public static final String GXDCH_LOIRE_SERVICE_URL = "https://compliance.gaia-x.eu/v2";
 
   /**
    * Compliance endpoint path used by the Gaia-X Loire / GXDCH deployment.
    */
-  static final String GXDCH_LOIRE_COMPLIANCE_PATH = "/api/credential-offers/standard-compliance";
+  public static final String GXDCH_LOIRE_COMPLIANCE_PATH = "/api/credential-offers/standard-compliance";
 
   /**
    * API version string for the GXDCH Loire v2 compliance protocol.
    */
-  static final String API_VERSION_V2 = "v2";
+  public static final String API_VERSION_V2 = "v2";
 
   /**
    * Expected per-request timeout in seconds for the Loire compliance client.
    */
-  static final int TIMEOUT_SECONDS = 30;
+  public static final int TIMEOUT_SECONDS = 30;
+
+  /**
+   * Roles known to be declared in the default gaia-x bundle (from framework.yaml).
+   */
+  public static final String TFW_ROLE_PARTICIPANT = "Participant";
+  public static final String TFW_ROLE_DIGITAL_SERVICE_OFFERING = "DigitalServiceOffering";
+  public static final String TFW_ROLE_SERVICE_OFFERING = "ServiceOffering";
+  public static final String TFW_ROLE_RESOURCE = "Resource";
 
   private TestTrustFrameworkConstants() {
   }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistryTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkRegistryTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,52 +15,52 @@ import org.junit.jupiter.api.Test;
 
 class TrustFrameworkRegistryTest {
 
-  // Minimal ontology: Participant as a root class, no subclasses declared.
+  // Minimal ontology: RoleA as a root class, no subclasses declared.
   private static final String MINIMAL_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
-      gx:Participant a owl:Class .
+      ex:RoleA a owl:Class .
       """;
 
-  // Ontology with declared subclass: LegalPerson rdfs:subClassOf Participant.
+  // Ontology with declared subclass: RoleASub rdfs:subClassOf RoleA.
   private static final String SUBCLASS_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      gx:LegalPerson a owl:Class ; rdfs:subClassOf gx:Participant .
+      ex:RoleA a owl:Class .
+      ex:RoleASub a owl:Class ; rdfs:subClassOf ex:RoleA .
       """;
 
-  // Ontology where DigitalServiceOffering is NOT a subclass of ServiceOffering (gx-2511 reality).
-  private static final String DSO_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+  // Ontology where RoleBAlt is NOT a subclass of RoleB (framework reality in Gaia-x Loire 2511 ontology).
+  private static final String SIBLING_ROLE_ONTOLOGY = """
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
-      gx:ServiceOffering a owl:Class .
-      gx:DigitalServiceOffering a owl:Class .
+      ex:RoleB a owl:Class .
+      ex:RoleBAlt a owl:Class .
       """;
 
-  // Ontology with 2-hop subclass chain: PrivateLegalPerson → LegalPerson → Participant.
+  // Ontology with 2-hop subclass chain: RoleASubSub → RoleASub → RoleA.
   private static final String TWO_HOP_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      gx:LegalPerson a owl:Class ; rdfs:subClassOf gx:Participant .
-      gx:PrivateLegalPerson a owl:Class ; rdfs:subClassOf gx:LegalPerson .
+      ex:RoleA a owl:Class .
+      ex:RoleASub a owl:Class ; rdfs:subClassOf ex:RoleA .
+      ex:RoleASubSub a owl:Class ; rdfs:subClassOf ex:RoleASub .
       """;
 
-  // Ontology that includes an anonymous (blank-node) subclass of Participant.
+  // Ontology that includes an anonymous (blank-node) subclass of RoleA.
   private static final String BLANK_NODE_ONTOLOGY = """
-      @prefix gx: <https://w3id.org/gaia-x/> .
+      @prefix ex: <https://example.org/test/> .
       @prefix owl: <http://www.w3.org/2002/07/owl#> .
       @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-      gx:Participant a owl:Class .
-      [] rdfs:subClassOf gx:Participant .
+      ex:RoleA a owl:Class .
+      [] rdfs:subClassOf ex:RoleA .
       """;
 
   private static TrustFrameworkBundle shaclBundle(String profileId, String namespace,
                                                   Map<String, RoleConfig> roles, String ontologyTtl) {
-    var config = new FrameworkBundleConfig(profileId, "gaia-x", namespace, ValidationType.SHACL, roles, Map.of());
+    var config = new FrameworkBundleConfig(profileId, "test-family", namespace, ValidationType.SHACL, roles, Map.of());
     var ontology = new eu.xfsc.fc.core.pojo.ContentAccessorDirect(ontologyTtl);
     return new TrustFrameworkBundle(config, ontology, null);
   }
@@ -79,79 +80,95 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void resolveRole_rootUri_returnsResolvedRole() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/Participant"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleA"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
   @Test
   void resolveRole_subclassOfRoot_returnsResolvedRole() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, SUBCLASS_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SUBCLASS_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    // gx:LegalPerson rdfs:subClassOf gx:Participant — must resolve to Participant
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/LegalPerson"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    // ex:RoleASub rdfs:subClassOf ex:RoleA — must resolve to RoleA
+    assertThat(registry.resolveRole("https://example.org/test/RoleASub"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
-  // additionalRoots: DigitalServiceOffering is NOT a subclass of ServiceOffering in OWL
-  // but is covered via additionalRoots in RoleConfig (gx-2511 workaround)
+  // additionalRoots: RoleBAlt is NOT a subclass of RoleB in OWL
+  // but is covered via additionalRoots in RoleConfig (framework workaround)
   @Test
   void resolveRole_additionalRoot_returnsResolvedRole() {
-    var roles = Map.of("ServiceOffering", new RoleConfig(
-        List.of("https://w3id.org/gaia-x/DigitalServiceOffering"), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, DSO_ONTOLOGY);
+    var roles = Map.of("RoleB", new RoleConfig(
+        List.of("https://example.org/test/RoleBAlt"), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SIBLING_ROLE_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/DigitalServiceOffering"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "ServiceOffering"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleBAlt"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleB"));
   }
 
   @Test
   void resolveRole_2hopSubclassOfRoot_returnsResolvedRole() {
-    // gx:PrivateLegalPerson rdfs:subClassOf gx:LegalPerson rdfs:subClassOf gx:Participant
+    // ex:RoleASubSub rdfs:subClassOf ex:RoleASub rdfs:subClassOf ex:RoleA
     // OWL_MEM_MICRO_RULE_INF infers the transitive closure — both hops must be covered
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, TWO_HOP_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, TWO_HOP_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/PrivateLegalPerson"))
-        .isEqualTo(new ResolvedRole("gaia-x-2511", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleASubSub"))
+        .isEqualTo(new ResolvedRole("test-framework", "RoleA"));
   }
 
   @Test
   void resolveRole_firstBundleWinsOnRootUriConflict() {
     // Same root URI claimed by two bundles — first registration must win (putIfAbsent semantics)
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle1 = shaclBundle("framework-a", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
-    var bundle2 = shaclBundle("framework-b", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle1 = shaclBundle("framework-a", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
+    var bundle2 = shaclBundle("framework-b", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle1, bundle2));
 
-    assertThat(registry.resolveRole("https://w3id.org/gaia-x/Participant"))
-        .isEqualTo(new ResolvedRole("framework-a", "Participant"));
+    assertThat(registry.resolveRole("https://example.org/test/RoleA"))
+        .isEqualTo(new ResolvedRole("framework-a", "RoleA"));
   }
 
   // bundle index methods
   @Test
   void getActiveBundles_returnsAllLoadedBundles() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
     assertThat(registry.getActiveBundles()).containsExactly(bundle);
   }
 
   @Test
+  void getAllBundles_preservesRegistrationOrder() {
+    // Three bundles with profile IDs intentionally not in lexicographic order, so a HashMap-backed
+    // index would shuffle them. Iteration must follow input list order.
+    var bundleZ = shaclBundle("z-framework", "https://example.org/z/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+    var bundleA = shaclBundle("a-framework", "https://example.org/a/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+    var bundleM = shaclBundle("m-framework", "https://example.org/m/",
+        Map.of("RoleA", new RoleConfig(List.of(), List.of())), MINIMAL_ONTOLOGY);
+
+    var registry = new TrustFrameworkRegistry(List.of(bundleZ, bundleA, bundleM));
+
+    assertThat(registry.getAllBundles()).containsExactly(bundleZ, bundleA, bundleM);
+  }
+
+  @Test
   void getActiveBundles_returnsImmutableSnapshot() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
     assertThatThrownBy(() -> registry.getActiveBundles().clear())
@@ -160,10 +177,10 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void getBundle_knownProfileId_returnsBundle() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.getBundle("gaia-x-2511")).contains(bundle);
+    assertThat(registry.getBundle("test-framework")).contains(bundle);
   }
 
   @Test
@@ -175,10 +192,10 @@ class TrustFrameworkRegistryTest {
 
   @Test
   void isFrameworkEnabled_knownBundle_returnsTrue() {
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.isFrameworkEnabled("gaia-x-2511")).isTrue();
+    assertThat(registry.isFrameworkEnabled("test-framework")).isTrue();
   }
 
   @Test
@@ -191,13 +208,13 @@ class TrustFrameworkRegistryTest {
   @Test
   void getEffectiveRoles_knownBundle_returnsRoleNames() {
     var roles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+        "RoleA", new RoleConfig(List.of(), List.of()),
+        "RoleB", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThat(registry.getEffectiveRoles("gaia-x-2511"))
-        .containsExactlyInAnyOrder("Participant", "ServiceOffering");
+    assertThat(registry.getEffectiveRoles("test-framework"))
+        .containsExactlyInAnyOrder("RoleA", "RoleB");
   }
 
   @Test
@@ -208,12 +225,34 @@ class TrustFrameworkRegistryTest {
   }
 
   @Test
-  void getEffectiveRoles_returnsImmutableSnapshot() {
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, MINIMAL_ONTOLOGY);
+  void getEffectiveRoles_preservesDeclarationOrder() {
+    // LinkedHashMap fixes the input declaration order; Map.of() would scramble it.
+    // Generic role names — the registry must not assume any framework-specific vocabulary.
+    var roles = new LinkedHashMap<String, RoleConfig>();
+    roles.put("RoleC", new RoleConfig(List.of(), List.of()));
+    roles.put("RoleA", new RoleConfig(List.of(), List.of()));
+    roles.put("RoleB", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles,
+        """
+            @prefix ex: <https://example.org/test/> .
+            @prefix owl: <http://www.w3.org/2002/07/owl#> .
+            ex:RoleA a owl:Class .
+            ex:RoleB a owl:Class .
+            ex:RoleC a owl:Class .
+            """);
     var registry = new TrustFrameworkRegistry(List.of(bundle));
 
-    assertThatThrownBy(() -> registry.getEffectiveRoles("gaia-x-2511").add("fake"))
+    assertThat(registry.getEffectiveRoles("test-framework"))
+        .containsExactly("RoleC", "RoleA", "RoleB");
+  }
+
+  @Test
+  void getEffectiveRoles_returnsImmutableSnapshot() {
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, MINIMAL_ONTOLOGY);
+    var registry = new TrustFrameworkRegistry(List.of(bundle));
+
+    assertThatThrownBy(() -> registry.getEffectiveRoles("test-framework").add("fake"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 
@@ -249,12 +288,12 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_duplicateBundleId_keepsFirstBundle() {
     // Two bundles with the same ID — first registration wins; second is ignored
-    var bundle1 = shaclBundle("gaia-x-2511", "https://namespace-a.org/", Map.of(), MINIMAL_ONTOLOGY);
-    var bundle2 = shaclBundle("gaia-x-2511", "https://namespace-b.org/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle1 = shaclBundle("test-framework", "https://namespace-a.org/", Map.of(), MINIMAL_ONTOLOGY);
+    var bundle2 = shaclBundle("test-framework", "https://namespace-b.org/", Map.of(), MINIMAL_ONTOLOGY);
 
     var registry = new TrustFrameworkRegistry(List.of(bundle1, bundle2));
 
-    assertThat(registry.getBundle("gaia-x-2511").get().config().namespace())
+    assertThat(registry.getBundle("test-framework").get().config().namespace())
         .isEqualTo("https://namespace-a.org/");
   }
 
@@ -262,10 +301,10 @@ class TrustFrameworkRegistryTest {
   void constructor_nullAdditionalRoot_doesNotThrow() {
     // A null entry in additionalRoots (e.g. from malformed YAML) must be skipped, not NPE
     var rolesWithNull = new HashMap<String, RoleConfig>();
-    rolesWithNull.put("Participant", new RoleConfig(
-        new ArrayList<>(Arrays.asList(null, "https://w3id.org/gaia-x/Participant")),
+    rolesWithNull.put("RoleA", new RoleConfig(
+        new ArrayList<>(Arrays.asList(null, "https://example.org/test/RoleA")),
         List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", rolesWithNull, MINIMAL_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", rolesWithNull, MINIMAL_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -274,8 +313,8 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_blankNodeSubclass_doesNotThrow() {
     // An anonymous (blank-node) subclass in the ontology must be skipped, not NPE
-    var roles = Map.of("Participant", new RoleConfig(List.of(), List.of()));
-    var bundle = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", roles, BLANK_NODE_ONTOLOGY);
+    var roles = Map.of("RoleA", new RoleConfig(List.of(), List.of()));
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, BLANK_NODE_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -308,9 +347,9 @@ class TrustFrameworkRegistryTest {
   @Test
   void constructor_uriWithInjectionCharacter_doesNotThrow() {
     // A URI containing '>' in additionalRoots must not break SPARQL query construction
-    var roles = Map.of("ServiceOffering", new RoleConfig(
+    var roles = Map.of("RoleB", new RoleConfig(
         List.of("https://example.org/bad>uri"), List.of()));
-    var bundle = shaclBundle("test", "https://example.org/", roles, DSO_ONTOLOGY);
+    var bundle = shaclBundle("test-framework", "https://example.org/test/", roles, SIBLING_ROLE_ONTOLOGY);
 
     assertThatCode(() -> new TrustFrameworkRegistry(List.of(bundle)))
         .doesNotThrowAnyException();
@@ -319,7 +358,7 @@ class TrustFrameworkRegistryTest {
   @Test
   void getActiveBundles_excludesDeferredBundles() {
     // SHACL bundle is active; JSON_SCHEMA bundle is deferred — getActiveBundles() must exclude deferred
-    var active = shaclBundle("gaia-x-2511", "https://w3id.org/gaia-x/", Map.of(), MINIMAL_ONTOLOGY);
+    var active = shaclBundle("test-framework", "https://example.org/test/", Map.of(), MINIMAL_ONTOLOGY);
     var deferred = jsonSchemaBundle("untp-v1");
     var registry = new TrustFrameworkRegistry(List.of(active, deferred));
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkServiceRoleStateTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkServiceRoleStateTest.java
@@ -1,0 +1,253 @@
+package eu.xfsc.fc.core.service.trustframework;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import eu.xfsc.fc.core.config.DatabaseConfig;
+import eu.xfsc.fc.core.config.TrustFrameworkRegistryConfig;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkRoleStateRepository;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import eu.xfsc.fc.core.security.SecurityAuditorAware;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
+
+/**
+ * Integration tests for per-role enabled state.
+ *
+ * <p>Tests verify behavior through the public service interface only. The embedded Zonky
+ * Postgres database runs the full Liquibase migration, so persisted state survives across
+ * method calls within a test and is cleaned up in {@link #cleanUp()}.
+ *
+ * <p>{@code frameworkId} values here are registry profile IDs (e.g. {@code gaia-x-2511}),
+ * NOT family IDs — role state is keyed by the bundle's profile ID because roles are
+ * declared per bundle, and validation is performed against the registry.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest
+@ActiveProfiles("test")
+@ContextConfiguration(classes = {
+    TrustFrameworkServiceRoleStateTest.TestConfig.class,
+    DatabaseConfig.class,
+    SecurityAuditorAware.class,
+    TrustFrameworkRegistryConfig.class,
+    TrustFrameworkService.class,
+})
+@AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
+class TrustFrameworkServiceRoleStateTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class TestConfig {
+  }
+
+  /**
+   * Registry profile ID of the built-in Gaia-X 2511 bundle.
+   * Roles in this bundle: Participant, ServiceOffering, Resource.
+   */
+  private static final String BUNDLE_GAIA_X_2511 = "gaia-x-2511";
+
+  /** Unknown bundle — not present in the registry. */
+  private static final String UNKNOWN_BUNDLE = "no-such-bundle";
+
+  @Autowired
+  private TrustFrameworkService service;
+
+  @Autowired
+  private TrustFrameworkRoleStateRepository roleStateRepo;
+
+  /** Family ID as stored in the {@code trust_frameworks} table (the DB row key). */
+  private static final String FAMILY_GAIA_X = "gaia-x";
+
+  @AfterEach
+  void cleanUp() {
+    roleStateRepo.deleteAll();
+    // Restore the family to the Liquibase-seeded default (disabled) so tests are order-independent.
+    service.setEnabled(FAMILY_GAIA_X, false);
+  }
+
+  @Test
+  void isRoleEnabled_noRowPersisted_returnsTrue() {
+    // Family must be enabled, otherwise bundle-off dominance short-circuits to true
+    // and the role-state lookup path is never exercised.
+    service.setEnabled(FAMILY_GAIA_X, true);
+
+    // No explicit state row → absence means enabled by default
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void isRoleEnabled_afterSetFalse_returnsFalse() {
+    // Role-toggle is only effective when the bundle family is enabled.
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isFalse();
+  }
+
+  @Test
+  void isRoleEnabled_afterSetTrue_returnsTrue() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, true);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_oneRole_doesNotAffectOtherRole() {
+    // Family must be enabled, otherwise bundle-off dominance short-circuits to true
+    // and the role-state lookup path is never exercised.
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    // ServiceOffering was not touched — must still read as default true
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_calledTwice_upserts() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, true);
+
+    // Exactly one row (upsert, not two inserts)
+    assertThat(roleStateRepo.findByFrameworkId(BUNDLE_GAIA_X_2511)).hasSize(1);
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  @Test
+  void setRoleEnabled_unknownBundle_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.setRoleEnabled(UNKNOWN_BUNDLE, TFW_ROLE_PARTICIPANT, false))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void setRoleEnabled_unknownRole_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.setRoleEnabled(BUNDLE_GAIA_X_2511, "NoSuchRole", false))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void getRoleStates_noExplicitState_allRolesReturnedAsTrue() {
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    // All roles from the registry bundle must appear, all defaulting to true
+    assertThat(states).isNotEmpty();
+    assertThat(states).containsKeys(TFW_ROLE_PARTICIPANT, TFW_ROLE_SERVICE_OFFERING);
+    assertThat(states).allSatisfy((role, enabled) -> assertThat(enabled).isTrue());
+  }
+
+  @Test
+  void getRoleStates_withOneRoleDisabled_reflectsOverride() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    assertThat(states).containsEntry(TFW_ROLE_PARTICIPANT, false);
+    assertThat(states).containsEntry(TFW_ROLE_SERVICE_OFFERING, true);
+  }
+
+  @Test
+  void getRoleStates_preservesYamlDeclarationOrder() {
+    // gaia-x-2511 framework.yaml declares roles in the order:
+    //   Participant, ServiceOffering, Resource
+    // The returned LinkedHashMap must iterate in that exact order so the UI can render
+    // role-toggle rows deterministically.
+    Map<String, Boolean> states = service.getRoleStates(BUNDLE_GAIA_X_2511);
+
+    assertThat(states).containsExactly(
+        Map.entry(TFW_ROLE_PARTICIPANT, true),
+        Map.entry(TFW_ROLE_SERVICE_OFFERING, true),
+        Map.entry(TFW_ROLE_RESOURCE, true));
+  }
+
+  @Test
+  void getRoleStates_unknownBundle_throwsNotFoundException() {
+    assertThatThrownBy(() -> service.getRoleStates(UNKNOWN_BUNDLE))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void setRoleEnabled_persistsAcrossRepositoryRead() {
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT, false);
+
+    // Verify the row via repository (one row, correct field values)
+    var rows = roleStateRepo.findByFrameworkId(BUNDLE_GAIA_X_2511);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.getFirst().getFrameworkId()).isEqualTo(BUNDLE_GAIA_X_2511);
+    assertThat(rows.get(0).getRoleName()).isEqualTo(TFW_ROLE_PARTICIPANT);
+    assertThat(rows.get(0).isEnabled()).isFalse();
+  }
+
+  /**
+   * When the family bundle is disabled AND the role is explicitly disabled,
+   * {@code isRoleEnabled} must return {@code true}: the role-toggle layer is bypassed
+   * because bundle-off already blocks all resolution through that bundle.
+   * The caller (ClaimValidator) will receive a bundle-disabled rejection separately;
+   * the role-toggle must not add a second rejection on top.
+   */
+  @Test
+  void isRoleEnabled_bundleDisabled_roleExplicitlyDisabled_returnsTrueBypassingRoleCheck() {
+    // DB seed has gaia-x enabled=false (Liquibase default) — no need to call setEnabled here
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING, false);
+
+    // Bundle-off dominates: role-toggle check is bypassed → returns true
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isTrue();
+  }
+
+  /**
+   * When the family bundle is disabled and no role row exists (default-true),
+   * {@code isRoleEnabled} must still return {@code true} (bundle-off dominates).
+   */
+  @Test
+  void isRoleEnabled_bundleDisabled_noRoleRow_returnsTrueBypassingRoleCheck() {
+    // DB seed has gaia-x enabled=false — bundle is off, no role row set
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  /**
+   * When the family bundle is enabled and the role is explicitly disabled,
+   * {@code isRoleEnabled} must return {@code false} — normal role-toggle behavior.
+   */
+  @Test
+  void isRoleEnabled_bundleEnabled_roleDisabled_returnsFalse() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+    service.setRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING, false);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_SERVICE_OFFERING)).isFalse();
+  }
+
+  /**
+   * When the family bundle is enabled and no role row exists,
+   * {@code isRoleEnabled} must return {@code true} — default-true semantics apply.
+   */
+  @Test
+  void isRoleEnabled_bundleEnabled_noRoleRow_returnsTrue() {
+    service.setEnabled(FAMILY_GAIA_X, true);
+
+    assertThat(service.isRoleEnabled(BUNDLE_GAIA_X_2511, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+
+  /**
+   * For a framework ID that is not known to the registry,
+   * {@code isRoleEnabled} must return {@code true} — preserve existing caller semantics.
+   */
+  @Test
+  void isRoleEnabled_unknownFrameworkId_returnsTrue() {
+    assertThat(service.isRoleEnabled(UNKNOWN_BUNDLE, TFW_ROLE_PARTICIPANT)).isTrue();
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireTypeResolutionTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/LoireTypeResolutionTest.java
@@ -8,6 +8,13 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiPredicate;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_DIGITAL_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_FAMILY_GAIA_X;
 
 import org.apache.jena.riot.system.stream.StreamManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +41,10 @@ import eu.xfsc.fc.core.util.ClaimValidator;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LoireTypeResolutionTest {
 
+  /** All roles enabled — passed to {@link eu.xfsc.fc.core.util.ClaimValidator#resolveSubjectRole}
+   *  so existing tests are unaffected by the new mandatory predicate parameter. */
+  private static final BiPredicate<String, String> ALL_ENABLED = (b, r) -> true;
+
   private static final String PROFILE_ID = "gaia-x-2511";
   private static final String NAMESPACE = "https://w3id.org/gaia-x/2511#";
 
@@ -55,30 +66,28 @@ class LoireTypeResolutionTest {
 
     // 2511 roles — mirrors the production gaia-x-2511 bundle
     Map<String, RoleConfig> loireRoles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(
-            List.of(NAMESPACE + "DigitalServiceOffering"), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig loireConfig = new FrameworkBundleConfig(
-        PROFILE_ID, "gaia-x", NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
     loireRegistry = new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(loireConfig, gx2511Ontology, null)));
 
     // Legacy gax-core roles — intentionally different namespace
     Map<String, RoleConfig> legacyRoles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(List.of(), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig legacyConfig = new FrameworkBundleConfig(
-        "gaia-x-legacy", "gaia-x", "https://w3id.org/gaia-x/core#",
+        "gaia-x-legacy", TFW_FAMILY_GAIA_X, "https://w3id.org/gaia-x/core#",
         ValidationType.SHACL, legacyRoles, Map.of());
     legacyRegistry = new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(legacyConfig, gx2511Ontology, null)));
   }
-
-  // ==================== 2511 type resolution (Loire path) ====================
 
   @Test
   @DisplayName("gx:LegalPerson resolves to Participant via 2511 ontology")
@@ -86,9 +95,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#LegalPerson");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Participant"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
         "gx:LegalPerson → gx:Participant → gx:GaiaXEntity; should resolve to Participant");
   }
 
@@ -98,9 +107,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#DigitalServiceOffering");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "ServiceOffering"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
         "gx:DigitalServiceOffering is a sibling of gx:ServiceOffering; resolves via additionalRoots");
   }
 
@@ -110,9 +119,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#DataProduct");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "ServiceOffering"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
         "gx:DataProduct rdfs:subClassOf gx:DigitalServiceOffering; traversal from DSO root reaches DataProduct");
   }
 
@@ -122,9 +131,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#VirtualResource");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Resource"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_RESOURCE), result,
         "gx:VirtualResource rdfs:subClassOf gx:Resource; should resolve to Resource");
   }
 
@@ -134,12 +143,10 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/SomeOtherType");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, loireRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(), "Type not in the 2511 hierarchy should return UNKNOWN");
   }
-
-  // ==================== Namespace isolation ====================
 
   @Test
   @DisplayName("2511 type returns UNKNOWN when legacy (gax-core) registry is used — hierarchies disconnected")
@@ -147,14 +154,12 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://w3id.org/gaia-x/2511#LegalPerson");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, legacyRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, legacyRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(),
         "gx:2511#LegalPerson is not a subclass of gax-core:Participant; "
             + "disconnected hierarchies must not cross-resolve");
   }
-
-  // ==================== Composite ontology slow path ====================
 
   private static final String COMPOSITE_ONTOLOGY_TTL = """
       @prefix gx: <https://w3id.org/gaia-x/2511#> .
@@ -172,9 +177,9 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/CustomParticipant");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, compositeOntology);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, compositeOntology, ALL_ENABLED);
 
-    assertEquals(new ResolvedRole(PROFILE_ID, "Participant"), result,
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
         "Custom subclass absent from boot index should resolve via composite ontology");
   }
 
@@ -185,23 +190,22 @@ class LoireTypeResolutionTest {
     String credential = buildCredential("https://example.com/CustomParticipant");
 
     ResolvedRole result =
-        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, null);
+        ClaimValidator.resolveSubjectRole(streamManager, credential, rootsOnlyRegistry, null, ALL_ENABLED);
 
     assertFalse(result.isResolved(),
         "Custom subclass absent from boot index with no ontology fallback should return UNKNOWN");
   }
 
-  // ==================== Helpers ====================
 
   private TrustFrameworkRegistry buildRootsOnlyRegistry() {
     Map<String, RoleConfig> roles = Map.of(
-        "Participant", new RoleConfig(List.of(), List.of()),
-        "ServiceOffering", new RoleConfig(
-            List.of(NAMESPACE + "DigitalServiceOffering"), List.of()),
-        "Resource", new RoleConfig(List.of(), List.of())
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
     );
     FrameworkBundleConfig config = new FrameworkBundleConfig(
-        PROFILE_ID, "gaia-x", NAMESPACE, ValidationType.SHACL, roles, Map.of());
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, roles, Map.of());
     return new TrustFrameworkRegistry(
         List.of(new TrustFrameworkBundle(config, null, null)));
   }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RoleToggleResolutionTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/RoleToggleResolutionTest.java
@@ -1,0 +1,194 @@
+package eu.xfsc.fc.core.service.verification;
+
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_FAMILY_GAIA_X;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_DIGITAL_SERVICE_OFFERING;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_PARTICIPANT;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_RESOURCE;
+import static eu.xfsc.fc.core.service.trustframework.TestTrustFrameworkConstants.TFW_ROLE_SERVICE_OFFERING;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import org.apache.jena.riot.system.stream.StreamManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
+import eu.xfsc.fc.core.service.trustframework.FrameworkBundleConfig;
+import eu.xfsc.fc.core.service.trustframework.ResolvedRole;
+import eu.xfsc.fc.core.service.trustframework.RoleConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.ValidationType;
+import eu.xfsc.fc.core.util.ClaimValidator;
+
+/**
+ * Tests for role-toggle enforcement in {@link ClaimValidator#resolveSubjectRole}.
+ *
+ * <p>Verifies that a disabled role (predicate returns false) causes a {@link ClientException}
+ * on both direct registry hits and ontology-subclass-walk hits, while enabled roles resolve
+ * normally (including the default-true predicate used for backward compatibility).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RoleToggleResolutionTest {
+
+  private static final String PROFILE_ID = "gaia-x-2511";
+  private static final String NAMESPACE   = "https://w3id.org/gaia-x/2511#";
+
+  /** Predicate that disables every role — used for disabled-role tests. */
+  private static final BiPredicate<String, String> ALL_DISABLED = (bundleId, roleName) -> false;
+
+  /** Predicate that enables every role — backward-compat baseline. */
+  private static final BiPredicate<String, String> ALL_ENABLED  = (bundleId, roleName) -> true;
+
+  /** Predicate that disables only "Participant". */
+  private static final BiPredicate<String, String> PARTICIPANT_DISABLED =
+      (bundleId, roleName) -> !(TFW_ROLE_PARTICIPANT.equals(roleName));
+
+  private TrustFrameworkRegistry loireRegistry;
+  private TrustFrameworkRegistry rootsOnlyRegistry;
+  private ContentAccessorDirect  compositeOntology;
+  private StreamManager          streamManager;
+
+  @BeforeAll
+  void setUp() throws IOException {
+    String ttlPath = "Schema-Tests/gx-2511-test-ontology.ttl";
+    ContentAccessorDirect gx2511Ontology;
+    try (InputStream is = getClass().getClassLoader().getResourceAsStream(ttlPath)) {
+      if (is == null) {
+        throw new IllegalStateException("Test resource not found: " + ttlPath);
+      }
+      gx2511Ontology = new ContentAccessorDirect(
+          new String(is.readAllBytes(), StandardCharsets.UTF_8));
+    }
+    streamManager = StreamManager.get().clone();
+
+    Map<String, RoleConfig> loireRoles = Map.of(
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
+    );
+    FrameworkBundleConfig loireConfig = new FrameworkBundleConfig(
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, loireRoles, Map.of());
+    loireRegistry = new TrustFrameworkRegistry(
+        List.of(new TrustFrameworkBundle(loireConfig, gx2511Ontology, null)));
+
+    // roots-only (no boot-time ontology) — forces composite-ontology slow path
+    Map<String, RoleConfig> rootsOnlyRoles = Map.of(
+        TFW_ROLE_PARTICIPANT, new RoleConfig(List.of(), List.of()),
+        TFW_ROLE_SERVICE_OFFERING, new RoleConfig(
+            List.of(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING), List.of()),
+        TFW_ROLE_RESOURCE, new RoleConfig(List.of(), List.of())
+    );
+    FrameworkBundleConfig rootsOnlyConfig = new FrameworkBundleConfig(
+        PROFILE_ID, TFW_FAMILY_GAIA_X, NAMESPACE, ValidationType.SHACL, rootsOnlyRoles, Map.of());
+    rootsOnlyRegistry = new TrustFrameworkRegistry(
+        List.of(new TrustFrameworkBundle(rootsOnlyConfig, null, null)));
+
+    compositeOntology = new ContentAccessorDirect("""
+        @prefix gx: <%s> .
+        @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix ex: <https://example.com/> .
+
+        ex:CustomParticipant rdfs:subClassOf gx:Participant .
+        """.formatted(NAMESPACE));
+  }
+
+  @Test
+  @DisplayName("Direct match on disabled role throws ClientException")
+  void resolveSubjectRole_directMatch_disabledRole_throwsClientException() {
+    String credential = buildCredential(NAMESPACE + "LegalPerson");
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, loireRegistry, null, ALL_DISABLED),
+        "A disabled role direct match must throw ClientException (HTTP 400)");
+  }
+
+  @Test
+  @DisplayName("additionalRoots match on disabled role throws ClientException")
+  void resolveSubjectRole_additionalRootsMatch_disabledRole_throwsClientException() {
+    // gx:DigitalServiceOffering is indexed via additionalRoots, not namespace+roleName
+    String credential = buildCredential(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING);
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, loireRegistry, null, ALL_DISABLED),
+        "A disabled role matched via additionalRoots must throw ClientException");
+  }
+
+  @Test
+  @DisplayName("Ontology subclass walk on disabled role throws ClientException")
+  void resolveSubjectRole_ontologyWalk_disabledRole_throwsClientException() {
+    // ex:CustomParticipant is not in the boot index; only resolvable via composite ontology
+    String credential = buildCredential("https://example.com/CustomParticipant");
+
+    assertThrows(ClientException.class, () ->
+        ClaimValidator.resolveSubjectRole(
+            streamManager, credential, rootsOnlyRegistry, compositeOntology, ALL_DISABLED),
+        "A disabled role matched via ontology subclass walk must throw ClientException");
+  }
+
+  @Test
+  @DisplayName("Enabled role in same bundle resolves normally when another role is disabled")
+  void resolveSubjectRole_enabledRole_whileOtherRoleDisabled_resolvesNormally() {
+    // PARTICIPANT_DISABLED disables only TFW_ROLE_PARTICIPANT; TFW_ROLE_SERVICE_OFFERING remains enabled
+    String credential = buildCredential(NAMESPACE + TFW_ROLE_DIGITAL_SERVICE_OFFERING);
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, PARTICIPANT_DISABLED);
+
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_SERVICE_OFFERING), result,
+        "ServiceOffering must resolve normally even when Participant is disabled");
+  }
+
+  @Test
+  @DisplayName("Default-true predicate (all-enabled) resolves Participant normally")
+  void resolveSubjectRole_allEnabled_resolvesPrimaryRoleNormally() {
+    String credential = buildCredential(NAMESPACE + "LegalPerson");
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, ALL_ENABLED);
+
+    assertEquals(new ResolvedRole(PROFILE_ID, TFW_ROLE_PARTICIPANT), result,
+        "With all roles enabled the predicate must not interfere with normal resolution");
+  }
+
+  @Test
+  @DisplayName("Unknown type returns UNKNOWN regardless of predicate")
+  void resolveSubjectRole_unknownType_returnsUnknown() {
+    String credential = buildCredential("https://example.com/SomeOtherType");
+
+    ResolvedRole result = ClaimValidator.resolveSubjectRole(
+        streamManager, credential, loireRegistry, null, ALL_ENABLED);
+
+    assertFalse(result.isResolved(),
+        "Type not in any registered bundle should still return UNKNOWN");
+  }
+
+  private static String buildCredential(String subjectTypeUri) {
+    return """
+        {
+          "@context": {
+            "cred": "https://www.w3.org/2018/credentials#",
+            "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"}
+          },
+          "credentialSubject": {
+            "@type": ["%s"],
+            "@id": "did:web:subject.example.com"
+          }
+        }
+        """.formatted(subjectTypeUri);
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/VerificationServiceTest.java
@@ -370,7 +370,7 @@ public class VerificationServiceTest {
 
       jdbcTemplate.update("UPDATE trust_frameworks SET enabled = false WHERE id = 'gaia-x'");
 
-      // AC-3: ext:CustomParticipant is not in any active bundle (gaia-x disabled, no ontology loaded)
+      // ext:CustomParticipant is not in any active bundle (gaia-x disabled, no ontology loaded)
       // → resolveSubjectRole returns UNKNOWN → ClientException.
       ContentAccessor customExtContent = getAccessor("VerificationService/syntax/customExtParticipant.jsonld");
       assertThrowsExactly(ClientException.class,
@@ -405,7 +405,7 @@ public class VerificationServiceTest {
 
   @Test
   void validComplexCredentialPartType() {
-    // AC-3: VCs whose outer "type" array has only "VerifiableCredential" (no domain type) are rejected.
+    // VCs whose outer "type" array has only "VerifiableCredential" (no domain type) are rejected.
     // complexCredentialPartType.jsonld's VCs all have type=["VerifiableCredential"], so role=null → 400.
     schemaStore.initializeDefaultSchemas();
     String path = "VerificationService/syntax/complexCredentialPartType.jsonld";
@@ -685,7 +685,7 @@ public class VerificationServiceTest {
 
   @Test
   void extractClaims_allFcmetaClaimsFiltered_returnsEmptyList() {
-    // AC-3: credentialSubject has no @type → UNKNOWN → ClientException.
+    // credentialSubject has no @type → UNKNOWN → ClientException.
     // The fcmeta-only fixture's credentialSubject carries only protected-namespace predicates and no type,
     // so role resolution fails before claims are returned.
     ContentAccessor content = getAccessor("Claims-Extraction-Tests/participantCredential-only-fcmeta.jsonld");
@@ -696,7 +696,7 @@ public class VerificationServiceTest {
   // --- T5: JWT signature verification smoke tests ---
 
   /**
-   * AC 1 / AC 3 (guard removed): JWT credential with verifyVCSignatures=true no longer throws
+   * JWT credential with verifyVCSignatures=true no longer throws
    * UnsupportedOperationException; JwtSignatureVerifier is invoked and returns a Validator.
    */
   @Test
@@ -717,7 +717,7 @@ public class VerificationServiceTest {
   }
 
   /**
-   * AC 9: LD credential with verifyVCSignatures=true is rejected — LD proof verification
+   * LD credential with verifyVCSignatures=true is rejected - LD proof verification
    * was removed. JwtSignatureVerifier is NOT invoked.
    */
   @Test
@@ -731,10 +731,6 @@ public class VerificationServiceTest {
     verify(jwtVerifierMock, never()).verify(any());
   }
 
-  /**
-   * AC 7 (VP JWT iss ≠ holder): VP JWT where iss does not match holder must throw
-   * VerificationException when verifySemantics=true.
-   */
   @Test
   void verifyCredential_vpJwtIssNotEqualHolder_throwsVerificationException() {
     ContentAccessor vpJwt = new ContentAccessorDirect(
@@ -752,10 +748,6 @@ public class VerificationServiceTest {
     assertTrue(ex.getMessage().contains("holder"), "Error must mention holder: " + ex.getMessage());
   }
 
-  /**
-   * AC 2 (VP JWT happy path): VP JWT with iss == holder and verifyVPSignatures=true succeeds
-   * and result contains validators.
-   */
   @Test
   void verifyCredential_vpJwtIssEqualsHolder_returnsValidators() {
     ContentAccessor vpJwt = new ContentAccessorDirect(
@@ -763,7 +755,7 @@ public class VerificationServiceTest {
 
     Validator testValidator = new Validator("did:test:key-1", "{\"kty\":\"EC\"}", null);
     when(jwtVerifierMock.verify(any())).thenReturn(testValidator);
-    // input.vp.jsonld causes PROTECTED_TERM_REDEFINITION during role resolution (AC-3 would reject it).
+    // input.vp.jsonld causes PROTECTED_TERM_REDEFINITION during role resolution
     // Use legalParticipant.jsonld instead — a proper Gaia-X VP whose type resolves to Participant.
     ContentAccessor vpJsonLd = getAccessor("VerificationService/syntax/legalParticipant.jsonld");
     doReturn(vpJsonLd).when(jwtPreprocessorSpy).unwrap(any());
@@ -777,9 +769,6 @@ public class VerificationServiceTest {
     assertFalse(result.getValidators().isEmpty());
   }
 
-  /**
-   * AC 3 (skip path): JWT credential with both signature flags=false must not invoke JwtSignatureVerifier.
-   */
   @Test
   void verifyCredential_jwtWithBothSigFlagsFalse_jwtVerifierNotInvoked() {
     String vcJson = getAccessor("Claims-Tests/participantVC2.jsonld").getContentAsString();
@@ -974,7 +963,7 @@ public class VerificationServiceTest {
   // --- VC 2.0 non-Gaia-X RDF asset tests ---
 
   /**
-   * AC-3: VC 2.0 credential without any recognised trust-framework type must be rejected
+   * VC 2.0 credential without any recognised trust-framework type must be rejected
    * regardless of whether the Gaia-X bundle is enabled or not. Type resolution returns
    * UNKNOWN → 400 ClientException.
    */
@@ -1011,7 +1000,7 @@ public class VerificationServiceTest {
   void verifyCredential_evcWrapper_innerVcJwtUnwrappedAndProcessed() {
     // EVC per ICAM 24.07: outer JSON-LD wrapper with data: URI carrying a Loire VC JWT.
     // The wrapper is stripped; inner JWT routes through Loire path. fakeLoireJwt has no domain type
-    // → AC-3 throws ClientException after unwrap. The spy call still happens before the exception.
+    // → throws ClientException after unwrap. The spy call still happens before the exception.
     String innerJwt = TestUtil.fakeLoireJwt("did:example:issuer");
     String evcBody = "{\"@context\":\"https://www.w3.org/ns/credentials/v2\","
         + "\"type\":\"EnvelopedVerifiableCredential\","
@@ -1027,7 +1016,7 @@ public class VerificationServiceTest {
   void verifyCredential_evpWrapper_innerVpJwtUnwrappedAndProcessed() {
     // EVP per ICAM 24.07: outer JSON-LD wrapper with data: URI carrying a Loire VP JWT.
     // The wrapper is stripped; inner JWT routes through Loire path. fakeLoireVpJwt has no domain type
-    // → AC-3 throws ClientException after unwrap. The spy call still happens before the exception.
+    // → throws ClientException after unwrap. The spy call still happens before the exception.
     String innerJwt = fakeLoireVpJwt("did:example:issuer");
     String evpBody = "{\"@context\":\"https://www.w3.org/ns/credentials/v2\","
         + "\"type\":\"EnvelopedVerifiablePresentation\","

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/signature/JwtSignatureVerifierTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/signature/JwtSignatureVerifierTest.java
@@ -155,7 +155,6 @@ class JwtSignatureVerifierTest {
     VerificationException ex = assertThrows(VerificationException.class,
         () -> verifier.verify(compact));
 
-    // AC 10: error message contains attempted kid and available method IDs
     assertTrue(ex.getMessage().contains(KID), "message should contain attempted kid: " + ex.getMessage());
     assertTrue(ex.getMessage().contains(KID_B), "message should list available ids: " + ex.getMessage());
   }

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -132,6 +132,7 @@ public class SecurityConfig {
 
           // Trust Framework Admin APIs
           .requestMatchers(HttpMethod.GET, "/admin/trust-frameworks").hasRole(ADMIN_ALL)
+          .requestMatchers(HttpMethod.PATCH, "/admin/trust-frameworks/**").hasRole(ADMIN_ALL)
           .requestMatchers(HttpMethod.PUT, "/admin/trust-frameworks/**").hasRole(ADMIN_ALL)
 
           // Schema Validation Admin APIs
@@ -140,7 +141,7 @@ public class SecurityConfig {
           // ever be broader, add a more specific matcher ABOVE this line — anyRequest()
           // .authenticated() further down does NOT enforce roles, only login status.
           .requestMatchers(HttpMethod.GET, "/admin/schema-validation", "/admin/schema-validation/**").hasRole(ADMIN_ALL)
-          .requestMatchers(HttpMethod.PUT, "/admin/schema-validation/**").hasRole(ADMIN_ALL)
+          .requestMatchers(HttpMethod.PATCH, "/admin/schema-validation/**").hasRole(ADMIN_ALL)
 
           // Graph Database Admin APIs
           .requestMatchers(HttpMethod.GET, "/admin/graph-database").hasRole(ADMIN_ALL)

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/listener/GraphStoreStartupChecker.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/listener/GraphStoreStartupChecker.java
@@ -8,6 +8,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
 
 import eu.xfsc.fc.api.generated.model.AssetStatus;
+import eu.xfsc.fc.core.dao.assets.ContentKind;
 import eu.xfsc.fc.core.pojo.GraphBackendType;
 import eu.xfsc.fc.core.pojo.AssetFilter;
 import eu.xfsc.fc.core.service.graphdb.GraphRebuildService;
@@ -67,18 +68,19 @@ public class GraphStoreStartupChecker implements ApplicationListener<Application
 
     AssetFilter filter = new AssetFilter();
     filter.setStatuses(List.of(AssetStatus.ACTIVE));
+    filter.setContentKinds(List.of(ContentKind.RDF));
     filter.setLimit(0);
     filter.setOffset(0);
-    long activeAssetCount = assetStore.getByFilter(filter, false, false).getTotalCount();
+    long rdfAssetCount = assetStore.getByFilter(filter, false, false).getTotalCount();
 
-    if (claimCount == 0 && activeAssetCount > 0) {
-      log.warn("Graph store is empty but {} active assets exist in storage", activeAssetCount);
+    if (claimCount == 0 && rdfAssetCount > 0) {
+      log.warn("Graph store has no claims but {} RDF assets exist in storage", rdfAssetCount);
       if (autoRebuildOnEmpty) {
         log.info("Auto-rebuild is enabled, triggering graph rebuild");
         graphRebuildService.triggerRebuild(1, 0, rebuildThreads, rebuildBatchSize);
       }
     } else {
-      log.info("Graph store state: {} claims, {} active assets", claimCount, activeAssetCount);
+      log.info("Graph store state: {} claims, {} RDF assets", claimCount, rdfAssetCount);
     }
   }
 }

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/listener/TrustFrameworkStartupLogger.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/listener/TrustFrameworkStartupLogger.java
@@ -27,7 +27,7 @@ public class TrustFrameworkStartupLogger implements ApplicationListener<Applicat
 
   private static final String DISABLED_FAMILY_MSG =
       "trust-framework '{}' registered (profiles: {}) — disabled."
-          + " Enable via PUT /admin/trust-frameworks/{}/enabled?enabled=true"
+          + " Enable via PATCH /admin/trust-frameworks/{} with body {\"enabled\":true}"
           + " or env FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS={}";
 
   private final TrustFrameworkRegistry trustFrameworkRegistry;

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphDatabaseAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphDatabaseAdminService.java
@@ -1,48 +1,73 @@
 package eu.xfsc.fc.server.service;
 
+import java.util.List;
+import java.util.Locale;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import eu.xfsc.fc.api.generated.model.AssetStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.SwitchGraphDatabaseRequest;
 import eu.xfsc.fc.core.dao.adminconfig.AdminConfigEntry;
 import eu.xfsc.fc.core.dao.adminconfig.AdminConfigRepository;
+import eu.xfsc.fc.core.dao.assets.ContentKind;
 import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.AssetFilter;
 import eu.xfsc.fc.core.pojo.GraphBackendType;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.server.service.graphdb.RoutingGraphStore;
 import eu.xfsc.fc.server.generated.controller.GraphDatabaseAdminApiDelegate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Service for graph database administration endpoints.
+ *
+ * <p>A "Switch Backend" request performs an in-process swap via
+ * {@link RoutingGraphStore#setActive(GraphBackendType)} so the change takes effect
+ * immediately, with no JVM restart. The chosen backend is also written to
+ * {@code admin_config} so the same backend is reactivated on the next cold boot.
+ *
+ * <p>Switches are pre-flighted via {@link GraphStoreProbe} against the target backend's
+ * configured URI. Persisting a preference for an unreachable backend would trap the
+ * next cold boot, so the endpoint rejects with {@code 400} when the probe fails and
+ * leaves both the persisted preference and the active adapter untouched.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GraphDatabaseAdminService implements GraphDatabaseAdminApiDelegate {
 
-  private static final String KEY_PREFERRED_BACKEND = "graphstore.preferred.backend";
-
   private final GraphStore graphStore;
+  private final AssetStore assetStore;
   private final AdminConfigRepository adminConfigRepository;
+  private final GraphStoreProbe graphStoreProbe;
+  private final RoutingGraphStore routingGraphStore;
 
   @Override
   public ResponseEntity<GraphDatabaseStatus> getGraphDatabaseStatus() {
     GraphDatabaseStatus status = new GraphDatabaseStatus();
     try {
       GraphBackendType backendType = graphStore.getBackendType();
+      long rdfAssetCount = countActiveRdfAssets();
       status.setActiveBackend(backendType.name());
       status.setConnected(backendType != GraphBackendType.NONE && graphStore.isHealthy());
       status.setClaimCount(graphStore.getClaimCount());
-      status.setVersion(backendType.name() + " (active)");
-    } catch (Exception e) {
-      log.warn("Failed to get graph database status", e);
+      status.setVersion(buildVersionString(backendType));
+      status.setRebuildNeeded(computeRebuildNeeded(backendType, status.getClaimCount(),
+          rdfAssetCount));
+      status.setRdfAssetCount(rdfAssetCount);
+    } catch (RuntimeException ex) {
+      log.warn("Failed to get graph database status", ex);
       status.setActiveBackend("UNKNOWN");
       status.setConnected(false);
       status.setClaimCount(-1L);
       status.setVersion("unavailable");
+      status.setRebuildNeeded(false);
+      status.setRdfAssetCount(0L);
     }
     return ResponseEntity.ok(status);
   }
@@ -50,27 +75,68 @@ public class GraphDatabaseAdminService implements GraphDatabaseAdminApiDelegate 
   @Override
   public ResponseEntity<GraphDatabaseSwitchResult> switchGraphDatabase(
       SwitchGraphDatabaseRequest request) {
-    String backend = request.getBackend();
+    GraphBackendType target = parseTarget(request.getBackend());
 
-    // Validate backend name
-    try {
-      GraphBackendType.valueOf(backend.toUpperCase());
-    } catch (IllegalArgumentException e) {
-      throw new ClientException("Invalid graph database backend: " + backend
-          + ". Valid options: NEO4J, FUSEKI, NONE");
+    GraphStoreProbe.Result probe = graphStoreProbe.probe(target);
+    if (!probe.reachable()) {
+      throw new ClientException(
+          "Target backend " + target.name() + " is not reachable: " + probe.message()
+          + ". Verify the backend container is up and the URI configuration is correct.");
     }
 
-    // Persist the preferred backend
-    AdminConfigEntry entry = adminConfigRepository.findById(KEY_PREFERRED_BACKEND)
-        .orElse(new AdminConfigEntry(KEY_PREFERRED_BACKEND, null, null));
-    entry.setConfigValue(backend.toUpperCase());
+    // Swap the live adapter first; persist the preference only after a successful swap.
+    // Reversing this order would leave a preference pointing at a backend the server
+    // could not actually serve, trapping the next cold boot.
+    routingGraphStore.setActive(target);
+
+    AdminConfigEntry entry = adminConfigRepository.findById(RoutingGraphStore.KEY_PREFERRED_BACKEND)
+        .orElse(new AdminConfigEntry(RoutingGraphStore.KEY_PREFERRED_BACKEND, null, null));
+    entry.setConfigValue(target.name());
     adminConfigRepository.save(entry);
 
     GraphDatabaseSwitchResult result = new GraphDatabaseSwitchResult();
-    result.setRestartRequired(true);
-    result.setMessage("Graph database backend set to " + backend.toUpperCase()
-        + ". Restart the server for the change to take effect. "
-        + "After restart, trigger a graph rebuild to re-index existing assets.");
+    result.setMessage("Graph database backend switched to " + target.name()
+        + ". " + probe.message()
+        + ". If the new graph store has no claims but RDF assets exist, the page will "
+        + "offer a one-click rebuild.");
     return ResponseEntity.ok(result);
+  }
+
+  private GraphBackendType parseTarget(String backend) {
+    if (backend == null || backend.isBlank()) {
+      throw new ClientException("Missing 'backend' field. Valid options: "
+          + List.of(GraphBackendType.values()));
+    }
+    try {
+      return GraphBackendType.valueOf(backend.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException ex) {
+      throw new ClientException("Invalid graph database backend: " + backend
+          + ". Valid options: NEO4J, FUSEKI, NONE");
+    }
+  }
+
+  private boolean computeRebuildNeeded(GraphBackendType backendType, long claimCount,
+      long rdfAssetCount) {
+    if (backendType == GraphBackendType.NONE || claimCount != 0L) {
+      return false;
+    }
+    return rdfAssetCount > 0L;
+  }
+
+  private long countActiveRdfAssets() {
+    // AssetFilter.setLimit(0) means "no limit" — would materialize every row on each
+    // status load. Page size 1 still yields the full totalCount via the COUNT query.
+    AssetFilter filter = new AssetFilter();
+    filter.setStatuses(List.of(AssetStatus.ACTIVE));
+    filter.setContentKinds(List.of(ContentKind.RDF));
+    filter.setLimit(1);
+    filter.setOffset(0);
+    return assetStore.getByFilter(filter, false, false).getTotalCount();
+  }
+
+  private String buildVersionString(GraphBackendType backendType) {
+    return backendType == GraphBackendType.NONE
+        ? "(no graph database)"
+        : backendType.name() + " (active)";
   }
 }

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphStoreProbe.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphStoreProbe.java
@@ -1,0 +1,117 @@
+package eu.xfsc.fc.server.service;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import eu.xfsc.fc.core.pojo.GraphBackendType;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reachability probe for graph store backends, independent of which backend is currently
+ * active. Used by {@code GraphDatabaseAdminService} to pre-flight a switch — the operator
+ * cannot persist a backend the server will then fail to boot against.
+ *
+ * <p>Each probe opens a short-lived connection (Bolt driver verifyConnectivity, HTTP GET
+ * on the Fuseki dataset URL) and reports a {@link Result} with the reason on failure so
+ * the admin endpoint can return an actionable {@code 400}.
+ */
+@Slf4j
+@Component
+public class GraphStoreProbe {
+
+  private static final Duration PROBE_TIMEOUT = Duration.ofSeconds(3);
+
+  private final String neo4jUri;
+  private final String neo4jUser;
+  private final String neo4jPassword;
+  private final String fusekiUri;
+
+  public GraphStoreProbe(
+      @Value("${graphstore.neo4j.uri:${graphstore.uri:}}") String neo4jUri,
+      @Value("${graphstore.user:}") String neo4jUser,
+      @Value("${graphstore.password:}") String neo4jPassword,
+      @Value("${graphstore.fuseki.uri:${graphstore.uri:}}") String fusekiUri) {
+    this.neo4jUri = neo4jUri;
+    this.neo4jUser = neo4jUser;
+    this.neo4jPassword = neo4jPassword;
+    this.fusekiUri = fusekiUri;
+  }
+
+  public Result probe(GraphBackendType target) {
+    return switch (target) {
+      case NEO4J -> probeNeo4j();
+      case FUSEKI -> probeFuseki();
+      case NONE -> Result.reachable("DummyGraphStore is always available");
+    };
+  }
+
+  private Result probeNeo4j() {
+    if (neo4jUri == null || neo4jUri.isBlank()) {
+      return Result.unreachable("Neo4j URI is not configured (graphstore.neo4j.uri)");
+    }
+    // Cap driver-side connect / acquisition / pool size so a black-holed host fails within
+    // PROBE_TIMEOUT instead of stalling on the OS-level connect timeout (~75s on Linux).
+    Config cfg = Config.builder()
+        .withConnectionTimeout(PROBE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+        .withConnectionAcquisitionTimeout(PROBE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
+        .withMaxConnectionPoolSize(1)
+        .build();
+    try (Driver driver = GraphDatabase.driver(
+        neo4jUri, AuthTokens.basic(neo4jUser, neo4jPassword), cfg)) {
+      driver.verifyConnectivity();
+      return Result.reachable("Neo4j at " + neo4jUri + " is reachable");
+    } catch (RuntimeException ex) {
+      log.warn("Neo4j probe failed at {}", neo4jUri, ex);
+      return Result.unreachable("Neo4j at " + neo4jUri + " is not reachable: " + ex.getMessage());
+    }
+  }
+
+  private Result probeFuseki() {
+    if (fusekiUri == null || fusekiUri.isBlank()) {
+      return Result.unreachable("Fuseki URI is not configured (graphstore.fuseki.uri)");
+    }
+    try {
+      HttpClient client = HttpClient.newBuilder().connectTimeout(PROBE_TIMEOUT).build();
+      HttpRequest req = HttpRequest.newBuilder()
+          .uri(URI.create(fusekiUri))
+          .timeout(PROBE_TIMEOUT)
+          .GET()
+          .build();
+      HttpResponse<Void> resp = client.send(req, HttpResponse.BodyHandlers.discarding());
+      // Fuseki returns 200 on a dataset URL and 400 on root-level GET without a query.
+      // Either is a positive signal that the server is up; we only fail on connection
+      // errors or 5xx.
+      if (resp.statusCode() >= 500) {
+        return Result.unreachable("Fuseki at " + fusekiUri + " responded with HTTP " + resp.statusCode());
+      }
+      return Result.reachable("Fuseki at " + fusekiUri + " is reachable (HTTP " + resp.statusCode() + ")");
+    } catch (RuntimeException | java.io.IOException | InterruptedException ex) {
+      if (ex instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      log.warn("Fuseki probe failed at {}", fusekiUri, ex);
+      return Result.unreachable("Fuseki at " + fusekiUri + " is not reachable: " + ex.getMessage());
+    }
+  }
+
+  public record Result(boolean reachable, String message) {
+    public static Result reachable(String message) {
+      return new Result(true, message);
+    }
+
+    public static Result unreachable(String message) {
+      return new Result(false, message);
+    }
+  }
+}

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/SchemaValidationAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/SchemaValidationAdminService.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.SchemaValidationModule;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.core.dao.adminconfig.AdminConfigEntry;
@@ -94,17 +95,28 @@ public class SchemaValidationAdminService implements SchemaValidationAdminApiDel
     return ResponseEntity.ok(status);
   }
 
+  /**
+   * Applies a merge-patch to the identified schema validation module. Only non-null patch fields
+   * are applied. Returns 400 if the module type is not one of the four valid values.
+   *
+   * @param type  module type (SHACL, JSON_SCHEMA, XML_SCHEMA, OWL)
+   * @param patch fields to update
+   * @return 200 on success
+   */
   @Override
   @CacheEvict(value = SchemaModuleConfigService.CACHE_NAME, allEntries = true)
-  public ResponseEntity<Void> setSchemaModuleEnabled(String type, Boolean enabled) {
+  public ResponseEntity<Void> patchSchemaModule(String type, SchemaModulePatch patch) {
     if (!VALID_MODULE_TYPES.contains(type)) {
       throw new ClientException("Invalid module type: " + type
           + ". Valid types: " + String.join(", ", VALID_MODULE_TYPES));
     }
+    if (patch.getEnabled() == null) {
+      throw new ClientException("Patch body must contain at least one field");
+    }
     String key = CONFIG_PREFIX + type + CONFIG_SUFFIX;
     AdminConfigEntry entry = adminConfigRepository.findById(key)
         .orElse(new AdminConfigEntry(key, null, null));
-    entry.setConfigValue(String.valueOf(enabled));
+    entry.setConfigValue(String.valueOf(patch.getEnabled()));
     adminConfigRepository.save(entry);
     return ResponseEntity.ok().build();
   }

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
@@ -1,17 +1,22 @@
 package eu.xfsc.fc.server.service;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import eu.xfsc.fc.api.generated.model.TrustFrameworkBundleEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 import eu.xfsc.fc.server.config.AdminDashboardConfig;
 import eu.xfsc.fc.server.generated.controller.TrustFrameworkAdminApiDelegate;
@@ -32,6 +37,7 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
   private static final int DEFAULT_TIMEOUT_SECONDS = 30;
 
   private final TrustFrameworkService trustFrameworkService;
+  private final TrustFrameworkRegistry trustFrameworkRegistry;
   private final AdminDashboardConfig adminDashboardConfig;
 
   @Value("${federated-catalogue.enabled-trust-frameworks:}")
@@ -74,6 +80,12 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
   }
 
   @Override
+  public ResponseEntity<Void> setTrustFrameworkRoleEnabled(String bundleId, String roleName, Boolean enabled) {
+    trustFrameworkService.setRoleEnabled(bundleId, roleName, enabled);
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
   public ResponseEntity<Void> updateTrustFrameworkConfig(String id,
       TrustFrameworkConfigUpdate config) {
     int timeoutSeconds = config.getTimeoutSeconds() != null ? config.getTimeoutSeconds() : DEFAULT_TIMEOUT_SECONDS;
@@ -93,7 +105,30 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
     entry.setTimeoutSeconds(config.timeoutSeconds());
     entry.setEnabled(config.enabled());
     entry.setConnected(checkConnectivity(config));
+    entry.setBundles(buildBundleEntries(config.id()));
     return entry;
+  }
+
+  /**
+   * Builds a list of {@link TrustFrameworkBundleEntry} for each bundle belonging to the given
+   * family, carrying the per-bundle role enabled states so the UI can address role-toggle PUTs
+   * by the correct bundle profile ID.
+   *
+   * @param familyId trust framework family identifier (e.g. {@code gaia-x})
+   * @return list of bundle entries in registry order; empty if no bundles belong to the family
+   */
+  private List<TrustFrameworkBundleEntry> buildBundleEntries(String familyId) {
+    List<TrustFrameworkBundleEntry> result = new ArrayList<>();
+    for (TrustFrameworkBundle bundle : trustFrameworkRegistry.getAllBundles()) {
+      if (!familyId.equals(bundle.config().family())) {
+        continue;
+      }
+      TrustFrameworkBundleEntry bundleEntry = new TrustFrameworkBundleEntry();
+      bundleEntry.setId(bundle.config().id());
+      bundleEntry.setRoles(trustFrameworkService.getRoleStates(bundle.config().id()));
+      result.add(bundleEntry);
+    }
+    return result;
   }
 
   private boolean checkConnectivity(TrustFrameworkConfig config) {

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
@@ -3,7 +3,6 @@ package eu.xfsc.fc.server.service;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,8 +10,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import eu.xfsc.fc.api.generated.model.TrustFrameworkBundleEntry;
-import eu.xfsc.fc.api.generated.model.TrustFrameworkConfigUpdate;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkRolePatch;
+import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
@@ -73,26 +74,44 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
     return ResponseEntity.ok(entries);
   }
 
+  /**
+   * Applies a merge-patch to the identified trust framework family. Supports toggling the
+   * enabled state and updating configuration fields independently or in combination.
+   * Returns 404 if the family identifier is not registered.
+   *
+   * @param id    trust framework family identifier
+   * @param patch fields to update; only non-null fields are applied
+   * @return 200 on success, 404 if unknown id
+   */
   @Override
-  public ResponseEntity<Void> setTrustFrameworkEnabled(String id, Boolean enabled) {
-    trustFrameworkService.setEnabled(id, enabled);
-    return ResponseEntity.ok().build();
-  }
-
-  @Override
-  public ResponseEntity<Void> setTrustFrameworkRoleEnabled(String bundleId, String roleName, Boolean enabled) {
-    trustFrameworkService.setRoleEnabled(bundleId, roleName, enabled);
-    return ResponseEntity.ok().build();
-  }
-
-  @Override
-  public ResponseEntity<Void> updateTrustFrameworkConfig(String id,
-      TrustFrameworkConfigUpdate config) {
-    int timeoutSeconds = config.getTimeoutSeconds() != null ? config.getTimeoutSeconds() : DEFAULT_TIMEOUT_SECONDS;
-    if (trustFrameworkService.updateConfig(id, config.getServiceUrl(), config.getApiVersion(), timeoutSeconds)
-        .isEmpty()) {
-      throw new NotFoundException("Trust framework not found: " + id);
+  public ResponseEntity<Void> patchTrustFramework(String id, TrustFrameworkPatch patch) {
+    boolean touchesConfig = patch.getServiceUrl() != null
+        || patch.getApiVersion() != null
+        || patch.getTimeoutSeconds() != null;
+    if (patch.getEnabled() == null && !touchesConfig) {
+      throw new ClientException("Patch body must contain at least one field");
     }
+    if (patch.getEnabled() != null) {
+      trustFrameworkService.setEnabled(id, patch.getEnabled());
+    }
+    if (touchesConfig) {
+      int timeoutSeconds = patch.getTimeoutSeconds() != null
+          ? patch.getTimeoutSeconds() : DEFAULT_TIMEOUT_SECONDS;
+      if (trustFrameworkService.updateConfig(id, patch.getServiceUrl(),
+          patch.getApiVersion(), timeoutSeconds).isEmpty()) {
+        throw new NotFoundException("Trust framework not found: " + id);
+      }
+    }
+    return ResponseEntity.ok().build();
+  }
+
+  @Override
+  public ResponseEntity<Void> patchTrustFrameworkRole(String bundleId, String roleName,
+                                                      TrustFrameworkRolePatch patch) {
+    if (patch.getEnabled() == null) {
+      throw new ClientException("Patch body must contain at least one field");
+    }
+    trustFrameworkService.setRoleEnabled(bundleId, roleName, patch.getEnabled());
     return ResponseEntity.ok().build();
   }
 
@@ -111,7 +130,7 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
 
   /**
    * Builds a list of {@link TrustFrameworkBundleEntry} for each bundle belonging to the given
-   * family, carrying the per-bundle role enabled states so the UI can address role-toggle PUTs
+   * family, carrying the per-bundle role enabled states so the UI can address role-toggle requests
    * by the correct bundle profile ID.
    *
    * @param familyId trust framework family identifier (e.g. {@code gaia-x})

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/graphdb/RoutingGraphStore.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/graphdb/RoutingGraphStore.java
@@ -1,0 +1,183 @@
+package eu.xfsc.fc.server.service.graphdb;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import eu.xfsc.fc.api.generated.model.QueryLanguage;
+import eu.xfsc.fc.core.dao.adminconfig.AdminConfigRepository;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.GraphBackendType;
+import eu.xfsc.fc.core.pojo.GraphQuery;
+import eu.xfsc.fc.core.pojo.PaginatedResults;
+import eu.xfsc.fc.core.pojo.RdfClaim;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Delegating {@link GraphStore} that holds the currently-active adapter behind a
+ * {@code volatile} reference. The admin "Switch Backend" action updates this reference
+ * in process, so a switch takes effect without a JVM restart.
+ *
+ * <p>On cold boot the active backend is resolved in this order:
+ * <ol>
+ *   <li>{@code admin_config[graphstore.preferred.backend]} — the persisted preference set
+ *       by a prior switch.</li>
+ *   <li>{@code graphstore.impl} environment property — the deployment-time bootstrap.</li>
+ *   <li>{@link GraphBackendType#NONE} — last-resort fallback so the application can boot
+ *       even without a configured graph store.</li>
+ * </ol>
+ */
+@Slf4j
+@Component
+@Primary
+@RequiredArgsConstructor
+public class RoutingGraphStore implements GraphStore {
+
+  public static final String KEY_PREFERRED_BACKEND = "graphstore.preferred.backend";
+
+  private final List<GraphStore> availableAdapters;
+  private final AdminConfigRepository adminConfigRepository;
+
+  @Value("${graphstore.impl:none}")
+  private String envBackendName;
+
+  private final Map<GraphBackendType, GraphStore> adapterByType =
+      new EnumMap<>(GraphBackendType.class);
+  private volatile GraphStore activeAdapter;
+
+  @PostConstruct
+  void initialize() {
+    for (GraphStore adapter : availableAdapters) {
+      if (adapter == this) {
+        continue;
+      }
+      adapterByType.put(adapter.getBackendType(), adapter);
+    }
+    GraphBackendType target = resolveInitialBackend();
+    activeAdapter = adapterFor(target);
+    log.info("RoutingGraphStore initialized with active backend: {} (available adapters: {})",
+        target, adapterByType.keySet());
+  }
+
+  private GraphBackendType resolveInitialBackend() {
+    Optional<GraphBackendType> persisted = adminConfigRepository.getValue(KEY_PREFERRED_BACKEND)
+        .flatMap(RoutingGraphStore::parseBackend);
+    if (persisted.isPresent()) {
+      log.info("Active backend from admin_config: {}", persisted.get());
+      return persisted.get();
+    }
+    Optional<GraphBackendType> fromEnv = parseBackend(envBackendName);
+    if (fromEnv.isPresent()) {
+      log.info("Active backend from graphstore.impl env: {}", fromEnv.get());
+      return fromEnv.get();
+    }
+    log.info("No persisted or env-configured backend; defaulting to NONE");
+    return GraphBackendType.NONE;
+  }
+
+  private static Optional<GraphBackendType> parseBackend(String raw) {
+    if (raw == null || raw.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      return Optional.of(GraphBackendType.valueOf(raw.trim().toUpperCase(java.util.Locale.ROOT)));
+    } catch (IllegalArgumentException ex) {
+      log.warn("Unknown graph backend name '{}' — ignoring", raw);
+      return Optional.empty();
+    }
+  }
+
+  private GraphStore adapterFor(GraphBackendType type) {
+    GraphStore adapter = adapterByType.get(type);
+    if (adapter == null) {
+      log.warn("No adapter for {}; falling back to NONE", type);
+      adapter = adapterByType.get(GraphBackendType.NONE);
+    }
+    if (adapter == null) {
+      throw new IllegalStateException(
+          "No graph store adapter available — DummyGraphStore must be on the classpath");
+    }
+    return adapter;
+  }
+
+  /**
+   * Switches the active adapter to the given backend. Serialized — concurrent switches
+   * apply one at a time. The volatile reference makes the change immediately visible to
+   * any thread observing it on the next read.
+   *
+   * <p>Unlike cold-boot resolution, an explicit switch must not silently fall back when
+   * the requested backend has no registered adapter — that would let a probe-passing
+   * switch return 200 against a backend the server cannot actually serve. Throws a
+   * {@link ClientException} so the admin endpoint returns {@code 400}.
+   *
+   * @param target the backend to activate
+   * @throws ClientException if no adapter is registered for the requested backend
+   */
+  public synchronized void setActive(GraphBackendType target) {
+    GraphStore next = adapterByType.get(target);
+    if (next == null) {
+      throw new ClientException(
+          "Backend %s is not available in this deployment (no adapter registered). Available backends: %s".formatted(
+              target.name(), adapterByType.keySet()));
+    }
+    GraphBackendType previous = activeAdapter == null ? null : activeAdapter.getBackendType();
+    activeAdapter = next;
+    log.info("RoutingGraphStore active backend changed: {} -> {}", previous, target);
+  }
+
+  // --- GraphStore delegation ---
+
+  @Override
+  public void addClaims(List<RdfClaim> claimList, String credentialSubject) {
+    activeAdapter.addClaims(claimList, credentialSubject);
+  }
+
+  @Override
+  public void deleteClaims(String credentialSubject) {
+    activeAdapter.deleteClaims(credentialSubject);
+  }
+
+  @Override
+  public void deleteValidationResultClaims(String resultIri) {
+    activeAdapter.deleteValidationResultClaims(resultIri);
+  }
+
+  @Override
+  public PaginatedResults<Map<String, Object>> queryData(GraphQuery query) {
+    return activeAdapter.queryData(query);
+  }
+
+  @Override
+  public Optional<QueryLanguage> getSupportedQueryLanguage() {
+    return activeAdapter.getSupportedQueryLanguage();
+  }
+
+  @Override
+  public GraphBackendType getBackendType() {
+    return activeAdapter.getBackendType();
+  }
+
+  @Override
+  public boolean isHealthy() {
+    return activeAdapter.isHealthy();
+  }
+
+  @Override
+  public long getClaimCount() {
+    return activeAdapter.getClaimCount();
+  }
+
+  @Override
+  public long getRDFAssetCountInGraph() {
+    return activeAdapter.getRDFAssetCountInGraph();
+  }
+}

--- a/fc-service-server/src/main/resources/application.yml
+++ b/fc-service-server/src/main/resources/application.yml
@@ -1,9 +1,5 @@
 management:
   endpoint:
-    configprops:
-      show-values: ALWAYS
-    env:
-      show-values: ALWAYS
     health:
       show-details: when_authorized
   endpoints:
@@ -91,9 +87,22 @@ admin:
     file-store-path: ${datastore.file-path}
 
 graphstore:
-  impl: neo4j #fuseki, none
+  # Cold-boot fallback only. The active backend is resolved at startup by
+  # RoutingGraphStore: admin_config[graphstore.preferred.backend] first, this value
+  # second, NONE last. The admin "Switch Backend" action performs a live in-process
+  # switch and updates the persisted preference for subsequent boots.
+  impl: fuseki #neo4j, none
   auto-rebuild-on-empty: false
-  uri: bolt://localhost:7687
+  # Per-backend URIs. Both are read at runtime; only the URI for the active backend
+  # opens a driver. The pre-flight probe in GraphDatabaseAdminService reads the other
+  # backend's URI to verify reachability before persisting a switch.
+  neo4j:
+    uri: bolt://localhost:7687
+  fuseki:
+    uri: http://localhost:3030/ds
+  # Deprecated single URI — kept as a fallback for either adapter. New deployments
+  # should set the per-backend URIs above.
+  uri: ${graphstore.fuseki.uri}
   user: neo4j
   password: neo12345
   timeout-marker: The transaction has not completed within the timeout specified

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetValidationControllerToggleDemoTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/AssetValidationControllerToggleDemoTest.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.server.controller;
 
+import static eu.xfsc.fc.api.FcMediaTypes.MERGE_PATCH_JSON_VALUE;
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -25,7 +26,7 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 
 /**
- * Demonstration of the AU-01 acceptance criterion "the toggle takes effect": the SHACL
+ * Demonstration the validation toggles taking effect. The SHACL
  * module toggle, flipped via the admin endpoint, observably changes the
  * {@code POST /assets/validate} response body for a subsequent request.
  *
@@ -59,11 +60,19 @@ public class AssetValidationControllerToggleDemoTest {
   @Autowired
   private MockMvc mockMvc;
 
+  private static final String ENABLED_TRUE = """
+      {"enabled":true}
+      """;
+  private static final String ENABLED_FALSE = """
+      {"enabled":false}
+      """;
+
   @AfterEach
   void resetShaclToEnabled() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "true")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf())
             .with(adminUser()))
         .andExpect(status().isOk());
@@ -83,8 +92,9 @@ public class AssetValidationControllerToggleDemoTest {
   @WithMockUser(roles = {ADMIN_ALL})
   void validateAssets_shaclModuleDisabled_returns400ModuleDisabled() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "false")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_FALSE)
             .with(csrf()))
         .andExpect(status().isOk());
 
@@ -101,8 +111,9 @@ public class AssetValidationControllerToggleDemoTest {
   @WithMockUser(roles = {ADMIN_ALL})
   void validateAssets_shaclModuleEnabled_doesNotReturnModuleDisabled() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "true")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isOk());
 

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/DistributedQueryControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/DistributedQueryControllerTest.java
@@ -231,7 +231,6 @@ public class DistributedQueryControllerTest {
 
   private void initialiseAllDataBaseWithManuallyAddingCredentialFromRepository() throws Exception {
 
-	  log.debug("INIT-DATA.START");
 	  try {
     //adding 1st credential
     ContentAccessorDirect contentAccessor =
@@ -242,7 +241,7 @@ public class DistributedQueryControllerTest {
             verificationResult.getIssuer(), verificationResult.getValidators(), contentAccessor);
     assetStorePublisher.storeCredential(assetMetadata, verificationResult);
 
-    //adding second credential
+        //adding 2nd credential
     ContentAccessorDirect contentAccessor2
             = new ContentAccessorDirect(FileReaderHelper.getMockFileDataAsString("default-credential-service-offering.json"));
         CredentialVerificationResult verificationResult2
@@ -251,7 +250,7 @@ public class DistributedQueryControllerTest {
             verificationResult2.getIssuer(), verificationResult2.getValidators(), contentAccessor2);
     assetStorePublisher.storeCredential(assetMetadata2, verificationResult2);
 
-    //adding third credential
+        //adding 3rd credential
    ContentAccessorDirect contentAccessorDirect3 =
         new ContentAccessorDirect(FileReaderHelper.getMockFileDataAsString("unique-participant.json"));
         CredentialVerificationResult verificationResult3
@@ -261,10 +260,8 @@ public class DistributedQueryControllerTest {
     assetStorePublisher.storeCredential(assetMetadata3, verificationResult3);
     
 	  } catch (Exception ex) {
-		  log.error("INIT-DATA.ERROR", ex);
-		  throw ex;
+        log.error("Error while adding credential to database: {}", ex.getMessage(), ex);
+        throw ex;
 	  }
-	  log.debug("INIT-DATA.FINISH");
   }
-
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/GraphDatabaseAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/GraphDatabaseAdminControllerTest.java
@@ -1,11 +1,15 @@
 package eu.xfsc.fc.server.controller;
 
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,14 +19,22 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import eu.xfsc.fc.core.dao.adminconfig.AdminConfigRepository;
+import eu.xfsc.fc.server.service.GraphStoreProbe;
+import eu.xfsc.fc.server.service.graphdb.RoutingGraphStore;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 
 /**
  * Integration tests for Graph Database Admin endpoints.
+ *
+ * <p>{@link GraphStoreProbe} is mocked here — the probe makes real network connections
+ * to the configured backend URIs, which the embedded Fuseki / unit-test environment
+ * cannot satisfy. The probe itself is covered by its own unit test.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -35,6 +47,19 @@ public class GraphDatabaseAdminControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
+  @Autowired
+  private AdminConfigRepository adminConfigRepository;
+
+  @MockitoBean
+  private GraphStoreProbe graphStoreProbe;
+
+  @BeforeEach
+  void resetProbe() {
+    when(graphStoreProbe.probe(any()))
+        .thenReturn(GraphStoreProbe.Result.reachable("ok"));
+    adminConfigRepository.deleteById(RoutingGraphStore.KEY_PREFERRED_BACKEND);
+  }
+
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
   void getGraphDatabaseStatus_withAdminRole_returnsStatus() throws Exception {
@@ -43,7 +68,11 @@ public class GraphDatabaseAdminControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.activeBackend").value(isA(String.class)))
         .andExpect(jsonPath("$.connected").value(isA(Boolean.class)))
-        .andExpect(jsonPath("$.claimCount").value(isA(Number.class)));
+        .andExpect(jsonPath("$.claimCount").value(isA(Number.class)))
+        .andExpect(jsonPath("$.rebuildNeeded").value(isA(Boolean.class)))
+        .andExpect(jsonPath("$.rdfAssetCount").value(isA(Number.class)))
+        .andExpect(jsonPath("$.preferredBackend").doesNotExist())
+        .andExpect(jsonPath("$.restartRequired").doesNotExist());
   }
 
   @Test
@@ -75,14 +104,24 @@ public class GraphDatabaseAdminControllerTest {
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void switchGraphDatabase_validBackend_returnsRestartRequired() throws Exception {
+  void switchGraphDatabase_validBackend_appliesLiveAndPersists() throws Exception {
+    // FUSEKI is the adapter wired in this test context (graphstore.impl=fuseki).
     mockMvc.perform(MockMvcRequestBuilders.post("/admin/graph-database/switch")
             .contentType(MediaType.APPLICATION_JSON)
             .content("{\"backend\":\"FUSEKI\"}")
             .with(csrf()))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.restartRequired").value(true))
-        .andExpect(jsonPath("$.message").value(isA(String.class)));
+        .andExpect(jsonPath("$.message").value(isA(String.class)))
+        .andExpect(jsonPath("$.restartRequired").doesNotExist());
+
+    String persisted = adminConfigRepository.findById(RoutingGraphStore.KEY_PREFERRED_BACKEND)
+        .orElseThrow().getConfigValue();
+    org.junit.jupiter.api.Assertions.assertEquals("FUSEKI", persisted);
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/graph-database")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.activeBackend").value("FUSEKI"));
   }
 
   @Test
@@ -93,6 +132,24 @@ public class GraphDatabaseAdminControllerTest {
             .content("{\"backend\":\"INVALID\"}")
             .with(csrf()))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void switchGraphDatabase_targetUnreachable_returns400WithReason() throws Exception {
+    when(graphStoreProbe.probe(any()))
+        .thenReturn(GraphStoreProbe.Result.unreachable("Fuseki at http://fuseki:3030/ds connection refused"));
+
+    mockMvc.perform(MockMvcRequestBuilders.post("/admin/graph-database/switch")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("{\"backend\":\"FUSEKI\"}")
+            .with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(containsString("connection refused")));
+
+    org.junit.jupiter.api.Assertions.assertTrue(
+        adminConfigRepository.findById(RoutingGraphStore.KEY_PREFERRED_BACKEND).isEmpty(),
+        "Preference must not be persisted when probe rejects the target");
   }
 
   @Test

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaValidationAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/SchemaValidationAdminControllerTest.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.server.controller;
 
+import static eu.xfsc.fc.api.FcMediaTypes.MERGE_PATCH_JSON_VALUE;
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -66,53 +67,68 @@ public class SchemaValidationAdminControllerTest {
         .andExpect(status().isUnauthorized());
   }
 
+
   @Test
   @WithMockUser
-  void setModuleEnabled_withoutAdminRole_returns403() throws Exception {
+  void patchSchemaModule_withoutAdminRole_returns403() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "false")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("""
+                {"enabled":false}
+                """)
             .with(csrf()))
         .andExpect(status().isForbidden());
   }
 
   @Test
-  void setModuleEnabled_unauthenticated_returns401() throws Exception {
+  void patchSchemaModule_unauthenticated_returns401() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "false")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("""
+                {"enabled":false}
+                """)
             .with(csrf()))
         .andExpect(status().isUnauthorized());
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setModuleEnabled_validType_returns200() throws Exception {
+  void patchSchemaModule_enabledField_togglesState() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "false")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("""
+                {"enabled":false}
+                """)
             .with(csrf()))
         .andExpect(status().isOk());
 
-    // Verify toggle took effect
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/schema-validation")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.modules[?(@.type=='SHACL')].enabled").value(false));
 
     // Reset
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/SHACL")
-            .param("enabled", "true")
+            .patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("""
+                {"enabled":true}
+                """)
             .with(csrf()))
         .andExpect(status().isOk());
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setModuleEnabled_invalidType_returns400() throws Exception {
+  void patchSchemaModule_invalidType_returns400() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/schema-validation/modules/INVALID")
-            .param("enabled", "true")
+            .patch("/admin/schema-validation/modules/INVALID")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("""
+                {"enabled":true}
+                """)
             .with(csrf()))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.message").value(containsString("SHACL")))

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
@@ -1,8 +1,9 @@
 package eu.xfsc.fc.server.controller;
 
+import static eu.xfsc.fc.api.FcMediaTypes.MERGE_PATCH_JSON_VALUE;
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,6 +35,12 @@ import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
 public class TrustFrameworkAdminControllerTest {
 
+  public static final String ENABLED_FALSE = """
+      {"enabled":false}
+      """;
+  public static final String ENABLED_TRUE = """
+      {"enabled":true}
+      """;
   @Autowired
   private MockMvc mockMvc;
 
@@ -43,11 +50,11 @@ public class TrustFrameworkAdminControllerTest {
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$", hasSize(1)))
-        .andExpect(jsonPath("$[0].id").value("gaia-x"))
-        .andExpect(jsonPath("$[0].name").value("Gaia-X Trust Framework"))
-        .andExpect(jsonPath("$[0].enabled").value(false))
-        .andExpect(jsonPath("$[0].connected").value(isA(Boolean.class)));
+        .andExpect(jsonPath("$", hasSize(2)))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].name").value(hasItem("Gaia-X Trust Framework")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].enabled").value(hasItem(false)))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].name").value(hasItem("Mock Trust Framework")))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].enabled").value(hasItem(false)));
   }
 
   @Test
@@ -65,116 +72,138 @@ public class TrustFrameworkAdminControllerTest {
         .andExpect(status().isUnauthorized());
   }
 
+
   @Test
   @WithMockUser
-  void setTrustFrameworkEnabled_withoutAdminRole_returns403() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x/enabled")
-            .param("enabled", "true")
+  void patchTrustFramework_withoutAdminRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isForbidden());
   }
 
   @Test
-  void setTrustFrameworkEnabled_unauthenticated_returns401() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x/enabled")
-            .param("enabled", "true")
-            .with(csrf()))
-        .andExpect(status().isUnauthorized());
-  }
-
-  @Test
-  @WithMockUser
-  void updateTrustFrameworkConfig_withoutAdminRole_returns403() throws Exception {
-    String body = "{\"serviceUrl\":\"https://example.com\",\"apiVersion\":\"v2\",\"timeoutSeconds\":30}";
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(body)
-            .with(csrf()))
-        .andExpect(status().isForbidden());
-  }
-
-  @Test
-  void updateTrustFrameworkConfig_unauthenticated_returns401() throws Exception {
-    String body = "{\"serviceUrl\":\"https://example.com\",\"apiVersion\":\"v2\",\"timeoutSeconds\":30}";
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(body)
+  void patchTrustFramework_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isUnauthorized());
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkEnabled_validId_returns200() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x/enabled")
-            .param("enabled", "true")
+  void patchTrustFramework_enabledField_togglesState() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isOk());
 
-    // Verify it was enabled
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
             .accept(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$[0].enabled").value(true));
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].enabled").value(hasItem(true)));
 
-    // Reset
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x/enabled")
-            .param("enabled", "false")
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_FALSE)
             .with(csrf()))
         .andExpect(status().isOk());
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkEnabled_invalidId_returns404() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/nonexistent/enabled")
-            .param("enabled", "true")
+  void patchTrustFramework_unknownId_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/nonexistent")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isNotFound());
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void updateTrustFrameworkConfig_validPayload_returns200() throws Exception {
-    String body = "{\"serviceUrl\":\"https://new.example.com\","
-        + "\"apiVersion\":\"v2\",\"timeoutSeconds\":60}";
+  void patchTrustFramework_configFields_updatesConfig() throws Exception {
+    String body = """
+        {
+          "serviceUrl":"https://new.example.com",
+          "apiVersion":"v2",
+          "timeoutSeconds":60
+        }
+        """;
 
-    mockMvc.perform(MockMvcRequestBuilders.put("/admin/trust-frameworks/gaia-x")
-            .contentType(MediaType.APPLICATION_JSON)
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
             .content(body)
             .with(csrf()))
         .andExpect(status().isOk());
 
-    // Verify update
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
             .accept(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$[0].serviceUrl").value("https://new.example.com"))
-        .andExpect(jsonPath("$[0].apiVersion").value("v2"))
-        .andExpect(jsonPath("$[0].timeoutSeconds").value(60));
-  }
-  
-  @Test
-  @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkRoleEnabled_knownBundleAndRole_returns200() throws Exception {
-    mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
-            .param("enabled", "false")
-            .with(csrf()))
-        .andExpect(status().isOk());
-
-    // Reset to default
-    mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
-            .param("enabled", "true")
-            .with(csrf()))
-        .andExpect(status().isOk());
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].serviceUrl").value(hasItem("https://new.example.com")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].apiVersion").value(hasItem("v2")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].timeoutSeconds").value(hasItem(60)));
   }
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkRoleEnabled_unknownBundle_returns404() throws Exception {
+  void patchTrustFramework_enabledAndConfigFields_appliesBoth() throws Exception {
+    String body = """
+        {
+          "enabled":true,
+          "serviceUrl":"https://combined.example.com",
+          "apiVersion":"v3",
+          "timeoutSeconds":45
+        }
+        """;
+
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(body)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].enabled").value(hasItem(true)))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].serviceUrl").value(hasItem("https://combined.example.com")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].apiVersion").value(hasItem("v3")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].timeoutSeconds").value(hasItem(45)));
+
+    // Reset
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_FALSE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkRole_knownBundleAndRole_returns200() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/nonexistent-bundle/roles/Participant/enabled")
-            .param("enabled", "true")
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_FALSE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkRole_unknownBundle_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/nonexistent-bundle/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.message", notNullValue()));
@@ -182,10 +211,11 @@ public class TrustFrameworkAdminControllerTest {
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkRoleEnabled_unknownRole_returns404() throws Exception {
+  void patchTrustFrameworkRole_unknownRole_returns404() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/UnknownRole/enabled")
-            .param("enabled", "true")
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/UnknownRole")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.message", notNullValue()));
@@ -193,28 +223,43 @@ public class TrustFrameworkAdminControllerTest {
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
-  void setTrustFrameworkRoleEnabled_missingEnabledParam_returns400() throws Exception {
+  void patchTrustFrameworkRole_missingBody_returns400() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            // missing body
             .with(csrf()))
         .andExpect(status().isBadRequest());
   }
 
   @Test
-  void setTrustFrameworkRoleEnabled_unauthenticated_returns401() throws Exception {
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkRole_emptyBody_returns400() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
-            .param("enabled", "true")
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("{}")
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void patchTrustFrameworkRole_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isUnauthorized());
   }
 
   @Test
   @WithMockUser
-  void setTrustFrameworkRoleEnabled_wrongRole_returns403() throws Exception {
+  void patchTrustFrameworkRole_wrongRole_returns403() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders
-            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
-            .param("enabled", "true")
+            .patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isForbidden());
   }
@@ -225,10 +270,38 @@ public class TrustFrameworkAdminControllerTest {
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].bundles", hasSize(1)))
-        .andExpect(jsonPath("$[0].bundles[0].id").value("gaia-x-2511"))
-        .andExpect(jsonPath("$[0].bundles[0].roles.Participant").value(true))
-        .andExpect(jsonPath("$[0].bundles[0].roles.ServiceOffering").value(true))
-        .andExpect(jsonPath("$[0].bundles[0].roles.Resource").value(true));
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].bundles[0].id").value(hasItem("gaia-x-2511")))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].bundles[0].roles.Participant").value(hasItem(true)))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].bundles[0].roles.ServiceOffering").value(hasItem(true)))
+        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].bundles[0].roles.Resource").value(hasItem(true)));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void getTrustFrameworks_mockFamily_includesMock2026Bundle() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].id").value(hasItem("mock-2026")));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFramework_mockFamily_activatesAndReflectsInGet() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/mock")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_TRUE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].enabled").value(hasItem(true)));
+
+    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/mock")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(ENABLED_FALSE)
+            .with(csrf()))
+        .andExpect(status().isOk());
   }
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
@@ -3,6 +3,7 @@ package eu.xfsc.fc.server.controller;
 import static eu.xfsc.fc.server.util.CommonConstants.ADMIN_ALL;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,5 +150,85 @@ public class TrustFrameworkAdminControllerTest {
         .andExpect(jsonPath("$[0].serviceUrl").value("https://new.example.com"))
         .andExpect(jsonPath("$[0].apiVersion").value("v2"))
         .andExpect(jsonPath("$[0].timeoutSeconds").value(60));
+  }
+  
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_knownBundleAndRole_returns200() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "false")
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    // Reset to default
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_unknownBundle_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/nonexistent-bundle/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message", notNullValue()));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_unknownRole_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/UnknownRole/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message", notNullValue()));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void setTrustFrameworkRoleEnabled_missingEnabledParam_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void setTrustFrameworkRoleEnabled_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void setTrustFrameworkRoleEnabled_wrongRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .put("/admin/trust-frameworks/gaia-x-2511/roles/Participant/enabled")
+            .param("enabled", "true")
+            .with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void getTrustFrameworks_includesBundlesField() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].bundles", hasSize(1)))
+        .andExpect(jsonPath("$[0].bundles[0].id").value("gaia-x-2511"))
+        .andExpect(jsonPath("$[0].bundles[0].roles.Participant").value(true))
+        .andExpect(jsonPath("$[0].bundles[0].roles.ServiceOffering").value(true))
+        .andExpect(jsonPath("$[0].bundles[0].roles.Resource").value(true));
   }
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/listener/TrustFrameworkStartupLoggerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/listener/TrustFrameworkStartupLoggerTest.java
@@ -48,7 +48,7 @@ class TrustFrameworkStartupLoggerTest {
 
     assertThat(output.getAll())
         .contains("trust-framework 'gaia-x' registered (profiles: gaia-x-2511) — disabled.")
-        .contains("PUT /admin/trust-frameworks/gaia-x/enabled?enabled=true")
+        .contains("PATCH /admin/trust-frameworks/gaia-x with body {\"enabled\":true}")
         .contains("FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS=gaia-x");
   }
 

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphDatabaseAdminServiceTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphDatabaseAdminServiceTest.java
@@ -1,0 +1,63 @@
+package eu.xfsc.fc.server.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import eu.xfsc.fc.api.generated.model.SwitchGraphDatabaseRequest;
+import eu.xfsc.fc.core.dao.adminconfig.AdminConfigEntry;
+import eu.xfsc.fc.core.dao.adminconfig.AdminConfigRepository;
+import eu.xfsc.fc.core.pojo.GraphBackendType;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.server.service.graphdb.RoutingGraphStore;
+
+/**
+ * Unit tests for {@link GraphDatabaseAdminService}. Focused on the order of
+ * persist-vs-swap on the switch path — persisting a preference for a backend whose
+ * live swap then fails would trap the next cold boot, so save must not happen unless
+ * the swap succeeded.
+ */
+@ExtendWith(MockitoExtension.class)
+class GraphDatabaseAdminServiceTest {
+
+  @Mock
+  private GraphStore graphStore;
+  @Mock
+  private AssetStore assetStore;
+  @Mock
+  private AdminConfigRepository adminConfigRepository;
+  @Mock
+  private GraphStoreProbe graphStoreProbe;
+  @Mock
+  private RoutingGraphStore routingGraphStore;
+
+  @InjectMocks
+  private GraphDatabaseAdminService service;
+
+  @Test
+  void switchGraphDatabase_setActiveThrows_doesNotPersistPreference() {
+    when(graphStoreProbe.probe(GraphBackendType.NEO4J))
+        .thenReturn(GraphStoreProbe.Result.reachable("ok"));
+    RuntimeException swapFailure = new IllegalArgumentException("No adapter for NEO4J");
+    org.mockito.Mockito.doThrow(swapFailure).when(routingGraphStore).setActive(GraphBackendType.NEO4J);
+
+    SwitchGraphDatabaseRequest request = new SwitchGraphDatabaseRequest();
+    request.setBackend("NEO4J");
+
+    RuntimeException thrown = assertThrows(RuntimeException.class,
+        () -> service.switchGraphDatabase(request));
+    assertEquals(swapFailure, thrown);
+
+    verify(adminConfigRepository, never()).save(any(AdminConfigEntry.class));
+  }
+}

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphStoreProbeTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/GraphStoreProbeTest.java
@@ -1,0 +1,40 @@
+package eu.xfsc.fc.server.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.Test;
+
+import eu.xfsc.fc.core.pojo.GraphBackendType;
+
+/**
+ * Unit tests for {@link GraphStoreProbe}.
+ *
+ * <p>Probes must honor the class-level timeout budget for any backend — including the
+ * Neo4j Bolt path. A black-holed host (non-routable IP) would otherwise stall on the
+ * OS-level connect timeout (tens of seconds on Linux) and trap callers that assume the
+ * configured budget.
+ */
+class GraphStoreProbeTest {
+
+  // Non-routable IP (RFC 1918 unused range), guaranteed to silently drop SYNs locally.
+  // Picking a port that no Bolt listener uses; the connect must time out, not refuse.
+  private static final String BLACKHOLE_BOLT_URI = "bolt://10.255.255.1:7687";
+  private static final Duration BUDGET_PLUS_SLACK = Duration.ofSeconds(8);
+
+  @Test
+  void probe_blackHoledNeo4jHost_failsWithinTimeoutBudget() {
+    GraphStoreProbe probe = new GraphStoreProbe(BLACKHOLE_BOLT_URI, "", "", "");
+
+    Instant before = Instant.now();
+    GraphStoreProbe.Result result = probe.probe(GraphBackendType.NEO4J);
+    Duration elapsed = Duration.between(before, Instant.now());
+
+    assertFalse(result.reachable(), "black-holed host must be reported unreachable");
+    assertTrue(elapsed.compareTo(BUDGET_PLUS_SLACK) < 0,
+        "Neo4j probe must fail within " + BUDGET_PLUS_SLACK + " but took " + elapsed);
+  }
+}

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/graphdb/RoutingGraphStoreTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/graphdb/RoutingGraphStoreTest.java
@@ -1,0 +1,91 @@
+package eu.xfsc.fc.server.service.graphdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import eu.xfsc.fc.core.dao.adminconfig.AdminConfigRepository;
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.GraphBackendType;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+
+/**
+ * Unit tests for {@link RoutingGraphStore#setActive(GraphBackendType)}.
+ *
+ * <p>The runtime build always loads both Neo4j and Fuseki adapter modules
+ * unconditionally so a backend switch can happen without a JVM restart. That makes
+ * the "no adapter registered" branch of {@code setActive} unreachable via Spring
+ * wiring alone, so it is verified here against an in-process instance that omits
+ * the relevant adapter.
+ */
+class RoutingGraphStoreTest {
+
+  private AdminConfigRepository adminConfigRepository;
+
+  @BeforeEach
+  void setUp() {
+    adminConfigRepository = mock(AdminConfigRepository.class);
+    when(adminConfigRepository.getValue(RoutingGraphStore.KEY_PREFERRED_BACKEND))
+        .thenReturn(Optional.empty());
+  }
+
+  @Test
+  void setActive_targetWithoutRegisteredAdapter_throwsClientException() {
+    GraphStore fuseki = adapterReturning(GraphBackendType.FUSEKI);
+    GraphStore none = adapterReturning(GraphBackendType.NONE);
+    RoutingGraphStore routing = newRoutingStore(List.of(fuseki, none), "fuseki");
+
+    assertThatThrownBy(() -> routing.setActive(GraphBackendType.NEO4J))
+        .isInstanceOf(ClientException.class)
+        .hasMessageContaining("NEO4J")
+        .hasMessageContaining("no adapter registered");
+  }
+
+  @Test
+  void setActive_targetWithoutRegisteredAdapter_leavesActiveBackendUnchanged() {
+    GraphStore fuseki = adapterReturning(GraphBackendType.FUSEKI);
+    GraphStore none = adapterReturning(GraphBackendType.NONE);
+    RoutingGraphStore routing = newRoutingStore(List.of(fuseki, none), "fuseki");
+
+    assertThat(routing.getBackendType()).isEqualTo(GraphBackendType.FUSEKI);
+
+    assertThatThrownBy(() -> routing.setActive(GraphBackendType.NEO4J))
+        .isInstanceOf(ClientException.class);
+
+    assertThat(routing.getBackendType()).isEqualTo(GraphBackendType.FUSEKI);
+  }
+
+  @Test
+  void setActive_targetWithRegisteredAdapter_swapsActiveBackend() {
+    GraphStore fuseki = adapterReturning(GraphBackendType.FUSEKI);
+    GraphStore none = adapterReturning(GraphBackendType.NONE);
+    RoutingGraphStore routing = newRoutingStore(List.of(fuseki, none), "none");
+
+    assertThat(routing.getBackendType()).isEqualTo(GraphBackendType.NONE);
+
+    routing.setActive(GraphBackendType.FUSEKI);
+
+    assertThat(routing.getBackendType()).isEqualTo(GraphBackendType.FUSEKI);
+  }
+
+  private RoutingGraphStore newRoutingStore(List<GraphStore> adapters, String envBackend) {
+    RoutingGraphStore routing = new RoutingGraphStore(adapters, adminConfigRepository);
+    ReflectionTestUtils.setField(routing, "envBackendName", envBackend);
+    routing.initialize();
+    return routing;
+  }
+
+  private static GraphStore adapterReturning(GraphBackendType type) {
+    GraphStore stub = mock(GraphStore.class);
+    when(stub.getBackendType()).thenReturn(type);
+    return stub;
+  }
+}

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -684,6 +684,22 @@ components:
         enabled:
           type: boolean
           description: Whether this framework is active
+        bundles:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrustFrameworkBundleEntry'
+          description: Per-bundle role states for this trust framework family.
+    TrustFrameworkBundleEntry:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Bundle profile ID (e.g. gaia-x-2511)
+        roles:
+          type: object
+          additionalProperties:
+            type: boolean
+          description: Per-role enabled state for this bundle, keyed by role name.
     TrustFrameworkConfigUpdate:
       type: object
       properties:
@@ -1331,6 +1347,43 @@ paths:
       responses:
         '200':
           description: Framework enabled state updated
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /admin/trust-frameworks/{bundleId}/roles/{roleName}/enabled:
+    put:
+      tags:
+        - TrustFrameworkAdmin
+      summary: Toggle a single role's enabled state within a trust-framework bundle
+      operationId: setTrustFrameworkRoleEnabled
+      security:
+        - jwt: []
+      parameters:
+        - name: bundleId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: roleName
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: enabled
+          in: query
+          required: true
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Role enabled state updated
+        '400':
+          $ref: '#/components/responses/ClientError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -700,18 +700,53 @@ components:
           additionalProperties:
             type: boolean
           description: Per-role enabled state for this bundle, keyed by role name.
-    TrustFrameworkConfigUpdate:
+    TrustFrameworkPatch:
       type: object
+      description: >-
+        Merge-patch body for PATCH /admin/trust-frameworks/{id}. At least one field
+        must be present. Only the supplied fields are modified; absent fields are
+        left unchanged.
+      minProperties: 1
+      additionalProperties: false
       properties:
+        enabled:
+          type: boolean
+          description: Desired enabled state of the trust framework family.
         serviceUrl:
           type: string
-          description: New service URL
+          description: New compliance service URL.
         apiVersion:
           type: string
-          description: New API version
+          description: New API version string.
         timeoutSeconds:
           type: integer
-          description: New timeout in seconds
+          description: Connection timeout in seconds.
+          minimum: 1
+          maximum: 300
+    SchemaModulePatch:
+      type: object
+      description: >-
+        Merge-patch body for PATCH /admin/schema-validation/modules/{type}. At least
+        one field must be present. Only the supplied fields are modified; absent fields
+        are left unchanged.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        enabled:
+          type: boolean
+          description: Desired enabled state of the schema validation module.
+    TrustFrameworkRolePatch:
+      type: object
+      description: >-
+        Merge-patch body for PATCH /admin/trust-frameworks/{bundleId}/roles/{roleName}.
+        At least one field must be present. Only the supplied fields are modified;
+        absent fields are left unchanged.
+      minProperties: 1
+      additionalProperties: false
+      properties:
+        enabled:
+          type: boolean
+          description: Desired enabled state of the role within the bundle.
     SchemaValidationStatus:
       type: object
       properties:
@@ -1337,12 +1372,17 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/ServerError'
-  /admin/trust-frameworks/{id}/enabled:
-    put:
+  /admin/trust-frameworks/{id}:
+    patch:
       tags:
         - TrustFrameworkAdmin
-      summary: Toggle a trust framework's enabled state
-      operationId: setTrustFrameworkEnabled
+      summary: Partially update a trust framework
+      description: >-
+        Applies a merge-patch to the identified trust framework. Only the fields
+        present in the request body are modified; absent fields are left unchanged.
+        At least one field must be supplied (minProperties: 1). Unknown fields are
+        rejected (additionalProperties: false).
+      operationId: patchTrustFramework
       security:
         - jwt: []
       parameters:
@@ -1351,14 +1391,17 @@ paths:
           required: true
           schema:
             type: string
-        - name: enabled
-          in: query
-          required: true
-          schema:
-            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/TrustFrameworkPatch'
       responses:
         '200':
-          description: Framework enabled state updated
+          description: Trust framework updated
+        '400':
+          $ref: '#/components/responses/ClientError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1367,12 +1410,15 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /admin/trust-frameworks/{bundleId}/roles/{roleName}/enabled:
-    put:
+  /admin/trust-frameworks/{bundleId}/roles/{roleName}:
+    patch:
       tags:
         - TrustFrameworkAdmin
-      summary: Toggle a single role's enabled state within a trust-framework bundle
-      operationId: setTrustFrameworkRoleEnabled
+      summary: Merge-patch a single role within a trust-framework bundle
+      description: >-
+        Merge-patch semantics (RFC 7396): only fields present in the body are modified.
+        At least one field must be present.
+      operationId: patchTrustFrameworkRole
       security:
         - jwt: []
       parameters:
@@ -1386,47 +1432,17 @@ paths:
           required: true
           schema:
             type: string
-        - name: enabled
-          in: query
-          required: true
-          schema:
-            type: boolean
-      responses:
-        '200':
-          description: Role enabled state updated
-        '400':
-          $ref: '#/components/responses/ClientError'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '403':
-          $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /admin/trust-frameworks/{id}:
-    put:
-      tags:
-        - TrustFrameworkAdmin
-      summary: Update a trust framework's configuration
-      operationId: updateTrustFrameworkConfig
-      security:
-        - jwt: []
-      parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
       requestBody:
         required: true
         content:
-          application/json:
+          application/merge-patch+json:
             schema:
-              $ref: '#/components/schemas/TrustFrameworkConfigUpdate'
+              $ref: '#/components/schemas/TrustFrameworkRolePatch'
       responses:
         '200':
-          description: Framework configuration updated
+          description: Role state updated
+        '400':
+          $ref: '#/components/responses/ClientError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -1457,16 +1473,17 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
   /admin/schema-validation/modules/{type}:
-    put:
+    patch:
       tags:
         - SchemaValidationAdmin
-      summary: Toggle a schema validation module
+      summary: Partially update a schema validation module
       description: >-
-        Enables or disables one of the four schema validation modules.
-        Disabling a module makes affected endpoints return `400 module_disabled:<MODULE>`
-        (see `/assets/validate` and `/verification`). Storage of schemas is unaffected —
-        stored schemas remain queryable through `/schemas/**` regardless of toggle state.
-      operationId: setSchemaModuleEnabled
+        Applies a merge-patch to the identified schema validation module. Only the
+        fields present in the request body are modified. Disabling a module makes
+        affected endpoints return `400 module_disabled:<MODULE>` (see `/assets/validate`
+        and `/verification`). Storage of schemas is unaffected — stored schemas remain
+        queryable through `/schemas/**` regardless of toggle state.
+      operationId: patchSchemaModule
       security:
         - jwt: []
       parameters:
@@ -1480,20 +1497,21 @@ paths:
               - JSON_SCHEMA
               - XML_SCHEMA
               - OWL
-        - name: enabled
-          in: query
-          required: true
-          schema:
-            type: boolean
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              $ref: '#/components/schemas/SchemaModulePatch'
       responses:
         '200':
-          description: Module enabled state updated
+          description: Module updated
+        '400':
+          $ref: '#/components/responses/ClientError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
-        '400':
-          $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/ServerError'
   /admin/schema-validation/ontologies:
@@ -1507,7 +1525,7 @@ paths:
         contributes to each registered trust-framework role (Participant,
         ServiceOffering, Resource for the Gaia-X 2511 bundle). Read-only —
         admins toggle the OWL module as a whole on
-        `PUT /admin/schema-validation/modules/{type}`. This endpoint surfaces
+        `PATCH /admin/schema-validation/modules/{type}`. This endpoint surfaces
         what that toggle is gating.
       operationId: getOntologyImpact
       security:

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -824,15 +824,27 @@ components:
         version:
           type: string
           description: Graph database version or implementation info
+        rebuildNeeded:
+          type: boolean
+          description: |
+            True when the active graph store has no claims but RDF assets exist in
+            storage — typical after a backend switch or fresh start. The admin UI
+            surfaces a rebuild prompt that calls `POST /admin/graph/rebuild`. Non-RDF
+            assets are excluded from this check because they do not produce graph
+            claims even after a successful rebuild.
+        rdfAssetCount:
+          type: integer
+          format: int64
+          description: |
+            Number of active RDF assets in storage that would be re-indexed by a
+            rebuild. Surfaced alongside `rebuildNeeded` so the UI can show how many
+            assets the rebuild will process.
     GraphDatabaseSwitchResult:
       type: object
       properties:
-        restartRequired:
-          type: boolean
-          description: Whether a restart is needed for the switch to take effect
         message:
           type: string
-          description: Human-readable status message
+          description: Human-readable status message describing the live switch result
 
     StoredValidationResult:
       type: object
@@ -1538,7 +1550,17 @@ paths:
     post:
       tags:
         - GraphDatabaseAdmin
-      summary: Switch the graph database backend (requires restart)
+      summary: Switch the graph database backend
+      description: |
+        Performs a live in-process swap to the target backend and persists the
+        choice to `admin_config[graphstore.preferred.backend]` so the same backend
+        is reactivated on the next cold boot.
+
+        The target backend is pre-flighted before either the swap or the persist:
+        if the configured URI for that backend is unreachable, the request is
+        rejected with `400 Bad Request` and a message describing what to fix. The
+        active adapter and the persisted preference are both left untouched on
+        rejection.
       operationId: switchGraphDatabase
       security:
         - jwt: []
@@ -1562,7 +1584,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/GraphDatabaseSwitchResult'
         '400':
-          $ref: '#/components/responses/BadRequest'
+          description: |
+            Invalid backend value, or target backend is unreachable. The response
+            body's `message` field carries the specific reason (probe failure
+            message for unreachable targets, list of valid values for invalid
+            input).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,17 @@
                 <version>${okhttp.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Pin commons-io so that commons-compress (pulled in by Zonky embedded-postgres)
+                 resolves IOUtils.skip(InputStream, long, Supplier) at runtime.
+                 TODO: drop this pin once Zonky is bumped — embedded-postgres 2.2.x already
+                 declares commons-io 2.21.0 / commons-compress 1.28.0. Bump
+                 embedded-postgres + embedded-database-spring-test together
+                 (latest are 2.2.2 and 2.7.1/2.8.0 respectively) in May 2026. -->
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.19.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## 🚀 Summary

Implements (CAT-FR-CO-03, Teil 3/3): admin UI for trust frameworks. 

> for external trust frameworks as specified in CAT-FR-CO-03: enabling/disabling
implemented trust framework client modules; configuring their unique identifiers,

Reworks the family-level enable/disable endpoint from a query parameter to a JSON body (`{"enabled": <bool>}`), restructures the admin page to a four-column table (Name, Family ID, Profiles, Active) with dynamic binding from `GET /admin/trust-frameworks`, and removes the legacy service-URL column and non-effective configuration modal. 

Adds a `mock` trust-framework seed row (enabled=false) so the SRS verification step is reachable through the UI without portal-code changes. Includes a fix to the demo-portal proxy and `AdminClient` so the new request shape is forwarded end-to-end.

This change is part of the Enhancement of XFSC Federated Catalogue. Details can be found here (permalink):
https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

Not yet implemented: "configuring their unique identifiers". The incomplete implementation was removed in this PR to have a clean slate first.

## ✅ What's Changed

Removes dead configuration code for the trust framework bundle config, as the configuration stored but never evaluated/read. 

Fixes Error for Trust Framework Role/BaseClass toggles.

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

1. Build and start the catalogue stack (`docker/dev.sh` or `mvn spring-boot:run` for fc-service-server + fc-demo-portal).
2. Log in to the demo portal as a user with the `Ro-MU-CA` admin role and navigate to **Admin → Trust Frameworks**.
3. Verify the table shows two rows — `gaia-x` and `mock` — both with `Active=false`, with a `Profiles` column listing `gaia-x-2511` and `mock-2026` respectively. Confirm there is no Service-URL column and no gear/config button.
4. Toggle the `mock` row to active. Observe in the network panel a `PUT /admin/trust-frameworks/mock/enabled` with `Content-Type: application/json` and body `{"enabled":true}` returning 200. Refresh and confirm the toggle persists.
5. Toggle it back off and confirm the same JSON-body call shape with `{"enabled":false}`.
6. Negative path: with the dev tools, send `PUT /admin/trust-frameworks/mock/enabled` with no body — expect 400.
7. Run the test suite:
   ```bash
   mvn test -pl fc-service-server -Dtest=TrustFrameworkAdminControllerTest,TrustFrameworkStartupLoggerTest
   mvn test -pl fc-demo-portal -Dtest=AdminControllerTest
   ```

## 🔍 Related Issues

Related to #130
Was extracted to reduce scope of PR #128  .

## 📸 Screenshots (if applicable)

<img width="1288" height="587" alt="image" src="https://github.com/user-attachments/assets/6cf3c5bd-af45-40d9-97e5-71a3e4b309dd" />

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] I've updated documentation if necessary
- [x] My changes follow the project's coding style
