### PR TITLE
Dependency upgrade (CVE fixes)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -36,16 +36,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           lfs: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.target }}
           tags: |
@@ -66,7 +66,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push ${{ matrix.name }} image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: ${{ matrix.target }}

--- a/pom.xml
+++ b/pom.xml
@@ -452,10 +452,6 @@
                              requires an NVD API key (NVD_API_KEY / -Dnvd.api.key) and would otherwise fail
                              on NVD rate-limiting (HTTP 429) when no key is available. -->
                         <failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
-                        <suppressionFiles>
-                            <suppressionFile>${maven.multiModuleProjectDirectory}/owasp-suppressions.xml
-                            </suppressionFile>
-                        </suppressionFiles>
                         <nvdApiKey>${nvd.api.key}</nvdApiKey>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.7</version>
+        <version>3.5.14</version>
         <relativePath/>
     </parent>
     
@@ -67,9 +67,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- dependencies -->
-        <spring.version>6.2.12</spring.version>
-        <spring-boot.version>3.5.7</spring-boot.version>
-        <spring.security.version>6.5.6</spring.security.version>
+        <spring.version>6.2.18</spring.version>
+        <spring-boot.version>3.5.14</spring-boot.version>
+        <spring.security.version>6.5.10</spring.security.version>
         <springdoc.version>2.8.14</springdoc.version>
         <keycloak.version>26.0.3</keycloak.version>
         <liquibase.version>4.33.0</liquibase.version>
@@ -83,9 +83,9 @@
         <uni-resolver.version>0.51.0</uni-resolver.version>
         <titanium.version>1.7.0</titanium.version>
         <caffeine.version>3.2.3</caffeine.version>
-        <bcpkix-jdk18on.version>1.82</bcpkix-jdk18on.version>
+        <bcpkix-jdk18on.version>1.84</bcpkix-jdk18on.version>
         <jnats.version>2.23.0</jnats.version>
-        <jackson-bom.version>2.20.1</jackson-bom.version>
+        <jackson-bom.version>2.21.2</jackson-bom.version>
         <json-schema-validator.version>2.0.1</json-schema-validator.version>
         <!-- test libs -->
         <junit-platform.version>1.14.1</junit-platform.version>
@@ -98,9 +98,13 @@
         <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
         <tink.version>1.20.0</tink.version>
         <okhttp.version>5.3.0</okhttp.version>
+        <!-- CVE overrides beyond Spring Boot 3.5.14 BOM: newer patches close High/Critical CVEs. -->
+        <tomcat.version>10.1.55</tomcat.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <postgresql.version>42.7.11</postgresql.version>
+        <libthrift.version>0.23.0</libthrift.version>
         <!-- plugins -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-       <!-- <maven.compiler.proc>full</maven.compiler.proc>-->
         <plugin.jacoco.version>0.8.14</plugin.jacoco.version>
         <plugin.git-commit.version>4.9.10</plugin.git-commit.version>
         <plugin.openapi-generator.version>7.12.0</plugin.openapi-generator.version>
@@ -108,7 +112,11 @@
         <plugin.maven-license.version>2.4.0</plugin.maven-license.version>
         <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>
         <plugin.checkstyle.puppycrawl.version>10.3.1</plugin.checkstyle.puppycrawl.version>
-        <!-- repoositiry path -->
+        <plugin.dependency-check.version>12.2.2</plugin.dependency-check.version>
+        <!-- OWASP scan: CVSS threshold and NVD API key (supply via -Dnvd.api.key=... or NVD_API_KEY env in CI) -->
+        <dependency-check.failBuildOnCVSS>7</dependency-check.failBuildOnCVSS>
+        <nvd.api.key></nvd.api.key>
+        <!-- repository path -->
         <repository.path>eclipse/xfsc/cat/fc-service</repository.path>
         <!--jib-->
         <ci-registry>${env.HARBOR_HOST}/${env.HARBOR_PROJECT}</ci-registry>
@@ -382,11 +390,18 @@
                  TODO: drop this pin once Zonky is bumped — embedded-postgres 2.2.x already
                  declares commons-io 2.21.0 / commons-compress 1.28.0. Bump
                  embedded-postgres + embedded-database-spring-test together
-                 (latest are 2.2.2 and 2.7.1/2.8.0 respectively) in May 2026. -->
+                 (latest are 2.2.2 and 2.7.1/2.8.0 respectively). -->
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>2.19.0</version>
+            </dependency>
+            <!-- Override libthrift (transitive via Apache Jena 5.5.0) to close CVE-2026-43869
+                 (CVSS 7.3, TLS host-mismatch). Not managed by the Spring Boot BOM. -->
+            <dependency>
+                <groupId>org.apache.thrift</groupId>
+                <artifactId>libthrift</artifactId>
+                <version>${libthrift.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -432,6 +447,19 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
+                    <version>${plugin.dependency-check.version}</version>
+                    <configuration>
+                        <!-- Gate threshold for explicit manual runs (`mvn dependency-check:check`).
+                             NOT bound to the build lifecycle: the scan must never block CI, because it
+                             requires an NVD API key (NVD_API_KEY / -Dnvd.api.key) and would otherwise fail
+                             on NVD rate-limiting (HTTP 429) when no key is available. -->
+                        <failBuildOnCVSS>${dependency-check.failBuildOnCVSS}</failBuildOnCVSS>
+                        <suppressionFiles>
+                            <suppressionFile>${maven.multiModuleProjectDirectory}/owasp-suppressions.xml
+                            </suppressionFile>
+                        </suppressionFiles>
+                        <nvdApiKey>${nvd.api.key}</nvdApiKey>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.openapitools</groupId>
@@ -497,8 +525,6 @@
                     <emptyLineAfterHeader>true</emptyLineAfterHeader>
                     <outputDirectory>.</outputDirectory>
                     <thirdPartyFilename>THIRD-PARTY.txt</thirdPartyFilename>
-                    <!--fileTemplate>templates/third-party.ftl</fileTemplate-->
-                    <!--excludedArtifacts>dgc-lib</excludedArtifacts-->
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <junit-platform.version>1.14.1</junit-platform.version>
         <spring-cloud-contract-wiremock.version>4.3.0</spring-cloud-contract-wiremock.version>
         <security.test-addons.version>4.5.1</security.test-addons.version>
-        <embedded.postgres.version>2.1.1</embedded.postgres.version>
+        <embedded.postgres.version>2.2.2</embedded.postgres.version>
         <embedded.postgres.binaries.version>14.19.0</embedded.postgres.binaries.version>
-        <embedded.postgres.test.version>2.4.0</embedded.postgres.test.version>
+        <embedded.postgres.test.version>2.8.0</embedded.postgres.test.version>
         <jose4j.version>0.9.6</jose4j.version>
         <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
         <tink.version>1.20.0</tink.version>
@@ -384,17 +384,6 @@
                 <artifactId>mockwebserver</artifactId>
                 <version>${okhttp.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <!-- Pin commons-io so that commons-compress (pulled in by Zonky embedded-postgres)
-                 resolves IOUtils.skip(InputStream, long, Supplier) at runtime.
-                 TODO: drop this pin once Zonky is bumped — embedded-postgres 2.2.x already
-                 declares commons-io 2.21.0 / commons-compress 1.28.0. Bump
-                 embedded-postgres + embedded-database-spring-test together
-                 (latest are 2.2.2 and 2.7.1/2.8.0 respectively). -->
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>2.19.0</version>
             </dependency>
             <!-- Override libthrift (transitive via Apache Jena 5.5.0) to close CVE-2026-43869
                  (CVSS 7.3, TLS host-mismatch). Not managed by the Spring Boot BOM. -->

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,9 @@
         <netty.version>4.1.133.Final</netty.version>
         <postgresql.version>42.7.11</postgresql.version>
         <libthrift.version>0.23.0</libthrift.version>
+        <!-- plexus-utils (test-scope, transitive via spring-cloud-contract-wiremock -> maven-resolver):
+             pin to 3.6.1 to close CVE-2025-67030 (9.8, Expand.extractFile directory traversal). -->
+        <plexus-utils.version>3.6.1</plexus-utils.version>
         <!-- plugins -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <plugin.jacoco.version>0.8.14</plugin.jacoco.version>
@@ -391,6 +394,12 @@
                 <groupId>org.apache.thrift</groupId>
                 <artifactId>libthrift</artifactId>
                 <version>${libthrift.version}</version>
+            </dependency>
+            <!-- Override plexus-utils (test-scope transitive) to close CVE-2025-67030 (9.8). -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
 ## 🚀 Summary

  Remediate all in-scope High/Critical CVEs (CVSS ≥ 7.0) in the Maven dependency
  tree and modernise the dependency-security setup. Bumps Spring Boot 3.5.7 → 3.5.14
  (the parent BOM is the real lever — its version is a literal, not a property) and
  adds targeted `dependencyManagement` overrides for CVEs not yet closed by that BOM
  (tomcat 10.1.55, netty 4.1.133, postgresql 42.7.11, bcprov/bcpkix 1.84, libthrift
  0.23.0, plexus-utils 3.6.1). Also bumps the Zonky embedded-postgres test stack and
  drops the obsolete commons-io pin, and configures the OWASP dependency-check plugin
  (12.2.2) for manual runs only — deliberately not bound to the build lifecycle so a
  missing NVD API key cannot block CI. Neo4j-related and Spring Boot 4.x (major)
  upgrades are intentionally out of scope.

  ## ✅ What's: Changed

  - [x] Feature implemented / Bug fixed
  - [ ] Documentation updated (if needed)
  - [ ] Tests added or updated
  - [x] Code formatted and linted
  
  ## 🧪 How to Test

  1. `cd federated-catalogue && mvn clean verify` — full unit + integration suite
     must pass (validates the Spring Boot bump, the Zonky 2.2.2/2.8.0 upgrade, and
     removal of the commons-io pin).
  2. Generate an SBOM and scan it (key-less): `mvn org.cyclonedx:cyclonedx-maven-plugin:2.9.1:makeAggregateBom -DoutputFormat=json` then `grype sbom:target/bom.json` — expect **no in-scope High/Critical**;
  the only High remaining is `http2-common 10.0.20` via `neo4j-server` (out of scope).
  3. Optional formal scan (needs `NVD_API_KEY`): `NVD_API_KEY=… mvn dependency-check:check` — confirms 0 findings ≥ CVSS 7.0.
  4. Confirm CI is not gated: `mvn verify` does not invoke dependency-check (plugin is not bound to the `verify` phase).

  ## 🔍 Related Issues
  
Related to #40, #43, #99, #100, #101, #102, #103

  <!-- Not a UI change -->

  ## 📋 Checklist

  - [ ] I've tested my code locally
  - [ ] I've added tests if needed
  - [ ] I've updated documentation if necessary
  - [ ] My changes follow the project's coding style