### PR TITLE
feat(CAT-FR-GD-01): unwrap JWT-secured credentials on the graph rebuild

### DIFF
--- a/deployment/helm/fc-service/README.md
+++ b/deployment/helm/fc-service/README.md
@@ -77,7 +77,7 @@ kubectl apply -f deployment/cert-manager/clusterissuer.yaml
 
 ### 5. Create namespace and out-of-band secrets
 
-The Keycloak OAuth2 client secret is not managed by Helm. Its value must match the `secret` field of the `fc-service` client in `gaia-x-realm.json` (currently `**********`):
+The Keycloak OAuth2 client secret is not managed by Helm. Its value must match the `secret` field of the `federated-catalogue` client in `gaia-x-realm.json` (currently `**********`):
 
 ```bash
 kubectl create namespace federated-catalogue

--- a/docker/docker-compose.strict.yml
+++ b/docker/docker-compose.strict.yml
@@ -1,39 +1,19 @@
-# Strict verification overlay — enables signature, schema, and Gaia-X Trust Framework validation.
-# Also adds the mock compliance service (WireMock) for @uses.compliance-mock BDD scenarios.
+# Strict verification overlay — turns ON the verification flags only (schema + signatures).
+#
+# Per ADR-003, this overlay overrides *only* the env vars that differ from the base compose.
+# The mock trust framework, the compliance-mock WireMock stub, and the trustframeworks
+# override mount now live in the base docker-compose.yml (they are config-agnostic and used
+# by @cfg.default discovery/compliance scenarios), so they are NOT repeated here.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.strict.yml --env-file dev.env up
 #   ./dev.sh strict
 #
-# BDD tests: set CAT_WIREMOCK_HOST=http://localhost:8089 in env.sh.
-#
 # See: cat-integration-tests/docs/adr/003-interim-two-config-test-strategy.md
 
 services:
-  compliance-mock:
-    container_name: "compliance-mock"
-    image: wiremock/wiremock:3.13.2
-    networks:
-      - "gaia-x"
-    ports:
-      # 8089 on host to avoid conflict with Keycloak (8080).
-      # BDD tests reach WireMock admin API at http://localhost:8089.
-      - "8089:8080"
-
   server:
     environment:
-      # Enable gaia-x and mock trust frameworks.
-      FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS: "gaia-x,mock"
       FEDERATED_CATALOGUE_VERIFICATION_SCHEMA: "true"
       FEDERATED_CATALOGUE_VERIFICATION_VP_SIGNATURE: "true"
       FEDERATED_CATALOGUE_VERIFICATION_VC_SIGNATURE: "true"
-      # Mount the trustframeworks directory as the filesystem override source.
-      # Bundles here override classpath bundles by id (e.g. redirecting URLs to local services).
-      FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH: /app/trustframeworks-override
-    volumes:
-      # Mount all bundle subdirectories as the override directory.
-      # Each subdirectory (e.g. mock-2026/, gaia-x-2511/) overrides the matching classpath bundle by id.
-      - ./trustframeworks:/app/trustframeworks-override:ro
-    depends_on:
-      compliance-mock:
-        condition: service_started

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -143,6 +143,20 @@ services:
           - did-server
     restart: unless-stopped
 
+  # Mock GXDCH compliance service (WireMock) backing the mock-2026 trust-framework bundle.
+  # The mock-2026 filesystem override (mounted on server) points service_url here, so
+  # @uses.compliance-mock BDD scenarios drive compliance checks against a stub instead of a
+  # live GXDCH operator. Idle unless a compliance check runs.
+  compliance-mock:
+    container_name: "compliance-mock"
+    image: wiremock/wiremock:3.13.2
+    networks:
+      - "gaia-x"
+    ports:
+      # 8089 on host to avoid conflict with Keycloak (8080).
+      # BDD tests reach WireMock admin API at http://localhost:8089.
+      - "8089:8080"
+
   server:
     container_name: "fc-server"
 #    image: node-654e3bca7fbeeed18f81d7c7.ps-xaas.io/catalogue/fc-service-server:2.0.0
@@ -189,14 +203,16 @@ services:
       # Multiple families: comma-separated, e.g. "gaia-x,untp".
       FEDERATED_CATALOGUE_ENABLED_TRUST_FRAMEWORKS: "${ENABLED_TRUST_FRAMEWORKS:-}"
       FEDERATED_CATALOGUE_VERIFICATION_SCHEMA: "${VERIFY_SCHEMA:-false}"
-      # Per-framework verification config (e.g. trust anchor URL) is owned by the bundle's
-      # framework.yaml. To override the Loire trust anchor for test environments, mount a
-      # custom bundle directory at /app/trustframeworks/gaia-x-2511/.
+      # Filesystem bundle overrides (by id). The mock-2026 bundle here redirects its
+      # service_url to the compliance-mock container; gaia-x-2511 can override the trust anchor.
+      FEDERATED_CATALOGUE_TRUST_FRAMEWORKS_OVERRIDE_PATH: /app/trustframeworks-override
       JAVA_TOOL_OPTIONS: >-
         -Djavax.net.ssl.trustStore=/opt/certs/custom-cacerts
         -Djavax.net.ssl.trustStorePassword=changeit
     volumes:
       - ./certs/custom-cacerts:/opt/certs/custom-cacerts:ro
+      # Filesystem trust-framework bundle overrides (mock-2026 → compliance-mock, etc.).
+      - ./trustframeworks:/app/trustframeworks-override:ro
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://localhost:8081/actuator/health || exit 1
       interval: 30s
@@ -218,6 +234,8 @@ services:
       nats:
         condition: service_healthy
       did-server:
+        condition: service_started
+      compliance-mock:
         condition: service_started
   portal:
     container_name: "demo-portal"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     container_name: "neo4j"
     image: neo4j:5.18.0
     environment:
-      NEO4J_AUTH: "${GRAPH_STORE_USER}/${GRAPH_STORE_PASSWORD}"
+      NEO4J_AUTH: "${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-neo12345}"
       NEO4J_server_http_listen__address: :7474
       NEO4J_server_bolt_listen__address: :7687
       NEO4J_PLUGINS: '["apoc", "graph-data-science", "n10s"]'

--- a/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/config/ClientConfig.java
+++ b/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/config/ClientConfig.java
@@ -1,123 +1,135 @@
 package eu.xfsc.fc.demo.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import eu.xfsc.fc.api.FcMediaTypes;
+import eu.xfsc.fc.client.AdminClient;
+import eu.xfsc.fc.client.ParticipantClient;
+import eu.xfsc.fc.client.RoleClient;
+import eu.xfsc.fc.client.SessionClient;
+import eu.xfsc.fc.client.UserClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.http.codec.json.Jackson2JsonDecoder;
 import org.springframework.http.codec.json.Jackson2JsonEncoder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
-import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
-import org.springframework.security.oauth2.client.web.reactive.function.client.ServerOAuth2AuthorizedClientExchangeFilterFunction;
 import org.springframework.security.oauth2.client.web.reactive.function.client.ServletOAuth2AuthorizedClientExchangeFilterFunction;
-import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
 import org.springframework.web.reactive.function.client.WebClient;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-
-import eu.xfsc.fc.client.AdminClient;
-import eu.xfsc.fc.client.ParticipantClient;
-import eu.xfsc.fc.client.RoleClient;
-import eu.xfsc.fc.client.SessionClient;
-import eu.xfsc.fc.client.UserClient;
 
 /**
  * Defines additional configuration fot the web demo-application.
- * */
+ *
+ */
 @Configuration
 public class ClientConfig {
-    
+
   @Bean
-  public ParticipantClient participantClient(@Value("${federated-catalogue.base-uri}") final String baseUri, WebClient webClient) {
-      return new ParticipantClient(baseUri, webClient);
+  public ParticipantClient participantClient(@Value("${federated-catalogue.base-uri}") final String baseUri,
+                                             WebClient webClient) {
+    return new ParticipantClient(baseUri, webClient);
   }
 
   @Bean
   public RoleClient roleClient(@Value("${federated-catalogue.base-uri}") final String baseUri, WebClient webClient) {
-      return new RoleClient(baseUri, webClient);
+    return new RoleClient(baseUri, webClient);
   }
-  
+
   @Bean
-  public SessionClient sessionClient(@Value("${federated-catalogue.base-uri}") final String baseUri, WebClient webClient) {
-      return new SessionClient(baseUri, webClient);
+  public SessionClient sessionClient(@Value("${federated-catalogue.base-uri}") final String baseUri,
+                                     WebClient webClient) {
+    return new SessionClient(baseUri, webClient);
   }
-  
+
   @Bean
   public UserClient userClient(@Value("${federated-catalogue.base-uri}") final String baseUri, WebClient webClient) {
-      return new UserClient(baseUri, webClient);
+    return new UserClient(baseUri, webClient);
   }
 
   @Bean
   public AdminClient adminClient(@Value("${federated-catalogue.base-uri}") final String baseUri, WebClient webClient) {
-      return new AdminClient(baseUri, webClient);
+    return new AdminClient(baseUri, webClient);
   }
-  
+
   /**
    * Defines the web client bean used to connect to the Federated Catalogue Server.
    *
    * @param fcUri Federated Catalog URI.
-   */ 
+   */
   @Bean(name = "fcServer")
   public WebClient webClient(OAuth2AuthorizedClientManager authorizedClientManager,
-          @Value("${federated-catalogue.base-uri}") final String fcUri) {
-      
-      ObjectMapper mapper = new ObjectMapper()
-              //.findAndRegisterModules()   // 
-              .registerModule(new ParameterNamesModule())
-              .registerModule(new JavaTimeModule())
-              .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-      
-      ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2Client = new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
-      oauth2Client.setDefaultOAuth2AuthorizedClient(true);
-      //oauth2Client.setDefaultClientRegistrationId("fc-client-oidc");
+                             @Value("${federated-catalogue.base-uri}") final String fcUri) {
 
-      return WebClient.builder()
+    ObjectMapper mapper = new ObjectMapper()
+        //.findAndRegisterModules()   //
+        .registerModule(new ParameterNamesModule())
+        .registerModule(new JavaTimeModule())
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    ServletOAuth2AuthorizedClientExchangeFilterFunction oauth2Client =
+        new ServletOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager);
+    oauth2Client.setDefaultOAuth2AuthorizedClient(true);
+    //oauth2Client.setDefaultClientRegistrationId("fc-client-oidc");
+
+    return WebClient.builder()
         .apply(oauth2Client.oauth2Configuration())
         .baseUrl(fcUri)
-        .codecs(configurer -> {
-            configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(mapper, MediaType.APPLICATION_JSON));
-            configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(mapper, MediaType.APPLICATION_JSON));
-        })
+        .codecs(configurer -> configureFcCodecs(configurer, mapper))
         .defaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
         .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
         .build();
   }
-  
+
+  /**
+   * Registers Jackson JSON codecs for both {@code application/json} and
+   * {@code application/merge-patch+json}. The merge-patch media type is required by the admin
+   * API PATCH endpoints (RFC 7396); without it, body serialisation throws
+   * {@code UnsupportedMediaTypeException} before the request is dispatched.
+   */
+  static void configureFcCodecs(ClientCodecConfigurer configurer, ObjectMapper mapper) {
+    configurer.defaultCodecs().jackson2JsonEncoder(new Jackson2JsonEncoder(mapper,
+        MediaType.APPLICATION_JSON, FcMediaTypes.MERGE_PATCH_JSON));
+    configurer.defaultCodecs().jackson2JsonDecoder(new Jackson2JsonDecoder(mapper,
+        MediaType.APPLICATION_JSON, FcMediaTypes.MERGE_PATCH_JSON));
+  }
+
   //@Bean(name = "fcServer")
   //WebClient webClient(ReactiveClientRegistrationRepository clientRegistrations,
   //        ServerOAuth2AuthorizedClientRepository authorizedClients) {
   //    ServerOAuth2AuthorizedClientExchangeFilterFunction oauth =
   //            new ServerOAuth2AuthorizedClientExchangeFilterFunction(clientRegistrations, authorizedClients);
-      // (optional) explicitly opt into using the oauth2Login to provide an access token implicitly
-      // oauth.setDefaultOAuth2AuthorizedClient(true);
-      // (optional) set a default ClientRegistration.registrationId
-      // oauth.setDefaultClientRegistrationId("client-registration-id");
+  // (optional) explicitly opt into using the oauth2Login to provide an access token implicitly
+  // oauth.setDefaultOAuth2AuthorizedClient(true);
+  // (optional) set a default ClientRegistration.registrationId
+  // oauth.setDefaultClientRegistrationId("client-registration-id");
   //    return WebClient.builder()
   //            .filter(oauth)
   //            .build();
   //}  
-  
+
   @Bean
-  public OAuth2AuthorizedClientManager authorizedClientManager(ClientRegistrationRepository clientRegistrationRepository,
-          OAuth2AuthorizedClientRepository authorizedClientRepository) {
+  public OAuth2AuthorizedClientManager authorizedClientManager(
+      ClientRegistrationRepository clientRegistrationRepository,
+      OAuth2AuthorizedClientRepository authorizedClientRepository) {
 
-      OAuth2AuthorizedClientProvider authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
-          .authorizationCode()
-          .refreshToken()
-          .build();
-      DefaultOAuth2AuthorizedClientManager authorizedClientManager = new DefaultOAuth2AuthorizedClientManager(
+    OAuth2AuthorizedClientProvider authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
+        .authorizationCode()
+        .refreshToken()
+        .build();
+    DefaultOAuth2AuthorizedClientManager authorizedClientManager = new DefaultOAuth2AuthorizedClientManager(
         clientRegistrationRepository, authorizedClientRepository);
-      authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider);
 
-      return authorizedClientManager;
-  }  
+    return authorizedClientManager;
+  }
 }

--- a/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
+++ b/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
@@ -3,9 +3,9 @@ package eu.xfsc.fc.demo.controller;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,10 +21,10 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
 import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
-import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkRolePatch;
 import eu.xfsc.fc.client.AdminClient;
 import lombok.RequiredArgsConstructor;
 
@@ -89,6 +89,41 @@ public class AdminController {
     adminClient.patchTrustFramework(id, patch, authorizedClient);
   }
 
+  /**
+   * Partially update the external client configuration of a trust framework bundle using
+   * RFC 7396 merge-patch semantics.
+   */
+  @PatchMapping("/trust-frameworks/bundles/{bundleId}")
+  public void patchTrustFrameworkBundleConfig(
+      @PathVariable("bundleId") String bundleId,
+      @RequestBody Map<String, Object> patch,
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    adminClient.patchTrustFrameworkBundleConfig(bundleId, patch, authorizedClient);
+  }
+
+  /**
+   * Remove all persisted overrides for a trust framework bundle, restoring the bundle YAML
+   * as the sole source of compliance configuration.
+   */
+  @DeleteMapping("/trust-frameworks/bundles/{bundleId}")
+  public void deleteTrustFrameworkBundleConfig(
+      @PathVariable("bundleId") String bundleId,
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    adminClient.deleteTrustFrameworkBundleConfig(bundleId, authorizedClient);
+  }
+
+  /**
+   * Partially update a role within a trust framework bundle.
+   */
+  @PatchMapping("/trust-frameworks/{bundleId}/roles/{roleName}")
+  public void patchTrustFrameworkRole(
+      @PathVariable("bundleId") String bundleId,
+      @PathVariable("roleName") String roleName,
+      @RequestBody TrustFrameworkRolePatch patch,
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    adminClient.patchTrustFrameworkRole(bundleId, roleName, patch, authorizedClient);
+  }
+
   // --- Schema Validation ---
 
   /** Get schema validation module status. */
@@ -131,19 +166,5 @@ public class AdminController {
       @RequestBody Map<String, String> body,
       @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
     return adminClient.switchGraphDatabase(body.get("backend"), authorizedClient);
-  }
-
-  /** Trigger a graph rebuild over the current backend. */
-  @PostMapping("/graph/rebuild")
-  public ResponseEntity<RebuildStatus> triggerGraphRebuild(
-      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
-    return adminClient.triggerGraphRebuild(authorizedClient);
-  }
-
-  /** Poll graph rebuild progress. */
-  @GetMapping("/graph/rebuild/status")
-  public RebuildStatus getGraphRebuildStatus(
-      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
-    return adminClient.getGraphRebuildStatus(authorizedClient);
   }
 }

--- a/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
+++ b/fc-demo-portal/src/main/resources/static/js/admin-trust-frameworks.js
@@ -4,6 +4,14 @@ $(document).ready(function() {
   var TF_API_BASE     = '/admin/trust-frameworks';
   var MERGE_PATCH_JSON = 'application/merge-patch+json';
 
+  // Bundle override property keys — must match server-recognised merge-patch+json fields
+  var KEY_CLIENT_TYPE      = 'clientType';
+  var KEY_SERVICE_URL      = 'serviceUrl';
+  var KEY_COMPLIANCE_PATH  = 'compliancePath';
+  var KEY_API_VERSION      = 'apiVersion';
+  var KEY_TIMEOUT_SECONDS  = 'timeoutSeconds';
+  var KEY_TRUST_ANCHOR_URL = 'trustAnchorUrl';
+
   $.ajax({
     url: ADMIN_ME_URL,
     type: 'GET',
@@ -78,12 +86,22 @@ $(document).ready(function() {
           data: null,
           orderable: false,
           render: function(data) {
-            return $('<button>', { class: 'btn btn-sm btn-outline-secondary tf-roles' })
-              .attr('data-id',      data.id)
-              .attr('data-enabled', data.enabled ? 'true' : 'false')
-              .attr('data-bundles', JSON.stringify(data.bundles || []))
-              .append('<i class="bi bi-gear"></i>')
-              .prop('outerHTML');
+            var bundles = data.bundles || [];
+            if (bundles.length === 0) {
+              return '';
+            }
+            var familyEnabled = data.enabled ? 'true' : 'false';
+            return bundles.map(function(bundle) {
+              return $('<button>', { class: 'btn btn-sm btn-outline-secondary tf-bundle-configure me-1' })
+                .attr('data-bundle-id',         bundle.id)
+                .attr('data-family-enabled',    familyEnabled)
+                .attr('data-roles',             JSON.stringify(bundle.roles || {}))
+                .attr('data-effective-config', JSON.stringify(bundle.effectiveConfig || {}))
+                .attr('data-overridden',        JSON.stringify(bundle.overriddenFields || []))
+                .append('<i class="bi bi-gear"></i> ')
+                .append($('<small>').text(bundle.id))
+                .prop('outerHTML');
+            }).join('');
           }
         }
       ]
@@ -106,58 +124,49 @@ $(document).ready(function() {
       });
     });
 
-    $('#tfTable').on('click', '.tf-roles', function() {
-      var $btn = $(this);
-      var familyEnabled = $btn.data('enabled') === 'true' || $btn.data('enabled') === true;
-      var bundles = $btn.data('bundles') || [];
-      if (typeof bundles === 'string') {
-        try { bundles = JSON.parse(bundles); } catch (e) { bundles = []; }
+    function recomputeAllDisabledWarning(familyEnabled) {
+      if (!familyEnabled) {
+        $('#tfRolesAllDisabledWarning').hide();
+        return;
       }
+      var allUnchecked = $('#tfRolesContainer .tf-role-toggle:checked').length === 0
+        && $('#tfRolesContainer .tf-role-toggle').length > 0;
+      $('#tfRolesAllDisabledWarning').toggle(allUnchecked);
+    }
 
+    function renderBundleRoles(bundleId, familyEnabled, roles) {
       var $container = $('#tfRolesContainer').empty();
       $('#tfRoleErrorBanner').hide();
-      var multiBundle = bundles.length > 1;
-      bundles.forEach(function(bundle) {
-        var roles = bundle.roles || {};
-        Object.keys(roles).forEach(function(roleName) {
-          var roleEnabled = roles[roleName];
-          var inputId = 'role-' + bundle.id + '-' + roleName;
-          var $check = $('<div class="form-check">').append(
-            $('<input>', {
-              type: 'checkbox',
-              class: 'form-check-input tf-role-toggle',
-              id: inputId,
-              'data-bundle': bundle.id,
-              'data-role': roleName
-            })
-              .prop('checked', roleEnabled)
-              .prop('disabled', !familyEnabled),
-            $('<label>', {
-              class: 'form-check-label' + (!familyEnabled ? ' text-muted' : ''),
-              for: inputId,
-              title: 'When disabled, this role and all its OWL subclasses reject credentials with HTTP 400.',
-              'data-bs-toggle': 'tooltip'
-            }).append(
-              document.createTextNode(roleName + ' '),
-              multiBundle
-                ? $('<small class="text-muted">').text('(' + bundle.id + ')')
-                : $()
-            )
-          );
-          $container.append($check);
-        });
+      Object.keys(roles).forEach(function(roleName) {
+        var roleEnabled = roles[roleName];
+        var inputId = 'role-' + bundleId + '-' + roleName;
+        var $check = $('<div class="form-check">').append(
+          $('<input>', {
+            type: 'checkbox',
+            class: 'form-check-input tf-role-toggle',
+            id: inputId,
+            'data-bundle': bundleId,
+            'data-role': roleName
+          })
+            .prop('checked', roleEnabled)
+            .prop('disabled', !familyEnabled),
+          $('<label>', {
+            class: 'form-check-label' + (!familyEnabled ? ' text-muted' : ''),
+            for: inputId,
+            title: 'When disabled, this role and all its OWL subclasses reject credentials with HTTP 400.',
+            'data-bs-toggle': 'tooltip'
+          }).append(document.createTextNode(roleName)),
+          $('<span class="badge bg-success ms-2 tf-role-saved-badge" style="display:none">')
+            .text('✓ saved')
+        );
+        $container.append($check);
       });
-
       $container.find('[data-bs-toggle="tooltip"]').each(function() {
         new bootstrap.Tooltip(this);
       });
+    }
 
-      $('#tfConfigModal').data('familyEnabled', familyEnabled);
-      recomputeAllDisabledWarning(familyEnabled);
-      new bootstrap.Modal('#tfConfigModal').show();
-    });
-
-    $('#tfConfigModal').on('change', '.tf-role-toggle', function() {
+    $('#tfBundleConfigModal').on('change', '.tf-role-toggle', function() {
       var $cb = $(this);
       var bundleId = $cb.data('bundle');
       var roleName = $cb.data('role');
@@ -171,11 +180,19 @@ $(document).ready(function() {
         data: JSON.stringify({enabled: enabled}),
         success: function() {
           $('#tfRoleErrorBanner').hide();
-          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+          recomputeAllDisabledWarning($('#tfBundleConfigModal').data('familyEnabled'));
+          // Flash a "✓ saved" badge next to this row so the operator sees the change
+          // committed (mirrors the deferred-Save affordance of the config fields above).
+          var $badge = $cb.closest('.form-check').find('.tf-role-saved-badge');
+          clearTimeout($badge.data('hideTimer'));
+          $badge.stop(true, true).show().css('opacity', 1);
+          $badge.data('hideTimer', setTimeout(function() {
+            $badge.fadeOut(400);
+          }, 1500));
         },
         error: function() {
           $cb.prop('checked', !enabled);
-          recomputeAllDisabledWarning($('#tfConfigModal').data('familyEnabled'));
+          recomputeAllDisabledWarning($('#tfBundleConfigModal').data('familyEnabled'));
           var $banner = $('#tfRoleErrorBanner');
           $banner.text('Failed to update role "' + roleName + '". Please try again.').show();
           clearTimeout($banner.data('hideTimer'));
@@ -184,15 +201,199 @@ $(document).ready(function() {
       });
     });
 
-    function recomputeAllDisabledWarning(familyEnabled) {
-      if (!familyEnabled) {
-        $('#tfRolesAllDisabledWarning').hide();
+    // ── Bundle client-config modal ──────────────────────────────────────────
+
+    // Set of field IDs that have been explicitly marked "clear" (→ null in PATCH body).
+    var tfBundleClearedFields = {};
+
+    function parseJsonAttr(value, fallback) {
+      if (typeof value !== 'string') {
+        return value == null ? fallback : value;
+      }
+      try { return JSON.parse(value); } catch (e) { return fallback; }
+    }
+
+    function renderBundleEffectiveConfig(effective, overridden) {
+      // Show effective values; mark fields whose value comes from a persisted override.
+      $('.tf-bundle-field').each(function() {
+        var $field = $(this);
+        var key = $field.data('key');
+        var value = effective[key];
+        if (value === undefined || value === null) {
+          $field.val('').attr('placeholder', '');
+        } else {
+          $field.val(value).attr('placeholder', '');
+        }
+      });
+      $('.tf-bundle-field').removeClass('border-primary');
+      $('.tf-bundle-clear').removeClass('btn-warning');
+      (overridden || []).forEach(function(key) {
+        var $field = $('.tf-bundle-field[data-key="' + key + '"]');
+        $field.addClass('border-primary');
+        var $btn = $('.tf-bundle-clear[data-target="' + $field.attr('id') + '"]');
+        $btn.addClass('btn-warning').removeClass('btn-outline-secondary');
+      });
+    }
+
+    // Snapshot of the effective values shown when the modal was opened, used to
+    // detect which fields the operator actually changed so a no-op Save does not
+    // accidentally promote YAML defaults to persisted overrides.
+    var tfBundleInitialValues = {};
+
+    $('#tfTable').on('click', '.tf-bundle-configure', function() {
+      var $btn = $(this);
+      var bundleId = $btn.data('bundle-id');
+      var familyEnabled = $btn.data('family-enabled') === 'true' || $btn.data('family-enabled') === true;
+      var roles = parseJsonAttr($btn.data('roles'), {});
+      var effective = parseJsonAttr($btn.data('effective-config'), {});
+      var overridden = parseJsonAttr($btn.data('overridden'), []);
+
+      $('#tfBundleConfigModalBundleId').text(bundleId);
+      $('#tfBundleConfigModal').data('bundleId', bundleId);
+      $('#tfBundleConfigModal').data('familyEnabled', familyEnabled);
+
+      // Reset cleared-field state, then populate from the row's effective config.
+      tfBundleClearedFields = {};
+      tfBundleInitialValues = {};
+      $('.tf-bundle-field').removeClass('tf-field-cleared').prop('disabled', false);
+      $('.tf-bundle-clear').removeClass('btn-danger').addClass('btn-outline-secondary');
+      $('#tfBundleConfigErrorBanner').hide();
+      renderBundleEffectiveConfig(effective, overridden);
+      // Snapshot the values shown so Save can detect what changed.
+      // Stored as strings so the Save comparison is type-safe across all input types.
+      $('.tf-bundle-field').each(function() {
+        var $f = $(this);
+        var v = $f.val();
+        tfBundleInitialValues[$f.data('key')] = $.trim(String(v == null ? '' : v));
+      });
+
+      // Populate the roles section
+      renderBundleRoles(bundleId, familyEnabled, roles);
+      recomputeAllDisabledWarning(familyEnabled);
+
+      new bootstrap.Modal('#tfBundleConfigModal').show();
+    });
+
+    // ✕ button: toggle "explicitly clear" (Save will send null for this field).
+    // Click again to un-mark — restores the field for editing without re-opening the modal.
+    $('#tfBundleConfigModal').on('click', '.tf-bundle-clear', function() {
+      var $btn = $(this);
+      var targetId = $btn.data('target');
+      var $field = $('#' + targetId);
+      var key = $field.data('key');
+
+      if (tfBundleClearedFields[key]) {
+        // Un-clear: restore initial value and editability.
+        delete tfBundleClearedFields[key];
+        $field
+          .removeClass('tf-field-cleared')
+          .prop('disabled', false)
+          .val(tfBundleInitialValues[key] || '');
+        $btn.removeClass('btn-danger').addClass('btn-outline-secondary');
+      } else {
+        tfBundleClearedFields[key] = true;
+        $field.val('').addClass('tf-field-cleared').prop('disabled', true);
+        $btn.removeClass('btn-outline-secondary btn-warning').addClass('btn-danger');
+      }
+    });
+
+    // Re-enable cleared field when modal is closed so it resets cleanly next open
+    $('#tfBundleConfigModal').on('hidden.bs.modal', function() {
+      tfBundleClearedFields = {};
+      $('.tf-bundle-field').prop('disabled', false).val('').removeClass('tf-field-cleared');
+      $('.tf-bundle-clear').removeClass('btn-danger').addClass('btn-outline-secondary');
+    });
+
+    $('#tfBundleConfigSave').on('click', function() {
+      var bundleId = $('#tfBundleConfigModal').data('bundleId');
+      if (!bundleId) { return; }
+
+      var payload = {};
+
+      // Fields explicitly cleared → null
+      var clearKeys = [
+        KEY_CLIENT_TYPE, KEY_SERVICE_URL, KEY_COMPLIANCE_PATH,
+        KEY_API_VERSION, KEY_TIMEOUT_SECONDS, KEY_TRUST_ANCHOR_URL
+      ];
+      clearKeys.forEach(function(k) {
+        if (tfBundleClearedFields[k]) {
+          payload[k] = null;
+        }
+      });
+
+      // Fields with a value → include only when the operator actually changed them
+      // (otherwise we would re-promote YAML defaults to overrides on every Save).
+      $('.tf-bundle-field').each(function() {
+        var $f = $(this);
+        var key = $f.data('key');
+        if (tfBundleClearedFields[key]) { return; } // already handled as null
+        var raw = $.trim(String($f.val() == null ? '' : $f.val()));
+        if (raw === '') { return; } // blank → omit (no-op)
+        var initial = String(tfBundleInitialValues[key] == null ? '' : tfBundleInitialValues[key]);
+        if (raw === initial) { return; } // unchanged → omit
+        payload[key] = (key === KEY_TIMEOUT_SECONDS) ? parseInt(raw, 10) : raw;
+      });
+
+      if (Object.keys(payload).length === 0) {
+        $('#tfBundleConfigErrorBanner').text('Nothing to save — fill in at least one field or mark one for clearing.').show();
         return;
       }
-      var allUnchecked = $('#tfRolesContainer .tf-role-toggle:checked').length === 0
-        && $('#tfRolesContainer .tf-role-toggle').length > 0;
-      $('#tfRolesAllDisabledWarning').toggle(allUnchecked);
-    }
+
+      $('#tfBundleConfigErrorBanner').hide();
+      $('#tfBundleConfigSave').prop('disabled', true);
+
+      fetch(TF_API_BASE + '/bundles/' + encodeURIComponent(bundleId), {
+        method: 'PATCH',
+        headers: { 'Content-Type': MERGE_PATCH_JSON },
+        body: JSON.stringify(payload)
+      })
+        .then(function(resp) {
+          if (resp.ok) {
+            $('#tfTable').DataTable().ajax.reload(null, false);
+            bootstrap.Modal.getInstance('#tfBundleConfigModal').hide();
+          } else {
+            return resp.json().then(function(err) {
+              var msg = (err && err.message) ? err.message : ('Server error ' + resp.status);
+              $('#tfBundleConfigErrorBanner').text(msg).show();
+            });
+          }
+        })
+        .catch(function() {
+          $('#tfBundleConfigErrorBanner').text('Network error — please try again.').show();
+        })
+        .finally(function() {
+          $('#tfBundleConfigSave').prop('disabled', false);
+        });
+    });
+
+    $('#tfBundleConfigRevertAll').on('click', function() {
+      var bundleId = $('#tfBundleConfigModal').data('bundleId');
+      if (!bundleId) { return; }
+
+      $('#tfBundleConfigErrorBanner').hide();
+      $('#tfBundleConfigRevertAll').prop('disabled', true);
+
+      fetch(TF_API_BASE + '/bundles/' + encodeURIComponent(bundleId), {
+        method: 'DELETE'
+      })
+        .then(function(resp) {
+          if (resp.ok) {
+            $('#tfTable').DataTable().ajax.reload(null, false);
+            bootstrap.Modal.getInstance('#tfBundleConfigModal').hide();
+          } else {
+            return resp.json().then(function(err) {
+              var msg = (err && err.message) ? err.message : ('Server error ' + resp.status);
+              $('#tfBundleConfigErrorBanner').text(msg).show();
+            });
+          }
+        })
+        .catch(function() {
+          $('#tfBundleConfigErrorBanner').text('Network error — please try again.').show();
+        })
+        .finally(function() {
+          $('#tfBundleConfigRevertAll').prop('disabled', false);
+        });
+    });
   }
 
 });

--- a/fc-demo-portal/src/main/resources/static/pages/admin/graphdb.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/graphdb.html
@@ -113,7 +113,7 @@
                     </div>
                     <div class="modal-body">
                         <p>The active graph has <strong id="modalClaimCount">-</strong> claims.
-                           Rebuild will re-index from active RDF assets and replace existing claims.</p>
+                            Rebuild will re-index from active RDF assets and replace existing claims.</p>
                         <p class="text-muted small mb-0">This can take time depending on asset count and backend.</p>
                     </div>
                     <div class="modal-footer">

--- a/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
+++ b/fc-demo-portal/src/main/resources/static/pages/admin/trust-frameworks.html
@@ -12,19 +12,113 @@
                 <th>Family ID</th>
                 <th>Profiles</th>
                 <th>Active</th>
-                <th>Roles</th>
+                <th>Config</th>
             </tr>
             </thead>
         </table>
 
-        <div class="modal" id="tfConfigModal" tabindex="-1">
-            <div class="modal-dialog">
+        <div class="modal" id="tfBundleConfigModal" tabindex="-1">
+            <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h5 class="modal-title">Trust Framework Roles</h5>
+                        <h5 class="modal-title">Bundle Client Configuration — <code
+                                id="tfBundleConfigModalBundleId"></code></h5>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
+                        <div id="tfBundleConfigErrorBanner" class="alert alert-danger" style="display:none"></div>
+                        <p class="text-muted small">
+                            Override the YAML-configured external client parameters for this bundle.
+                            Leave a field blank to leave it unchanged. Click <strong>✕</strong> to explicitly clear
+                            an override (reverts to YAML default). Click <strong>Revert all</strong> to clear every
+                            override at once.
+                        </p>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-clientType">Client type</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-clientType" data-key="clientType"
+                                       placeholder="e.g. gaia-x-registry">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-clientType" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-serviceUrl">Service URL</label>
+                            <div class="col-sm-8">
+                                <input type="url" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-serviceUrl" data-key="serviceUrl"
+                                       placeholder="https://compliance.example.org">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-serviceUrl" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-compliancePath">Compliance path</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-compliancePath" data-key="compliancePath"
+                                       placeholder="/api/v1/compliance">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-compliancePath" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-apiVersion">API version</label>
+                            <div class="col-sm-8">
+                                <input type="text" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-apiVersion" data-key="apiVersion"
+                                       placeholder="v1">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-apiVersion" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-timeoutSeconds">Timeout (s)</label>
+                            <div class="col-sm-8">
+                                <input type="number" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-timeoutSeconds" data-key="timeoutSeconds"
+                                       placeholder="30" min="1">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-timeoutSeconds" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+                        <div class="mb-3 row align-items-center">
+                            <label class="col-sm-3 col-form-label" for="tfbc-trustAnchorUrl">Trust anchor URL</label>
+                            <div class="col-sm-8">
+                                <input type="url" class="form-control form-control-sm tf-bundle-field"
+                                       id="tfbc-trustAnchorUrl" data-key="trustAnchorUrl"
+                                       placeholder="https://registry.example.org/trust-anchor">
+                            </div>
+                            <div class="col-sm-1 text-center">
+                                <button type="button" class="btn btn-sm btn-outline-secondary tf-bundle-clear"
+                                        data-target="tfbc-trustAnchorUrl" title="Clear override (revert to YAML)">✕
+                                </button>
+                            </div>
+                        </div>
+
+                        <hr class="my-4">
+
+                        <h6 class="mb-1">Roles</h6>
+                        <p class="text-muted small mb-3">
+                            Role toggles save immediately. The configuration fields above commit only when you press
+                            <strong>Save configuration</strong>.
+                        </p>
                         <div id="tfRoleErrorBanner" class="alert alert-danger" style="display:none"></div>
                         <div id="tfRolesAllDisabledWarning" class="alert alert-warning" style="display:none">
                             All roles are disabled — this bundle is enabled but cannot resolve any credentials.
@@ -32,7 +126,11 @@
                         <div id="tfRolesContainer"></div>
                     </div>
                     <div class="modal-footer">
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-outline-danger" id="tfBundleConfigRevertAll">Revert all
+                        </button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                        <button type="button" class="btn btn-primary" id="tfBundleConfigSave">Save configuration
+                        </button>
                     </div>
                 </div>
             </div>

--- a/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/config/ClientConfigCodecsTest.java
+++ b/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/config/ClientConfigCodecsTest.java
@@ -1,0 +1,73 @@
+package eu.xfsc.fc.demo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ClientCodecConfigurer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eu.xfsc.fc.api.FcMediaTypes;
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkRolePatch;
+
+/**
+ * Regression test for the portal WebClient codecs. The admin-API endpoints use the
+ * {@code application/merge-patch+json} media type (RFC 7396). The default
+ * {@link org.springframework.http.codec.json.Jackson2JsonEncoder} accepts only
+ * {@code application/json}, so issuing a PATCH with a merge-patch content-type fails with
+ * {@code UnsupportedMediaTypeException} at body serialisation before the request is
+ * dispatched. These tests pin {@link ClientConfig#configureFcCodecs} so a future refactor
+ * cannot regress the admin portal's PATCH proxy routes.
+ *
+ * <p>The check is performed directly against the configured codec writers (not through a
+ * stubbed {@code WebClient}, which short-circuits before body serialisation runs and so
+ * would silently pass even with the wrong codec list).
+ */
+class ClientConfigCodecsTest {
+
+  @Test
+  void configuredEncoder_writesTrustFrameworkPatch_underMergePatchJson() {
+    assertWritable(TrustFrameworkPatch.class);
+  }
+
+  @Test
+  void configuredEncoder_writesTrustFrameworkRolePatch_underMergePatchJson() {
+    assertWritable(TrustFrameworkRolePatch.class);
+  }
+
+  @Test
+  void configuredEncoder_writesSchemaModulePatch_underMergePatchJson() {
+    assertWritable(SchemaModulePatch.class);
+  }
+
+  @Test
+  void configuredEncoder_stillWritesUnderApplicationJson() {
+    ClientCodecConfigurer configurer = ClientCodecConfigurer.create();
+    ClientConfig.configureFcCodecs(configurer, new ObjectMapper());
+
+    boolean hasJsonWriter = configurer.getWriters().stream().anyMatch(writer ->
+        writer.canWrite(ResolvableType.forClass(TrustFrameworkPatch.class),
+            MediaType.APPLICATION_JSON));
+
+    assertThat(hasJsonWriter)
+        .as("application/json must remain writable after enabling merge-patch+json")
+        .isTrue();
+  }
+
+  private static void assertWritable(Class<?> bodyType) {
+    ClientCodecConfigurer configurer = ClientCodecConfigurer.create();
+    ClientConfig.configureFcCodecs(configurer, new ObjectMapper());
+
+    boolean hasMergePatchWriter = configurer.getWriters().stream().anyMatch(writer ->
+        writer.canWrite(ResolvableType.forClass(bodyType), FcMediaTypes.MERGE_PATCH_JSON));
+
+    assertThat(hasMergePatchWriter)
+        .as("portal WebClient must have a JSON writer accepting "
+            + FcMediaTypes.MERGE_PATCH_JSON_VALUE + " for " + bodyType.getSimpleName())
+        .isTrue();
+  }
+}

--- a/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/controller/AdminControllerTest.java
+++ b/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/controller/AdminControllerTest.java
@@ -1,26 +1,51 @@
 package eu.xfsc.fc.demo.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkRolePatch;
 import eu.xfsc.fc.client.AdminClient;
 import eu.xfsc.fc.demo.config.SecurityConfig;
 
 /**
- * Security tests for the AdminController proxy endpoints.
- * Verifies that /admin/** requires authentication. Role enforcement is done by the backend.
+ * Tests for the AdminController proxy endpoints. Covers both authentication enforcement and
+ * that authenticated requests forward to the {@link AdminClient} for each PATCH route. The
+ * proxy layer is thin, but mis-mapped routes silently fall through to Spring's
+ * static-resource handler and surface as a confusing 404 to the browser — these tests pin
+ * each route mapping.
  */
 @WebMvcTest(AdminController.class)
 @Import(SecurityConfig.class)
 class AdminControllerTest {
+
+  private static final String REG_ID = "fc-client-oidc";
+  private static final String ENABLED_TRUE = """
+      {"enabled":true}
+      """;
+  private static final String BUNDLE_CONFIG_PATCH = """
+      {"serviceUrl":"https://mock.test/v2"}
+      """;
 
   @Autowired
   private MockMvc mockMvc;
@@ -47,5 +72,114 @@ class AdminControllerTest {
   void getTrustFrameworks_unauthenticated_redirectsToLogin() throws Exception {
     mockMvc.perform(get("/admin/trust-frameworks"))
         .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void patchTrustFramework_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/gaia-x")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void patchTrustFrameworkRole_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/gaia-x-2511/roles/Participant")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void patchSchemaModule_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(patch("/admin/schema-validation/modules/SHACL")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void patchTrustFramework_authenticated_forwardsToAdminClient() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/gaia-x")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().isOk());
+
+    verify(adminClient).patchTrustFramework(eq("gaia-x"), any(TrustFrameworkPatch.class),
+        any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void patchTrustFrameworkRole_authenticated_forwardsToAdminClient() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/gaia-x-2511/roles/ServiceOffering")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().isOk());
+
+    verify(adminClient).patchTrustFrameworkRole(eq("gaia-x-2511"), eq("ServiceOffering"),
+        any(TrustFrameworkRolePatch.class), any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void patchSchemaModule_authenticated_forwardsToAdminClient() throws Exception {
+    mockMvc.perform(patch("/admin/schema-validation/modules/SHACL")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ENABLED_TRUE))
+        .andExpect(status().isOk());
+
+    verify(adminClient).patchSchemaModule(eq("SHACL"), any(SchemaModulePatch.class),
+        any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void patchTrustFrameworkBundleConfig_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(BUNDLE_CONFIG_PATCH))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void patchTrustFrameworkBundleConfig_authenticated_forwardsToAdminClient() throws Exception {
+    mockMvc.perform(patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(BUNDLE_CONFIG_PATCH))
+        .andExpect(status().isOk());
+
+    verify(adminClient).patchTrustFrameworkBundleConfig(eq("gaia-x-2511"),
+        any(Map.class), any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void deleteTrustFrameworkBundleConfig_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(delete("/admin/trust-frameworks/bundles/gaia-x-2511"))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void deleteTrustFrameworkBundleConfig_authenticated_returns200() throws Exception {
+    mockMvc.perform(delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID)))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  void deleteTrustFrameworkBundleConfig_authenticated_forwardsToAdminClient() throws Exception {
+    mockMvc.perform(delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID)))
+        .andExpect(status().isOk());
+
+    verify(adminClient).deleteTrustFrameworkBundleConfig(eq("gaia-x-2511"),
+        any(OAuth2AuthorizedClient.class));
   }
 }

--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/FusekiGraphDbConfig.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/config/FusekiGraphDbConfig.java
@@ -16,12 +16,12 @@ import lombok.extern.slf4j.Slf4j;
 @ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime')")
 public class FusekiGraphDbConfig {
 
-    @Value("${graphstore.fuseki.uri:${graphstore.uri}}")
+  @Value("${graphstore.fuseki.uri:${graphstore.uri}}")
     private String uri;
 
-    // RDFConnectionFuseki does not open a socket at construction; the first request
-    // touches the HTTP endpoint. No connect-on-build means an unreachable Fuseki at
-    // boot does not crash the JVM in routing mode.
+  // RDFConnectionFuseki does not open a socket at construction; the first request
+  // touches the HTTP endpoint. No connect-on-build means an unreachable Fuseki at
+  // boot does not crash the JVM in routing mode.
     @Bean
     @Scope(value = ConfigurableBeanFactory.SCOPE_SINGLETON)
     public RDFConnection rdfConnection() {

--- a/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
+++ b/fc-graphdb-fuseki/src/main/java/eu/xfsc/fc/graphdb/service/SparqlGraphStore.java
@@ -58,11 +58,11 @@ public class SparqlGraphStore implements GraphStore {
 
     private final ClaimValidator claimValidator;
 
-    // required = false so the adapter can be wired in test contexts that do not
-    // import an embedded Fuseki (RDFConnection bean absent). Calls into this
-    // adapter when rdfConnection is null will fail at runtime; the routing layer
-    // is expected to keep a Fuseki-less deployment from selecting FUSEKI as active.
-    @Autowired(required = false)
+  // required = false so the adapter can be wired in test contexts that do not
+  // import an embedded Fuseki (RDFConnection bean absent). Calls into this
+  // adapter when rdfConnection is null will fail at runtime; the routing layer
+  // is expected to keep a Fuseki-less deployment from selecting FUSEKI as active.
+  @Autowired(required = false)
     private RDFConnection rdfConnection;
 
     public SparqlGraphStore() {
@@ -85,9 +85,9 @@ public class SparqlGraphStore implements GraphStore {
     /** {@inheritDoc} */
     @Override
     public boolean isHealthy() {
-        if (rdfConnection == null) {
-            return false;
-        }
+      if (rdfConnection == null) {
+        return false;
+      }
         try {
             Txn.calculateRead(rdfConnection, () -> {
                 try (QueryExecution qe = rdfConnection.newQuery()

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/GraphDbConfig.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/config/GraphDbConfig.java
@@ -18,22 +18,22 @@ import lombok.extern.slf4j.Slf4j;
 @ConditionalOnExpression("'${federated-catalogue.scope}'.equals('runtime')")
 public class GraphDbConfig {
 
-    @Value("${graphstore.neo4j.uri:${graphstore.uri}}")
+  @Value("${graphstore.neo4j.uri:${graphstore.uri}}")
     private String uri;
     @Value("${graphstore.user}")
     private String user;
     @Value("${graphstore.password}")
     private String password;
 
-    // @Lazy + no eager session.run() — the Neo4j driver does not open a TCP connection at
-    // construction; it only connects on first session(). n10s schema bootstrap was moved
-    // out of this factory into Neo4jGraphStore.ensureInitialized() so that an unreachable
-    // Neo4j container at boot does not crash the JVM in routing mode.
+  // @Lazy + no eager session.run() — the Neo4j driver does not open a TCP connection at
+  // construction; it only connects on first session(). n10s schema bootstrap was moved
+  // out of this factory into Neo4jGraphStore.ensureInitialized() so that an unreachable
+  // Neo4j container at boot does not crash the JVM in routing mode.
     @Bean(destroyMethod = "close")
     @Lazy
     public Driver driver() {
         Config config = Config.builder().withLogging(Logging.slf4j()).build();
-        return GraphDatabase.driver(uri, AuthTokens.basic(user, password), config);
+      return GraphDatabase.driver(uri, AuthTokens.basic(user, password), config);
     }
 
 }

--- a/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
+++ b/fc-graphdb-neo4j/src/main/java/eu/xfsc/fc/graphdb/service/Neo4jGraphStore.java
@@ -47,15 +47,15 @@ public class Neo4jGraphStore implements GraphStore {
                                               "DETACH DELETE n;";
     private static final String queryUpdate = "MATCH (n) WHERE $uri IN n.claimsGraphUri\n" +
                                               "SET n.claimsGraphUri = [g IN n.claimsGraphUri WHERE g <> $uri];";
-    
-    // required = false so the adapter can be wired in test contexts that do not
-    // import an embedded Neo4j (Driver bean absent). Calls into this adapter when
-    // driver is null will fail at runtime; the routing layer is expected to keep
-    // a Neo4j-less deployment from selecting NEO4J as active.
-    @Autowired(required = false)
+
+  // required = false so the adapter can be wired in test contexts that do not
+  // import an embedded Neo4j (Driver bean absent). Calls into this adapter when
+  // driver is null will fail at runtime; the routing layer is expected to keep
+  // a Neo4j-less deployment from selecting NEO4J as active.
+  @Autowired(required = false)
     private Driver driver;
     private final ClaimValidator claimValidator;
-    private volatile boolean schemaInitialized;
+  private volatile boolean schemaInitialized;
 
     @Value("${graphstore.timeout-marker:timeout}")
     private String timeoutMarker;
@@ -70,36 +70,37 @@ public class Neo4jGraphStore implements GraphStore {
         this.claimValidator = new ClaimValidator();
     }
 
-    /**
-     * Ensures the n10s graphconfig and uniqueness constraint exist on the target Neo4j
-     * instance. Runs at most once per JVM (guarded by a double-checked volatile flag) and
-     * is invoked from every read/write entry point so an unreachable Neo4j at boot does
-     * not crash the JVM in routing mode — the schema bootstrap happens on first real use.
-     */
-    private void ensureInitialized() {
-        if (schemaInitialized) {
-            return;
-        }
-        synchronized (this) {
-            if (schemaInitialized) {
-                return;
-            }
-            try (Session session = driver.session()) {
-                Result result = session.run("CALL n10s.graphconfig.show();");
-                if (result.hasNext()) {
-                    log.info("Graph already configured (n10s graphconfig present)");
-                } else {
-                    // multivalPropList lists both Gaia-X namespaces — Tagus (service#) and Loire (2511#) —
-                    // so a Loire credential's claimsGraphUri is treated as multi-valued regardless of which
-                    // namespace the issuer used.
-                    session.run("CALL n10s.graphconfig.init({handleVocabUris:'MAP',handleMultival:'ARRAY',multivalPropList:['http://w3id.org/gaia-x/service#claimsGraphUri','https://w3id.org/gaia-x/2511#claimsGraphUri']});");
-                    session.run("CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
-                    log.info("n10s graphconfig initialized and constraints created");
-                }
-            }
-            schemaInitialized = true;
-        }
+  /**
+   * Ensures the n10s graphconfig and uniqueness constraint exist on the target Neo4j
+   * instance. Runs at most once per JVM (guarded by a double-checked volatile flag) and
+   * is invoked from every read/write entry point so an unreachable Neo4j at boot does
+   * not crash the JVM in routing mode — the schema bootstrap happens on first real use.
+   */
+  private void ensureInitialized() {
+    if (schemaInitialized) {
+      return;
     }
+    synchronized (this) {
+      if (schemaInitialized) {
+        return;
+      }
+      try (Session session = driver.session()) {
+        Result result = session.run("CALL n10s.graphconfig.show();");
+        if (result.hasNext()) {
+          log.info("Graph already configured (n10s graphconfig present)");
+        } else {
+          // multivalPropList lists both Gaia-X namespaces — Tagus (service#) and Loire (2511#) —
+          // so a Loire credential's claimsGraphUri is treated as multi-valued regardless of which
+          // namespace the issuer used.
+          session.run(
+              "CALL n10s.graphconfig.init({handleVocabUris:'MAP',handleMultival:'ARRAY',multivalPropList:['http://w3id.org/gaia-x/service#claimsGraphUri','https://w3id.org/gaia-x/2511#claimsGraphUri']});");
+          session.run("CREATE CONSTRAINT n10s_unique_uri IF NOT EXISTS FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
+          log.info("n10s graphconfig initialized and constraints created");
+        }
+      }
+      schemaInitialized = true;
+    }
+  }
 
     /** {@inheritDoc} */
     @Override
@@ -117,12 +118,12 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public boolean isHealthy() {
         if (driver == null) {
-            return false;
+          return false;
         }
-        try {
+      try {
             driver.verifyConnectivity();
-            ensureInitialized();
-            return true;
+        ensureInitialized();
+        return true;
         } catch (Exception e) {
             log.warn("Neo4j connectivity check failed", e);
             return false;
@@ -133,7 +134,7 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public long getClaimCount() {
         ensureInitialized();
-        try (Session session = driver.session()) {
+      try (Session session = driver.session()) {
             Result result = session.run(
                 "MATCH (n) WHERE n.claimsGraphUri IS NOT NULL RETURN count(n) AS cnt");
             return result.single().get("cnt").asLong();
@@ -147,7 +148,7 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public long getRDFAssetCountInGraph() {
         ensureInitialized();
-        try (Session session = driver.session()) {
+      try (Session session = driver.session()) {
             Result result = session.run(
                 "MATCH (n) WHERE n.claimsGraphUri IS NOT NULL "
                 + "UNWIND n.claimsGraphUri AS uri RETURN count(DISTINCT uri) AS cnt");
@@ -164,8 +165,8 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public void addClaims(List<RdfClaim> claimList, String credentialSubject) {
         if (!claimList.isEmpty()) {
-            ensureInitialized();
-            try (Session session = driver.session()) {
+          ensureInitialized();
+          try (Session session = driver.session()) {
                 Pair<String, Set<String>> props = claimValidator.resolveClaims(claimList, credentialSubject);
                 if (!props.getRight().isEmpty()) {
                     updateGraphConfig(session, props.getRight());
@@ -182,7 +183,7 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public void deleteClaims(String credentialSubject) {
         ensureInitialized();
-        Map<String, Object> params = Map.of("uri", credentialSubject);
+      Map<String, Object> params = Map.of("uri", credentialSubject);
         try (Session session = driver.session()) {
             Result rsDelete = session.run(queryDelete, params);
             log.debug("deleteClaims; deleted: {}", rsDelete.consume());
@@ -200,7 +201,7 @@ public class Neo4jGraphStore implements GraphStore {
     @Override
     public void deleteValidationResultClaims(String resultIri) {
         ensureInitialized();
-        try (Session session = driver.session()) {
+      try (Session session = driver.session()) {
             Result rs = session.run("MATCH (n {uri: $uri}) DETACH DELETE n", Map.of("uri", resultIri));
             log.debug("deleteValidationResultClaims; deleted: {}", rs.consume());
         }
@@ -218,7 +219,7 @@ public class Neo4jGraphStore implements GraphStore {
         }
 
         ensureInitialized();
-        TransactionConfig transactionConfig = TransactionConfig.builder()
+      TransactionConfig transactionConfig = TransactionConfig.builder()
                 .withTimeout(Duration.ofSeconds(query.getTimeout()))
                 .build();
 

--- a/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
+++ b/fc-graphdb-neo4j/src/test/java/eu/xfsc/fc/core/service/assetstore/AssetStoreCompositeTest.java
@@ -24,17 +24,26 @@ import eu.xfsc.fc.core.service.verification.VerificationServiceImpl;
 import eu.xfsc.fc.core.util.GraphRebuilder;
 import eu.xfsc.fc.graphdb.config.EmbeddedNeo4JConfig;
 import eu.xfsc.fc.graphdb.service.Neo4jGraphStore;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.Ed25519Signer;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
+import com.nimbusds.jose.util.JSONObjectUtils;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase.DatabaseProvider;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestMethodOrder;
 import org.neo4j.harness.Neo4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
@@ -58,7 +67,6 @@ import static eu.xfsc.fc.core.util.TestUtil.assertThatAssetHasTheSameData;
 import static eu.xfsc.fc.core.util.TestUtil.getAccessor;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@TestMethodOrder(MethodOrderer.MethodName.class)
 @SpringBootTest
 @ActiveProfiles("test")
 @ContextConfiguration(classes = {
@@ -115,6 +123,14 @@ public class AssetStoreCompositeTest {
     @Autowired
     private GraphRebuilder graphRebuilder;
 
+    private JWSSigner jwtSigner;
+
+    @BeforeAll
+    void initSigner() throws Exception {
+        OctetKeyPair jwk = new OctetKeyPairGenerator(Curve.Ed25519).keyID("test-key").generate();
+        jwtSigner = new Ed25519Signer(jwk);
+    }
+
     @BeforeEach
     void stubValidationResultStore() {
         when(validationResultStore.findAll(any())).thenReturn(Page.empty());
@@ -136,7 +152,7 @@ public class AssetStoreCompositeTest {
      * it again.
      */
     @Test
-    void test01StoreCredential() {
+    void storeCredential_validCredential_isRetrievableAndDeletable() {
 
         schemaStore.addSchema(getAccessor("Schema-Tests/gx-2511-test-ontology.ttl"));
         ContentAccessor content = getAccessor("Claims-Extraction-Tests/providerTest.jsonld");
@@ -169,7 +185,7 @@ public class AssetStoreCompositeTest {
     }
 
     @Test
-    void test02RebuildGraphDb() {
+    void rebuildGraphDb_afterClaimsDeleted_restoresClaims() {
 
         schemaStore.addSchema(getAccessor("Schema-Tests/gx-2511-test-ontology.ttl"));
         ContentAccessor content = getAccessor("Claims-Extraction-Tests/providerTest.jsonld");
@@ -208,7 +224,7 @@ public class AssetStoreCompositeTest {
     }
 
     @Test
-    void test03RebuildGraphDb_filtersProtectedNamespaceClaims() {
+    void rebuildGraphDb_protectedNamespaceClaims_filtersThemOut() {
 
         schemaStore.addSchema(getAccessor("Schema-Tests/gx-2511-test-ontology.ttl"));
         ContentAccessor content = getAccessor("Claims-Extraction-Tests/participantCredential-with-fcmeta.jsonld");
@@ -246,7 +262,7 @@ public class AssetStoreCompositeTest {
     }
 
     @Test
-    void test04RebuildGraphDb_nonCredentialNTriples_restoresClaimsAfterRebuild() {
+    void rebuildGraphDb_nonCredentialNTriples_restoresClaims() {
 
         // Arrange — minimal N-Triples document, deliberately not a VC/VP
         final String subjectUri = "http://example.org/non-credential-test/subject1";
@@ -288,5 +304,46 @@ public class AssetStoreCompositeTest {
                 "Graph must contain non-credential triples after rebuild");
 
         assetStorePublisher.deleteAsset(assetMeta.getAssetHash());
+    }
+
+    @Test
+    void rebuildGraphDb_jwtWrappedCredential_restoresSameClaims() throws Exception {
+
+        schemaStore.addSchema(getAccessor("Schema-Tests/gx-2511-test-ontology.ttl"));
+        String vpJson = getAccessor("Claims-Extraction-Tests/providerTest.jsonld").getContentAsString();
+        ContentAccessor content =
+                new ContentAccessorDirect(danubetechVpJwt(vpJson), VerificationConstants.MEDIA_TYPE_VP_JWT);
+
+        // Upload path: unwrap JWT → extract claims
+        CredentialVerificationResult result = verificationService.verifyCredential(content, true, false, false, false);
+        AssetMetadata assetMeta = new AssetMetadata(content, result);
+        assetStorePublisher.storeCredential(assetMeta, result);
+
+        int afterStore = graphStore.queryData(new GraphQuery("MATCH (n) RETURN n", null)).getResults().size();
+        Assertions.assertTrue(afterStore > 1, "JWT-wrapped credential must yield claims at upload time");
+
+        graphStore.deleteClaims(assetMeta.getId());
+        int afterDelete = graphStore.queryData(new GraphQuery("MATCH (n) RETURN n", null)).getResults().size();
+        Assertions.assertTrue(afterDelete < afterStore, "claims must be removed before rebuild");
+
+        graphRebuilder.rebuildGraphDb(1, 0, 1, 1);
+
+        int afterRebuild = graphStore.queryData(new GraphQuery("MATCH (n) RETURN n", null)).getResults().size();
+        Assertions.assertEquals(afterStore, afterRebuild,
+                "rebuild must restore the same claims for a JWT-wrapped credential as at upload");
+
+        assetStorePublisher.deleteAsset(assetMeta.getAssetHash());
+    }
+
+    /** Wraps a JSON-LD Verifiable Presentation into a danubetech-style compact JWT (vp wrapper claim). */
+    private String danubetechVpJwt(String vpJson) throws Exception {
+        Map<String, Object> vp = JSONObjectUtils.parse(vpJson);
+        JWTClaimsSet claims = new JWTClaimsSet.Builder().claim("vp", vp).build();
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+                .keyID("did:web:example.com#test-key")
+                .build();
+        SignedJWT signedJwt = new SignedJWT(header, claims);
+        signedJwt.sign(jwtSigner);
+        return signedJwt.serialize();
     }
 }

--- a/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
+++ b/fc-service-client/src/main/java/eu/xfsc/fc/client/AdminClient.java
@@ -15,11 +15,12 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
-import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.RebuildStatus;
+import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
+import eu.xfsc.fc.api.generated.model.TrustFrameworkRolePatch;
 
 /**
  * Client for Admin API endpoints.
@@ -54,7 +55,8 @@ public class AdminClient extends ServiceClient {
     /** Lists all registered trust frameworks. */
     public List<TrustFrameworkEntry> getTrustFrameworks(OAuth2AuthorizedClient authorizedClient) {
         return doGet("/admin/trust-frameworks", Map.of(), null,
-            new ParameterizedTypeReference<List<TrustFrameworkEntry>>(){},
+            new ParameterizedTypeReference<>() {
+            },
             authorizedClient);
     }
 
@@ -69,6 +71,50 @@ public class AdminClient extends ServiceClient {
   public void patchTrustFramework(String id, TrustFrameworkPatch patch,
         OAuth2AuthorizedClient authorizedClient) {
         doPatch("/admin/trust-frameworks/{id}", patch, Map.of("id", id), Void.class, authorizedClient);
+  }
+
+  /**
+   * Applies a merge-patch to a role within the identified bundle. Only fields present in the
+   * patch are modified; absent fields are left unchanged.
+   *
+   * @param bundleId         trust framework bundle identifier
+   * @param roleName         role name within the bundle
+   * @param patch            fields to update
+   * @param authorizedClient OAuth2 client for bearer token
+   */
+  public void patchTrustFrameworkRole(String bundleId, String roleName,
+                                      TrustFrameworkRolePatch patch, OAuth2AuthorizedClient authorizedClient) {
+    doPatch("/admin/trust-frameworks/{bundleId}/roles/{roleName}", patch,
+        Map.of("bundleId", bundleId, "roleName", roleName), Void.class, authorizedClient);
+  }
+
+  /**
+   * Applies a merge-patch to the external client identifiers of a bundle using RFC 7396
+   * merge-patch semantics. Only fields present in the map are modified; setting a field to
+   * {@code null} clears the stored override for that field; absent fields are left unchanged.
+   *
+   * @param bundleId         trust framework bundle identifier
+   * @param patch            free-form merge-patch map; must contain at least one entry
+   * @param authorizedClient OAuth2 client for bearer token
+   */
+  public void patchTrustFrameworkBundleConfig(String bundleId,
+                                              Map<String, Object> patch, OAuth2AuthorizedClient authorizedClient) {
+    doPatch("/admin/trust-frameworks/bundles/{bundleId}", patch,
+        Map.of("bundleId", bundleId), Void.class, authorizedClient);
+  }
+
+  /**
+   * Removes all persisted overrides for the given bundle, restoring the bundle YAML as the sole
+   * source of compliance configuration. Idempotent — a bundle without an override row still
+   * returns without error.
+   *
+   * @param bundleId         trust framework bundle identifier
+   * @param authorizedClient OAuth2 client for bearer token
+   */
+  public void deleteTrustFrameworkBundleConfig(String bundleId,
+                                               OAuth2AuthorizedClient authorizedClient) {
+    doDelete("/admin/trust-frameworks/bundles/{bundleId}",
+        Map.of("bundleId", bundleId), null, Void.class, authorizedClient);
   }
 
   /** Gets schema validation module status. */
@@ -135,11 +181,13 @@ public class AdminClient extends ServiceClient {
       }
       throw ex;
     }
-    }
+  }
 
-    /** Polls graph rebuild progress. */
-    public RebuildStatus getGraphRebuildStatus(OAuth2AuthorizedClient authorizedClient) {
-        return doGet("/admin/graph/rebuild/status", Map.of(), null,
-            RebuildStatus.class, authorizedClient);
-    }
+  /**
+   * Polls graph rebuild progress.
+   */
+  public RebuildStatus getGraphRebuildStatus(OAuth2AuthorizedClient authorizedClient) {
+    return doGet("/admin/graph/rebuild/status", Map.of(), null,
+        RebuildStatus.class, authorizedClient);
+  }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/config/DatabaseConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/config/DatabaseConfig.java
@@ -1,9 +1,13 @@
 package eu.xfsc.fc.core.config;
 
 import jakarta.persistence.EntityManagerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -17,10 +21,23 @@ import javax.sql.DataSource;
 @Configuration
 @EnableTransactionManagement
 // Wires SecurityAuditorAware to populate createdBy/modifiedBy from JWT subject on every JPA write
-@EnableJpaAuditing(auditorAwareRef = "securityAuditorAware")
+@EnableJpaAuditing(
+    auditorAwareRef = "securityAuditorAware",
+    dateTimeProviderRef = "zonedDateTimeProvider")
 @EnableJpaRepositories(basePackages = "eu.xfsc.fc.core.dao")
 @RequiredArgsConstructor
 public class DatabaseConfig {
+
+  /**
+   * Supplies {@link ZonedDateTime} timestamps to JPA auditing so that entities using
+   * timezone-aware temporal columns can be populated without a runtime conversion error.
+   * Spring Data's default provider returns {@code LocalDateTime} which is not convertible
+   * to {@code ZonedDateTime} by the auditing framework.
+   */
+  @Bean
+  public DateTimeProvider zonedDateTimeProvider() {
+    return () -> Optional.of(ZonedDateTime.now());
+  }
 
   private final DataSource dataSource;
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFramework.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFramework.java
@@ -31,15 +31,6 @@ public class TrustFramework {
   @Column(name = "name", length = 255, nullable = false)
   private String name;
 
-  @Column(name = "service_url", length = 1024)
-  private String serviceUrl;
-
-  @Column(name = "api_version", length = 50)
-  private String apiVersion;
-
-  @Column(name = "timeout_seconds")
-  private int timeoutSeconds;
-
   @Column(name = "enabled")
   private boolean enabled;
 

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkBundleConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkBundleConfig.java
@@ -1,0 +1,67 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import java.time.ZonedDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * Per-bundle runtime overrides for external client identifiers (compliance service URL,
+ * API version, timeout, client implementation key, trust-anchor list URL). Each non-null
+ * field overrides the corresponding value from the bundle's {@code framework.yaml};
+ * null fields fall back to the YAML value.
+ *
+ * <p>Absence of a row for a given bundle means "use YAML for every field". Rows for
+ * bundle IDs that are no longer registered are ignored at runtime with a warning.
+ */
+@Entity
+@Table(name = "trust_framework_bundle_config")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TrustFrameworkBundleConfig {
+
+  @Id
+  @Column(name = "bundle_id", length = 255, nullable = false)
+  private String bundleId;
+
+  @Column(name = "client_type", length = 255)
+  private String clientType;
+
+  @Column(name = "service_url", length = 1024)
+  private String serviceUrl;
+
+  @Column(name = "compliance_path", length = 1024)
+  private String compliancePath;
+
+  @Column(name = "api_version", length = 64)
+  private String apiVersion;
+
+  @Column(name = "timeout_seconds")
+  private Integer timeoutSeconds;
+
+  @Column(name = "trust_anchor_url", length = 1024)
+  private String trustAnchorUrl;
+
+  @CreatedDate
+  @Column(name = "created_at", updatable = false)
+  private ZonedDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at")
+  private ZonedDateTime updatedAt;
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkBundleConfigRepository.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkBundleConfigRepository.java
@@ -1,0 +1,12 @@
+package eu.xfsc.fc.core.dao.trustframework;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repository for per-bundle external-identifier overrides. Absence of a row means
+ * "no override — fall back to the bundle's {@code framework.yaml} values". A present
+ * row with a NULL field also falls back for that single field.
+ */
+public interface TrustFrameworkBundleConfigRepository
+    extends JpaRepository<TrustFrameworkBundleConfig, String> {
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkMapper.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/dao/trustframework/TrustFrameworkMapper.java
@@ -16,9 +16,6 @@ public final class TrustFrameworkMapper {
     return new TrustFrameworkConfig(
         entity.getId(),
         entity.getName(),
-        entity.getServiceUrl(),
-        entity.getApiVersion(),
-        entity.getTimeoutSeconds(),
         entity.isEnabled(),
         entity.getCreatedAt() != null ? entity.getCreatedAt().toInstant(ZoneOffset.UTC) : null,
         entity.getUpdatedAt() != null ? entity.getUpdatedAt().toInstant(ZoneOffset.UTC) : null

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/TrustFrameworkConfig.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/pojo/TrustFrameworkConfig.java
@@ -8,9 +8,6 @@ import java.time.Instant;
 public record TrustFrameworkConfig(
     String id,
     String name,
-    String serviceUrl,
-    String apiVersion,
-    int timeoutSeconds,
     boolean enabled,
     Instant createdAt,
     Instant updatedAt) {}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleConfigService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkBundleConfigService.java
@@ -1,0 +1,260 @@
+package eu.xfsc.fc.core.service.trustframework;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+// Function used for typed accessors of TrustFrameworkBundleConfig fields.
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfig;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfigRepository;
+import eu.xfsc.fc.core.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Mediates writes to the per-bundle external client identifier overrides. The bundle must
+ * be registered in {@link TrustFrameworkRegistry}; otherwise the write is rejected with
+ * {@link NotFoundException}.
+ *
+ * <p>Reads happen through {@link TrustFrameworkProfileResolver}, which combines the YAML
+ * baseline with rows persisted here.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrustFrameworkBundleConfigService {
+
+  private final TrustFrameworkRegistry registry;
+  private final TrustFrameworkBundleConfigRepository repository;
+
+  /**
+   * Applies a merge-patch to the per-bundle overrides. RFC 7396 semantics:
+   * <ul>
+   *   <li>A field name present in {@code overrides} sets the column to that value.</li>
+   *   <li>A field name present in {@code fieldsToClear} sets the column back to NULL,
+   *       letting the YAML value flow through again.</li>
+   *   <li>A field name absent from both maps is left unchanged.</li>
+   * </ul>
+   * The same field name MUST NOT appear in both arguments; the caller is responsible
+   * for partitioning the payload. Empty payloads are rejected here as a defensive
+   * fallback to the HTTP-layer {@code minProperties: 1}.
+   *
+   * @param bundleId      registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @param overrides     values to persist; keyed by the field name (clientType,
+   *                      serviceUrl, compliancePath, apiVersion, timeoutSeconds,
+   *                      trustAnchorUrl)
+   * @param fieldsToClear field names whose override should be removed
+   * @throws NotFoundException        when no bundle is registered for the given ID
+   * @throws IllegalArgumentException when both maps are empty
+   */
+  @Transactional
+  public void applyPatch(String bundleId, Overrides overrides, Set<Field> fieldsToClear) {
+    if (registry.getBundle(bundleId).isEmpty()) {
+      throw new NotFoundException("Unknown trust-framework bundle: " + bundleId);
+    }
+    if (overrides.isEmpty() && fieldsToClear.isEmpty()) {
+      throw new IllegalArgumentException("Patch must set or clear at least one field");
+    }
+
+    TrustFrameworkBundleConfig row = repository.findById(bundleId)
+        .orElseGet(() -> TrustFrameworkBundleConfig.builder().bundleId(bundleId).build());
+
+    overrides.applyTo(row);
+    for (Field field : fieldsToClear) {
+      field.clearer.accept(row, null);
+    }
+
+    repository.save(row);
+    log.info("applyPatch; bundle '{}' overrides set={} cleared={}",
+        bundleId, overrides.fieldNames(), fieldsToClear);
+  }
+
+  /**
+   * Clears every persisted override for the given bundle, restoring the YAML baseline
+   * as the sole source of compliance configuration. Idempotent — calling this when no
+   * row exists is a no-op.
+   *
+   * @param bundleId registry bundle profile ID
+   * @throws NotFoundException when no bundle is registered for the given ID
+   */
+  @Transactional
+  public void clear(String bundleId) {
+    if (registry.getBundle(bundleId).isEmpty()) {
+      throw new NotFoundException("Unknown trust-framework bundle: " + bundleId);
+    }
+    if (repository.existsById(bundleId)) {
+      repository.deleteById(bundleId);
+      log.info("clear; bundle '{}' configuration overrides removed", bundleId);
+    }
+  }
+
+  /**
+   * Enumeration of the override fields that a merge-patch can address. Each constant
+   * binds the wire JSON property name to setter / clearer accessors on
+   * {@link TrustFrameworkBundleConfig}.
+   */
+  public enum Field {
+    CLIENT_TYPE("clientType", "client_type",
+        TrustFrameworkBundleConfig::getClientType,
+        s -> s,
+        (row, value) -> row.setClientType((String) value)),
+    SERVICE_URL("serviceUrl", "service_url",
+        TrustFrameworkBundleConfig::getServiceUrl,
+        s -> s,
+        (row, value) -> row.setServiceUrl((String) value)),
+    COMPLIANCE_PATH("compliancePath", "compliance_path",
+        TrustFrameworkBundleConfig::getCompliancePath,
+        s -> s,
+        (row, value) -> row.setCompliancePath((String) value)),
+    API_VERSION("apiVersion", "api_version",
+        TrustFrameworkBundleConfig::getApiVersion,
+        s -> s,
+        (row, value) -> row.setApiVersion((String) value)),
+    TIMEOUT_SECONDS("timeoutSeconds", "timeout_seconds",
+        TrustFrameworkBundleConfig::getTimeoutSeconds,
+        Integer::parseInt,
+        (row, value) -> row.setTimeoutSeconds((Integer) value)),
+    TRUST_ANCHOR_URL("trustAnchorUrl", "trust_anchor_url",
+        TrustFrameworkBundleConfig::getTrustAnchorUrl,
+        s -> s,
+        (row, value) -> row.setTrustAnchorUrl((String) value));
+
+    private final String jsonName;
+    private final String yamlKey;
+    private final Function<TrustFrameworkBundleConfig, Object> overrideReader;
+    private final Function<String, Object> yamlParser;
+    private final BiConsumer<TrustFrameworkBundleConfig, Object> writer;
+    private final BiConsumer<TrustFrameworkBundleConfig, Object> clearer;
+
+    Field(String jsonName, String yamlKey,
+          Function<TrustFrameworkBundleConfig, Object> overrideReader,
+          Function<String, Object> yamlParser,
+          BiConsumer<TrustFrameworkBundleConfig, Object> writer) {
+      this.jsonName = jsonName;
+      this.yamlKey = yamlKey;
+      this.overrideReader = overrideReader;
+      this.yamlParser = yamlParser;
+      this.writer = writer;
+      this.clearer = writer;
+    }
+
+    public String jsonName() {
+      return jsonName;
+    }
+
+    public String yamlKey() {
+      return yamlKey;
+    }
+
+    /**
+     * Reads the persisted override value for this field, returning {@code null} when
+     * the row's column is NULL (i.e. no override is active for this field).
+     */
+    public Object readOverride(TrustFrameworkBundleConfig row) {
+      return overrideReader.apply(row);
+    }
+
+    /**
+     * Coerces a raw YAML string value into the column type ({@code String} for most
+     * fields, {@code Integer} for {@code timeoutSeconds}).
+     */
+    public Object parseYamlValue(String raw) {
+      return raw == null ? null : yamlParser.apply(raw);
+    }
+
+    public static Field fromJsonName(String jsonName) {
+      for (Field field : values()) {
+        if (field.jsonName.equals(jsonName)) {
+          return field;
+        }
+      }
+      throw new IllegalArgumentException("Unknown bundle config field: " + jsonName);
+    }
+  }
+
+  /**
+   * Effective configuration of a bundle after merging persisted overrides over the YAML
+   * baseline. Values are the typed payload (Strings for text fields, Integer for
+   * {@code timeoutSeconds}).
+   *
+   * @param values           effective value per field; null when neither override nor YAML supplied one
+   * @param overriddenFields fields whose effective value comes from the override row
+   */
+  public record EffectiveBundleConfig(
+      Map<Field, Object> values,
+      Set<Field> overriddenFields) {
+  }
+
+  /**
+   * Resolves the effective configuration for a registered bundle by combining the
+   * persisted override row (if any) with the YAML baseline read from
+   * {@link TrustFrameworkBundle#config()}.
+   *
+   * @param bundleId registry bundle profile ID
+   * @return effective configuration; {@link Optional#empty()} when the bundle is not registered
+   */
+  public Optional<EffectiveBundleConfig> getEffectiveConfig(String bundleId) {
+    return registry.getBundle(bundleId).map(bundle -> {
+      Map<String, String> yamlProps = bundle.config().properties();
+      Optional<TrustFrameworkBundleConfig> override = repository.findById(bundleId);
+
+      Map<Field, Object> values = new LinkedHashMap<>();
+      Set<Field> overridden = java.util.EnumSet.noneOf(Field.class);
+      for (Field field : Field.values()) {
+        Object overrideValue = override.map(field::readOverride).orElse(null);
+        if (overrideValue != null) {
+          values.put(field, overrideValue);
+          overridden.add(field);
+        } else {
+          String yamlRaw = yamlProps.get(field.yamlKey());
+          if (yamlRaw != null) {
+            values.put(field, field.parseYamlValue(yamlRaw));
+          }
+        }
+      }
+      return new EffectiveBundleConfig(values, overridden);
+    });
+  }
+
+  /**
+   * Type-safe carrier for the "set" half of a bundle-config merge-patch. Values are
+   * pre-coerced to the column types ({@code String} or {@code Integer}); use the
+   * static factory {@link Overrides#empty()} as a starting point and {@code put} to
+   * accumulate.
+   */
+  public static final class Overrides {
+
+    private final java.util.EnumMap<Field, Object> values = new java.util.EnumMap<>(Field.class);
+
+    private Overrides() {
+    }
+
+    public static Overrides empty() {
+      return new Overrides();
+    }
+
+    public Overrides put(Field field, Object value) {
+      values.put(field, value);
+      return this;
+    }
+
+    public boolean isEmpty() {
+      return values.isEmpty();
+    }
+
+    public Set<String> fieldNames() {
+      return values.keySet().stream().map(Field::jsonName)
+          .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+    }
+
+    void applyTo(TrustFrameworkBundleConfig row) {
+      values.forEach((field, value) -> field.writer.accept(row, value));
+    }
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkProfileResolver.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkProfileResolver.java
@@ -1,0 +1,68 @@
+package eu.xfsc.fc.core.service.trustframework;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfig;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfigRepository;
+import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Resolves the effective {@link TrustFrameworkProfileConfig} for a given bundle profile ID
+ * by combining the YAML baseline from {@link TrustFrameworkRegistry} with optional
+ * per-bundle overrides persisted in {@link TrustFrameworkBundleConfigRepository}.
+ *
+ * <p>Precedence per field is DB override (non-null column) > YAML value > hard-coded
+ * default. Absence of an override row, or a NULL column on an existing row, lets the
+ * YAML value flow through.
+ *
+ * <p>Override rows for bundle IDs that are not registered with the registry are ignored
+ * with a warning so a renamed or removed bundle does not break compliance resolution.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TrustFrameworkProfileResolver {
+
+  private final TrustFrameworkRegistry registry;
+  private final TrustFrameworkBundleConfigRepository overrideRepository;
+
+  /**
+   * Returns the effective compliance configuration for the given bundle profile ID, with
+   * any persisted per-bundle overrides applied on top of the YAML baseline.
+   *
+   * @param profileId registry bundle profile ID (e.g. {@code gaia-x-2511})
+   * @return effective configuration; empty when no bundle is registered for the ID
+   */
+  public Optional<TrustFrameworkProfileConfig> getProfileConfig(String profileId) {
+    Optional<TrustFrameworkProfileConfig> baseline = registry.getProfileConfig(profileId);
+    if (baseline.isEmpty()) {
+      overrideRepository.findById(profileId).ifPresent(orphan ->
+          log.warn("getProfileConfig; override row for unknown bundle '{}' ignored", profileId));
+      return baseline;
+    }
+    return overrideRepository.findById(profileId)
+        .map(override -> applyOverride(baseline.get(), override))
+        .or(() -> baseline);
+  }
+
+  private TrustFrameworkProfileConfig applyOverride(
+      TrustFrameworkProfileConfig base, TrustFrameworkBundleConfig override) {
+    return new TrustFrameworkProfileConfig(
+        base.frameworkProfileId(),
+        base.familyId(),
+        nonBlankOr(override.getClientType(), base.clientType()),
+        nonBlankOr(override.getServiceUrl(), base.serviceUrl()),
+        nonBlankOr(override.getCompliancePath(), base.compliancePath()),
+        nonBlankOr(override.getApiVersion(), base.apiVersion()),
+        override.getTimeoutSeconds() != null ? override.getTimeoutSeconds() : base.timeoutSeconds()
+    );
+  }
+
+  private static String nonBlankOr(String candidate, String fallback) {
+    return candidate != null && !candidate.isBlank() ? candidate : fallback;
+  }
+}

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkService.java
@@ -83,22 +83,6 @@ public class TrustFrameworkService {
   }
 
   /**
-   * Replaces the service URL, API version, and timeout for the trust framework identified
-   * by the given family ID. Returns the updated config, or empty when no record exists.
-   */
-  @Transactional
-  public Optional<TrustFrameworkConfig> updateConfig(String family, String serviceUrl, String apiVersion,
-                                                     int timeoutSeconds) {
-    return trustFrameworkRepository.findById(family).map(entity -> {
-      entity.setServiceUrl(serviceUrl);
-      entity.setApiVersion(apiVersion);
-      entity.setTimeoutSeconds(timeoutSeconds);
-      trustFrameworkRepository.save(entity);
-      return TrustFrameworkMapper.toConfig(entity);
-    });
-  }
-
-  /**
    * Returns true if the named role in the given bundle profile is enabled.
    * Absence of a persisted state row means the role is enabled by default.
    *

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
@@ -6,7 +6,7 @@ import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.ServiceUnavailableException;
 import eu.xfsc.fc.core.exception.TimeoutException;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
-import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkProfileResolver;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 
 import lombok.RequiredArgsConstructor;
@@ -39,7 +39,7 @@ public class ComplianceCheckOrchestrator {
   private static final String MDC_ASSET_ID = "assetId";
   private static final String MDC_PROFILE_ID = "frameworkProfileId";
 
-  private final TrustFrameworkRegistry registry;
+  private final TrustFrameworkProfileResolver profileResolver;
   private final TrustFrameworkService tfService;
   private final TrustFrameworkClientRegistry clientRegistry;
 
@@ -95,7 +95,7 @@ public class ComplianceCheckOrchestrator {
   }
 
   private ComplianceCheckOutcome doCheck(String frameworkProfileId, String assetPayload) {
-    TrustFrameworkProfileConfig config = registry.getProfileConfig(frameworkProfileId)
+    TrustFrameworkProfileConfig config = profileResolver.getProfileConfig(frameworkProfileId)
         .orElseThrow(() -> new ClientException("Unknown trust-framework profile: " + frameworkProfileId));
 
     if (!tfService.isEnabled(config.familyId())) {

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetector.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetector.java
@@ -58,6 +58,27 @@ public class CredentialFormatDetector {
         return format;
     }
 
+    /**
+     * Decodes JWT-secured credential content to JSON-LD without verifying signatures or
+     * enforcing trust-framework policy.
+     *
+     * <p>Detects the format and delegates to the matching processor's
+     * {@link CredentialFormatProcessor#unwrapNested(ContentAccessor)} — a pure decode.
+     * Content that is not JWT-secured, or whose format is not recognised, is returned
+     * unchanged.
+     *
+     * @param content the incoming credential content
+     * @return the JSON-LD payload, or {@code content} unchanged when no decode applies
+     */
+    public ContentAccessor unwrapToJsonLd(ContentAccessor content) {
+        CredentialFormat format = detect(content);
+        return processors.stream()
+            .filter(p -> p.getFormat() == format)
+            .findFirst()
+            .map(p -> p.unwrapNested(content))
+            .orElse(content);
+    }
+
     private DetectionContext buildContext(String body) {
         if (!body.startsWith(JWT_PREFIX)) {
             return new DetectionContext(body, null, parseJson(body));

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -166,23 +166,23 @@ public class GraphRebuilder {
     }
   }
 
-    /**
-     * Processes one asset hash. Returns true when claims were extracted and pushed to
-     * the graph store, false when the asset was skipped (non-RDF — null contentAccessor).
-     * The caller uses the return value to decide whether to tick the progress counter.
-     */
-    private boolean addAssetToGraph(String hash) throws Exception {
+  /**
+   * Processes one asset hash. Returns true when claims were extracted and pushed to
+   * the graph store, false when the asset was skipped (non-RDF — null contentAccessor).
+   * The caller uses the return value to decide whether to tick the progress counter.
+   */
+  private boolean addAssetToGraph(String hash) throws Exception {
     AssetMetadata assetMetaData = assetStore.getByHash(hash);
     if (assetMetaData.getContentAccessor() == null) {
       return false;
     }
-        List<RdfClaim> claims = extractClaims(assetMetaData);
+    List<RdfClaim> claims = extractClaims(assetMetaData);
     claims = protectedNamespaceFilter.filterClaims(claims, "graph rebuild").claims();
     graphStore.addClaims(claims, assetMetaData.getId());
     return true;
   }
 
-    private List<RdfClaim> extractClaims(AssetMetadata assetMetaData) throws Exception {
+  private List<RdfClaim> extractClaims(AssetMetadata assetMetaData) throws Exception {
         String contentType = assetMetaData.getContentType();
         if (VerificationConstants.MEDIA_TYPE_NTRIPLES.equals(contentType)
                 || VerificationConstants.MEDIA_TYPE_TURTLE.equals(contentType)

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -10,6 +10,7 @@ import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.assetstore.AssetStore;
 import eu.xfsc.fc.core.service.validation.ValidationResultStore;
 import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
+import eu.xfsc.fc.core.service.verification.EnvelopedCredentialResolver;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
 import eu.xfsc.fc.core.service.verification.VerificationConstants;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
@@ -48,6 +49,7 @@ public class GraphRebuilder {
   private final AssetRepository assetRepository;
   private final ValidationResultStore validationResultStore;
   private final CredentialFormatDetector credentialFormatDetector;
+  private final EnvelopedCredentialResolver envelopedCredentialResolver;
 
   /**
    * Starts rebuilding the graphDb, blocking until finished or interrupted.
@@ -190,6 +192,10 @@ public class GraphRebuilder {
         // Parity with the upload path: JWT-secured credentials must be decoded to JSON-LD
         // before claim extraction. Pure content decode — no signature or policy enforcement.
         ContentAccessor content = credentialFormatDetector.unwrapToJsonLd(assetMetaData.getContentAccessor());
+        // VP payloads may embed inner credentials as EnvelopedVerifiableCredential entries
+        // (data:application/vc+jwt,... URIs). Resolve them in place so the claim extractors
+        // see the inner credentialSubject; the upload path does this in extractAndValidateClaims.
+        content = envelopedCredentialResolver.resolveInnerEnvelopedCredentials(content);
         List<RdfClaim> claims = claimExtractionService.extractCredentialClaims(content);
         if (claims == null || claims.isEmpty()) {
             log.debug("extractClaims; credential extraction returned empty for {}, falling back to all-triples", contentType);

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -4,10 +4,12 @@ import eu.xfsc.fc.core.dao.assets.AssetRepository;
 import eu.xfsc.fc.core.dao.validation.ValidationResult;
 import eu.xfsc.fc.core.pojo.AssetType;
 import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.RdfClaim;
 import eu.xfsc.fc.core.service.graphdb.GraphStore;
 import eu.xfsc.fc.core.service.assetstore.AssetStore;
 import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
 import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
 import eu.xfsc.fc.core.service.verification.VerificationConstants;
 import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
@@ -45,6 +47,7 @@ public class GraphRebuilder {
   private final ProtectedNamespaceFilter protectedNamespaceFilter;
   private final AssetRepository assetRepository;
   private final ValidationResultStore validationResultStore;
+  private final CredentialFormatDetector credentialFormatDetector;
 
   /**
    * Starts rebuilding the graphDb, blocking until finished or interrupted.
@@ -184,10 +187,13 @@ public class GraphRebuilder {
                 || VerificationConstants.MEDIA_TYPE_RDF_XML.equals(contentType)) {
             return claimExtractionService.extractAllTriples(assetMetaData.getContentAccessor());
         }
-        List<RdfClaim> claims = claimExtractionService.extractCredentialClaims(assetMetaData.getContentAccessor());
+        // Parity with the upload path: JWT-secured credentials must be decoded to JSON-LD
+        // before claim extraction. Pure content decode — no signature or policy enforcement.
+        ContentAccessor content = credentialFormatDetector.unwrapToJsonLd(assetMetaData.getContentAccessor());
+        List<RdfClaim> claims = claimExtractionService.extractCredentialClaims(content);
         if (claims == null || claims.isEmpty()) {
             log.debug("extractClaims; credential extraction returned empty for {}, falling back to all-triples", contentType);
-            return claimExtractionService.extractAllTriples(assetMetaData.getContentAccessor());
+            return claimExtractionService.extractAllTriples(content);
         }
         return claims;
     }

--- a/fc-service-core/src/main/resources/liquibase/changesets/019-drop-trust-framework-dead-cols.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/019-drop-trust-framework-dead-cols.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="Eric Nowak" id="2026-05-26-drop-trust-framework-dead-cols">
+        <comment>
+            Drops the service_url, api_version, and timeout_seconds columns from trust_frameworks.
+            These columns were never read at runtime — the compliance client reads endpoint
+            configuration from per-bundle YAML via TrustFrameworkRegistry, not from the DB row.
+        </comment>
+
+        <dropColumn tableName="trust_frameworks" columnName="service_url"/>
+        <dropColumn tableName="trust_frameworks" columnName="api_version"/>
+        <dropColumn tableName="trust_frameworks" columnName="timeout_seconds"/>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/changesets/020-trust-framework-bundle-config.xml
+++ b/fc-service-core/src/main/resources/liquibase/changesets/020-trust-framework-bundle-config.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="Eric Nowak" id="2026-05-27-trust-framework-bundle-config">
+        <comment>
+            Per-bundle runtime overrides for external client identifiers. The bundle YAML
+            remains the deployment-time baseline; rows in this table override individual
+            fields at runtime. Absence of a row, or a NULL field on an existing row, means
+            "fall back to YAML". Primary key is the registry bundle profile ID (e.g.
+            gaia-x-2511).
+        </comment>
+
+        <createTable tableName="trust_framework_bundle_config">
+            <column name="bundle_id" type="varchar(255)">
+                <constraints primaryKey="true" primaryKeyName="pk_tf_bundle_config" nullable="false"/>
+            </column>
+            <column name="client_type" type="varchar(255)"/>
+            <column name="service_url" type="varchar(1024)"/>
+            <column name="compliance_path" type="varchar(1024)"/>
+            <column name="api_version" type="varchar(64)"/>
+            <column name="timeout_seconds" type="integer"/>
+            <column name="trust_anchor_url" type="varchar(1024)"/>
+            <column name="created_at" type="timestamp with time zone"/>
+            <column name="updated_at" type="timestamp with time zone"/>
+        </createTable>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fc-service-core/src/main/resources/liquibase/master-changelog.xml
+++ b/fc-service-core/src/main/resources/liquibase/master-changelog.xml
@@ -22,4 +22,6 @@
     <include file="changesets/016-content-kind.xml" relativeToChangelogFile="true" />
     <include file="changesets/017-trust-framework-role-states.xml" relativeToChangelogFile="true" />
     <include file="changesets/018-mock-trust-framework-seed.xml" relativeToChangelogFile="true" />
+    <include file="changesets/019-drop-trust-framework-dead-cols.xml" relativeToChangelogFile="true"/>
+    <include file="changesets/020-trust-framework-bundle-config.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkProfileResolverTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/TrustFrameworkProfileResolverTest.java
@@ -1,0 +1,142 @@
+package eu.xfsc.fc.core.service.trustframework;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfig;
+import eu.xfsc.fc.core.dao.trustframework.TrustFrameworkBundleConfigRepository;
+import eu.xfsc.fc.core.service.trustframework.compliance.TrustFrameworkProfileConfig;
+
+class TrustFrameworkProfileResolverTest {
+
+  private static final String BUNDLE_ID = "gaia-x-2511";
+  private static final String FAMILY_ID = "gaia-x";
+
+  private static final TrustFrameworkProfileConfig YAML_BASELINE = new TrustFrameworkProfileConfig(
+      BUNDLE_ID, FAMILY_ID,
+      "jwt-vc-compliance",
+      "https://compliance.gaia-x.eu/v2",
+      "/api/credential-offers/standard-compliance",
+      "v2",
+      30
+  );
+
+  private TrustFrameworkRegistry registry;
+  private TrustFrameworkBundleConfigRepository overrides;
+  private TrustFrameworkProfileResolver resolver;
+
+  @BeforeEach
+  void setUp() {
+    registry = mock(TrustFrameworkRegistry.class);
+    overrides = mock(TrustFrameworkBundleConfigRepository.class);
+    resolver = new TrustFrameworkProfileResolver(registry, overrides);
+    when(registry.getProfileConfig(BUNDLE_ID)).thenReturn(Optional.of(YAML_BASELINE));
+    when(overrides.findById(any())).thenReturn(Optional.empty());
+  }
+
+  @Test
+  void getProfileConfig_noOverrideRow_returnsYamlBaseline() {
+    Optional<TrustFrameworkProfileConfig> result = resolver.getProfileConfig(BUNDLE_ID);
+
+    assertThat(result).contains(YAML_BASELINE);
+  }
+
+  @Test
+  void getProfileConfig_unknownBundleId_returnsEmpty() {
+    when(registry.getProfileConfig("missing")).thenReturn(Optional.empty());
+
+    Optional<TrustFrameworkProfileConfig> result = resolver.getProfileConfig("missing");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void getProfileConfig_serviceUrlOverride_appliesOverride() {
+    TrustFrameworkBundleConfig override = TrustFrameworkBundleConfig.builder()
+        .bundleId(BUNDLE_ID)
+        .serviceUrl("https://mock.test/v2")
+        .build();
+    when(overrides.findById(BUNDLE_ID)).thenReturn(Optional.of(override));
+
+    TrustFrameworkProfileConfig result = resolver.getProfileConfig(BUNDLE_ID).orElseThrow();
+
+    assertThat(result.serviceUrl()).isEqualTo("https://mock.test/v2");
+    assertThat(result.compliancePath()).isEqualTo(YAML_BASELINE.compliancePath());
+    assertThat(result.apiVersion()).isEqualTo(YAML_BASELINE.apiVersion());
+    assertThat(result.timeoutSeconds()).isEqualTo(YAML_BASELINE.timeoutSeconds());
+    assertThat(result.clientType()).isEqualTo(YAML_BASELINE.clientType());
+  }
+
+  @Test
+  void getProfileConfig_timeoutOverride_appliesOverride() {
+    TrustFrameworkBundleConfig override = TrustFrameworkBundleConfig.builder()
+        .bundleId(BUNDLE_ID)
+        .timeoutSeconds(90)
+        .build();
+    when(overrides.findById(BUNDLE_ID)).thenReturn(Optional.of(override));
+
+    TrustFrameworkProfileConfig result = resolver.getProfileConfig(BUNDLE_ID).orElseThrow();
+
+    assertThat(result.timeoutSeconds()).isEqualTo(90);
+    assertThat(result.serviceUrl()).isEqualTo(YAML_BASELINE.serviceUrl());
+  }
+
+  @Test
+  void getProfileConfig_clientTypeOverride_appliesOverride() {
+    TrustFrameworkBundleConfig override = TrustFrameworkBundleConfig.builder()
+        .bundleId(BUNDLE_ID)
+        .clientType("untp-credential-exchange")
+        .build();
+    when(overrides.findById(BUNDLE_ID)).thenReturn(Optional.of(override));
+
+    TrustFrameworkProfileConfig result = resolver.getProfileConfig(BUNDLE_ID).orElseThrow();
+
+    assertThat(result.clientType()).isEqualTo("untp-credential-exchange");
+    assertThat(result.serviceUrl()).isEqualTo(YAML_BASELINE.serviceUrl());
+  }
+
+  @Test
+  void getProfileConfig_blankOverrideFields_fallsBackToYaml() {
+    TrustFrameworkBundleConfig override = TrustFrameworkBundleConfig.builder()
+        .bundleId(BUNDLE_ID)
+        .serviceUrl("   ")
+        .apiVersion("")
+        .build();
+    when(overrides.findById(BUNDLE_ID)).thenReturn(Optional.of(override));
+
+    TrustFrameworkProfileConfig result = resolver.getProfileConfig(BUNDLE_ID).orElseThrow();
+
+    assertThat(result.serviceUrl()).isEqualTo(YAML_BASELINE.serviceUrl());
+    assertThat(result.apiVersion()).isEqualTo(YAML_BASELINE.apiVersion());
+  }
+
+  @Test
+  void getProfileConfig_allFieldsOverridden_appliesAll() {
+    TrustFrameworkBundleConfig override = TrustFrameworkBundleConfig.builder()
+        .bundleId(BUNDLE_ID)
+        .clientType("untp-credential-exchange")
+        .serviceUrl("https://mock.test/v3")
+        .compliancePath("/different/path")
+        .apiVersion("v3")
+        .timeoutSeconds(15)
+        .build();
+    when(overrides.findById(BUNDLE_ID)).thenReturn(Optional.of(override));
+
+    TrustFrameworkProfileConfig result = resolver.getProfileConfig(BUNDLE_ID).orElseThrow();
+
+    assertThat(result.clientType()).isEqualTo("untp-credential-exchange");
+    assertThat(result.serviceUrl()).isEqualTo("https://mock.test/v3");
+    assertThat(result.compliancePath()).isEqualTo("/different/path");
+    assertThat(result.apiVersion()).isEqualTo("v3");
+    assertThat(result.timeoutSeconds()).isEqualTo(15);
+    assertThat(result.frameworkProfileId()).isEqualTo(BUNDLE_ID);
+    assertThat(result.familyId()).isEqualTo(FAMILY_ID);
+  }
+}

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
@@ -17,7 +17,7 @@ import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.ServiceUnavailableException;
 import eu.xfsc.fc.core.exception.TimeoutException;
-import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkProfileResolver;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 
 /**
@@ -45,7 +45,7 @@ class ComplianceCheckOrchestratorTest {
       "/api/credential-offers/standard-compliance", "loire", 30);
 
   @Mock
-  private TrustFrameworkRegistry registry;
+  private TrustFrameworkProfileResolver profileResolver;
 
   @Mock
   private TrustFrameworkService tfService;
@@ -60,7 +60,7 @@ class ComplianceCheckOrchestratorTest {
 
   @BeforeEach
   void setUp() {
-    orchestrator = new ComplianceCheckOrchestrator(registry, tfService, clientRegistry);
+    orchestrator = new ComplianceCheckOrchestrator(profileResolver, tfService, clientRegistry);
   }
 
   @Test
@@ -77,7 +77,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_unknownProfileId_throwsClientException() {
-    when(registry.getProfileConfig("unknown-id")).thenReturn(Optional.empty());
+    when(profileResolver.getProfileConfig("unknown-id")).thenReturn(Optional.empty());
 
     assertThrows(ClientException.class,
         () -> orchestrator.check(ASSET_ID, "unknown-id", ASSET_PAYLOAD));
@@ -85,7 +85,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_familyDisabled_throwsConflictException() {
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(false);
 
     assertThrows(ConflictException.class,
@@ -94,7 +94,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_clientRegistryThrowsIllegalArgument_throwsClientException() {
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenThrow(new IllegalArgumentException("unknown clientType"));
 
@@ -105,7 +105,7 @@ class ComplianceCheckOrchestratorTest {
   @Test
   void check_familyEnabled_delegatesToClientAndReturnsOutcome() {
     var expected = new IssuedAttestation("some-jwt", null);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenReturn(expected);
@@ -117,7 +117,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_clientThrowsTimeoutException_propagates() {
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenThrow(new TimeoutException("timed out"));
@@ -128,7 +128,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_clientThrowsServiceUnavailableException_propagates() {
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenThrow(new ServiceUnavailableException("unreachable"));
@@ -139,7 +139,7 @@ class ComplianceCheckOrchestratorTest {
 
   @Test
   void check_clientReturnsNull_throwsServiceUnavailableException() {
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenReturn(null);
@@ -158,7 +158,7 @@ class ComplianceCheckOrchestratorTest {
   @Test
   void check_vpIdMatches_delegatesToClient() {
     var expected = new IssuedAttestation("cred-jwt", null);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenReturn(expected);
@@ -171,7 +171,7 @@ class ComplianceCheckOrchestratorTest {
   @Test
   void check_clientThrowsClientException_propagates() {
     var cause = new ClientException("business error from compliance service");
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
     when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
     when(mockClient.check(any(), any())).thenThrow(cause);

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetectorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/verification/CredentialFormatDetectorTest.java
@@ -1,5 +1,6 @@
 package eu.xfsc.fc.core.service.verification;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -12,6 +13,8 @@ import com.nimbusds.jose.jwk.gen.OctetKeyPairGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
+import eu.xfsc.fc.core.exception.ClientException;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
 import eu.xfsc.fc.core.pojo.ContentAccessorDirect;
 import eu.xfsc.fc.core.service.verification.signature.JwtSignatureVerifier;
 
@@ -26,8 +29,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static eu.xfsc.fc.core.service.verification.TestVerificationConstants.GAIAX_2511_CONTEXT;
+import static eu.xfsc.fc.core.service.verification.VerificationConstants.JWT_PREFIX;
 import static eu.xfsc.fc.core.service.verification.VerificationConstants.VC_20_CONTEXT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CredentialFormatDetectorTest {
 
@@ -38,6 +46,15 @@ class CredentialFormatDetectorTest {
             mock(JwtSignatureVerifier.class)),
         new Vc2DanubeTechCredentialProcessor(
             mock(JwtContentPreprocessor.class),
+            mock(JwtSignatureVerifier.class))
+    ));
+    // Detector wired with real parsers so unwrapToJsonLd() actually decodes JWT → JSON-LD.
+    private final CredentialFormatDetector unwrappingDetector = new CredentialFormatDetector(OBJECT_MAPPER, List.of(
+        new LoireCredentialProcessor(
+            new LoireJwtParser(), mock(LoirePolicyEnforcer.class),
+            mock(JwtSignatureVerifier.class)),
+        new Vc2DanubeTechCredentialProcessor(
+            new JwtContentPreprocessor(),
             mock(JwtSignatureVerifier.class))
     ));
     private static JWSSigner signer;
@@ -265,6 +282,119 @@ class CredentialFormatDetectorTest {
         assertEquals(CredentialFormat.UNKNOWN, result);
     }
 
+
+    // --- unwrapToJsonLd: JWT-secured content is decoded to JSON-LD (no signature/policy) ---
+
+    @Test
+    void unwrapToJsonLd_loireVcJwt_returnsTopLevelJsonLd() throws Exception {
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(
+            new ContentAccessorDirect(buildLoireVcJwt()));
+
+        String json = result.getContentAsString();
+        assertFalse(json.startsWith(JWT_PREFIX), "payload must no longer be a compact JWT");
+        JsonNode payload = OBJECT_MAPPER.readTree(json);
+        assertTrue(payload.has("@context"), "Loire payload carries top-level @context");
+        assertTrue(payload.has("credentialSubject"), "VC payload carries credentialSubject");
+    }
+
+    @Test
+    void unwrapToJsonLd_loireVpJwt_returnsTopLevelJsonLd() throws Exception {
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(
+            new ContentAccessorDirect(buildLoireVpJwt()));
+
+        String json = result.getContentAsString();
+        assertFalse(json.startsWith(JWT_PREFIX), "payload must no longer be a compact JWT");
+        JsonNode payload = OBJECT_MAPPER.readTree(json);
+        assertEquals("VerifiablePresentation", payload.get("type").get(0).asText());
+    }
+
+    @Test
+    void unwrapToJsonLd_danubetechVcJwt_returnsJsonLd() throws Exception {
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(
+            new ContentAccessorDirect(buildDanubetechVcJwt()));
+
+        String json = result.getContentAsString();
+        assertFalse(json.startsWith(JWT_PREFIX), "payload must no longer be a compact JWT");
+        JsonNode payload = OBJECT_MAPPER.readTree(json);
+        assertTrue(payload.has("credentialSubject"), "unwrapped danubetech VC carries credentialSubject");
+    }
+
+    @Test
+    void unwrapToJsonLd_nonJwtVc2JsonLd_returnsUnchanged() {
+        ContentAccessor input = new ContentAccessorDirect("""
+            {
+              "@context": ["https://www.w3.org/ns/credentials/v2"],
+              "type": ["VerifiableCredential"]
+            }
+            """);
+
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(input);
+
+        assertSame(input, result, "non-JWT JSON-LD must pass through unchanged");
+    }
+
+    @Test
+    void unwrapToJsonLd_unknownContent_returnsUnchanged() {
+        ContentAccessor input = new ContentAccessorDirect("""
+            {
+              "@context": ["https://example.org/custom"],
+              "type": ["SomethingElse"]
+            }
+            """);
+
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(input);
+
+        assertSame(input, result, "unrecognised format must pass through unchanged");
+    }
+
+    @Test
+    void unwrapToJsonLd_nonRdfText_returnsUnchanged() {
+        ContentAccessor input = new ContentAccessorDirect("not json at all");
+
+        ContentAccessor result = unwrappingDetector.unwrapToJsonLd(input);
+
+        assertSame(input, result, "non-credential text must pass through unchanged");
+    }
+
+    @Test
+    void unwrapToJsonLd_recognizedButInvalidJwt_throwsClientException() throws Exception {
+        // typ + top-level @context route this to the Loire parser, which then rejects the
+        // missing 'cty' header. The resulting ClientException is what the rebuild worker
+        // catches, logs with the asset hash, and counts as an error (batch continues).
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+                .keyID("did:web:example.com#test-key")
+                .type(new JOSEObjectType("vc+ld+json+jwt"))
+                .build();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer("did:web:example.com")
+                .claim("@context", List.of(VC_20_CONTEXT, GAIAX_2511_CONTEXT))
+                .claim("type", List.of("VerifiableCredential", "gx:LegalPerson"))
+                .claim("credentialSubject", Map.of("id", "did:web:example.com"))
+                .build();
+        SignedJWT signedJwt = new SignedJWT(header, claims);
+        signedJwt.sign(signer);
+        ContentAccessor content = new ContentAccessorDirect(signedJwt.serialize());
+
+        assertThrows(ClientException.class, () -> unwrappingDetector.unwrapToJsonLd(content));
+    }
+
+    private String buildDanubetechVcJwt() throws Exception {
+        JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)
+                .keyID("did:web:example.com#test-key")
+                .build();
+        JSONObject vcObj = new JSONObject();
+        vcObj.put("@context", List.of(VC_20_CONTEXT));
+        vcObj.put("type", List.of("VerifiableCredential"));
+        vcObj.put("credentialSubject", Map.of("id", "did:web:example.com"));
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer("did:web:example.com")
+                .subject("did:web:example.com")
+                .claim("vc", vcObj)
+                .build();
+        SignedJWT signedJwt = new SignedJWT(header, claims);
+        signedJwt.sign(signer);
+        return signedJwt.serialize();
+    }
 
     private String buildLoireVcJwt() throws Exception {
         JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.EdDSA)

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/config/SecurityConfig.java
@@ -134,6 +134,7 @@ public class SecurityConfig {
           .requestMatchers(HttpMethod.GET, "/admin/trust-frameworks").hasRole(ADMIN_ALL)
           .requestMatchers(HttpMethod.PATCH, "/admin/trust-frameworks/**").hasRole(ADMIN_ALL)
           .requestMatchers(HttpMethod.PUT, "/admin/trust-frameworks/**").hasRole(ADMIN_ALL)
+          .requestMatchers(HttpMethod.DELETE, "/admin/trust-frameworks/**").hasRole(ADMIN_ALL)
 
           // Schema Validation Admin APIs
           // Both GET wildcards are load-bearing: any future GET /admin/schema-validation/<x>

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/ComplianceCheckService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/ComplianceCheckService.java
@@ -11,6 +11,7 @@ import eu.xfsc.fc.api.generated.model.ComplianceCheckRequest;
 import eu.xfsc.fc.api.generated.model.ComplianceCheckResult;
 import eu.xfsc.fc.api.generated.model.StoredValidationResult;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkPublicEntry;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkProfileResolver;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 import eu.xfsc.fc.core.service.trustframework.compliance.ComplianceCheckOrchestrator;
@@ -36,6 +37,7 @@ public class ComplianceCheckService implements ComplianceApiDelegate {
   private final ComplianceResultStore resultStore;
   private final TrustFrameworkService trustFrameworkService;
   private final TrustFrameworkRegistry registry;
+  private final TrustFrameworkProfileResolver profileResolver;
 
   @Override
   public ResponseEntity<ComplianceCheckResult> runComplianceCheck(String assetId,
@@ -46,7 +48,7 @@ public class ComplianceCheckService implements ComplianceApiDelegate {
     ComplianceCheckOutcome outcome = orchestrator.check(assetId, request.getFrameworkProfileId(),
         request.getCredential());
 
-    String familyId = registry.getProfileConfig(request.getFrameworkProfileId())
+    String familyId = profileResolver.getProfileConfig(request.getFrameworkProfileId())
         .map(TrustFrameworkProfileConfig::familyId)
         .orElse(request.getFrameworkProfileId());
 

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphDatabaseAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphDatabaseAdminService.java
@@ -81,7 +81,7 @@ public class GraphDatabaseAdminService implements GraphDatabaseAdminApiDelegate 
     if (!probe.reachable()) {
       throw new ClientException(
           "Target backend " + target.name() + " is not reachable: " + probe.message()
-          + ". Verify the backend container is up and the URI configuration is correct.");
+              + ". Verify the backend container is up and the URI configuration is correct.");
     }
 
     // Swap the live adapter first; persist the preference only after a successful swap.
@@ -116,7 +116,7 @@ public class GraphDatabaseAdminService implements GraphDatabaseAdminApiDelegate 
   }
 
   private boolean computeRebuildNeeded(GraphBackendType backendType, long claimCount,
-      long rdfAssetCount) {
+                                       long rdfAssetCount) {
     if (backendType == GraphBackendType.NONE || claimCount != 0L) {
       return false;
     }

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/TrustFrameworkAdminService.java
@@ -1,14 +1,17 @@
 package eu.xfsc.fc.server.service;
 
-import java.time.Duration;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import eu.xfsc.fc.api.generated.model.TrustFrameworkBundleEffectiveConfig;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkBundleEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
@@ -17,29 +20,28 @@ import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.NotFoundException;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundleConfigService;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundleConfigService.Field;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundleConfigService.Overrides;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
-import eu.xfsc.fc.server.config.AdminDashboardConfig;
 import eu.xfsc.fc.server.generated.controller.TrustFrameworkAdminApiDelegate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * HTTP delegate for the trust framework admin endpoints. Delegates persistence operations
- * to {@link TrustFrameworkService}; only HTTP-shape concerns (status codes, DTO mapping,
- * connectivity probing) live here.
+ * to {@link TrustFrameworkService}; only HTTP-shape concerns (status codes, DTO mapping)
+ * live here.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegate {
 
-  private static final Duration CONNECTIVITY_TIMEOUT = Duration.ofSeconds(5);
-  private static final int DEFAULT_TIMEOUT_SECONDS = 30;
-
   private final TrustFrameworkService trustFrameworkService;
   private final TrustFrameworkRegistry trustFrameworkRegistry;
-  private final AdminDashboardConfig adminDashboardConfig;
+  private final TrustFrameworkBundleConfigService bundleConfigService;
 
   @Value("${federated-catalogue.enabled-trust-frameworks:}")
   private List<String> enabledTrustFrameworkFamilies;
@@ -76,8 +78,7 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
 
   /**
    * Applies a merge-patch to the identified trust framework family. Supports toggling the
-   * enabled state and updating configuration fields independently or in combination.
-   * Returns 404 if the family identifier is not registered.
+   * enabled state. Returns 404 if the family identifier is not registered.
    *
    * @param id    trust framework family identifier
    * @param patch fields to update; only non-null fields are applied
@@ -85,23 +86,92 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
    */
   @Override
   public ResponseEntity<Void> patchTrustFramework(String id, TrustFrameworkPatch patch) {
-    boolean touchesConfig = patch.getServiceUrl() != null
-        || patch.getApiVersion() != null
-        || patch.getTimeoutSeconds() != null;
-    if (patch.getEnabled() == null && !touchesConfig) {
+    if (patch.getEnabled() == null) {
       throw new ClientException("Patch body must contain at least one field");
     }
-    if (patch.getEnabled() != null) {
-      trustFrameworkService.setEnabled(id, patch.getEnabled());
+    trustFrameworkService.setEnabled(id, patch.getEnabled());
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * Applies a merge-patch (RFC 7396) to the external client identifiers of a single
+   * bundle.
+   * <ul>
+   *   <li>A property with a non-null value overrides the YAML for that field.</li>
+   *   <li>A property explicitly set to JSON null clears the override and lets the YAML
+   *       value flow through again.</li>
+   *   <li>An omitted property leaves the existing state unchanged.</li>
+   * </ul>
+   * The change takes effect on the next compliance call — no restart required.
+   *
+   * @param bundleId registry bundle profile ID
+   * @param body     decoded merge-patch object (set of property → value)
+   * @return 200 on success, 400 if the body is empty or contains unknown / mistyped
+   * properties, 404 if the bundle is not registered
+   */
+  @Override
+  public ResponseEntity<Void> patchTrustFrameworkBundleConfig(
+      String bundleId, Map<String, Object> patch) {
+    if (patch == null || patch.isEmpty()) {
+      throw new ClientException("Patch body must contain at least one field");
     }
-    if (touchesConfig) {
-      int timeoutSeconds = patch.getTimeoutSeconds() != null
-          ? patch.getTimeoutSeconds() : DEFAULT_TIMEOUT_SECONDS;
-      if (trustFrameworkService.updateConfig(id, patch.getServiceUrl(),
-          patch.getApiVersion(), timeoutSeconds).isEmpty()) {
-        throw new NotFoundException("Trust framework not found: " + id);
+
+    Overrides overrides = Overrides.empty();
+    Set<Field> fieldsToClear = EnumSet.noneOf(Field.class);
+    for (Map.Entry<String, Object> entry : patch.entrySet()) {
+      Field field = parseField(entry.getKey());
+      Object value = entry.getValue();
+      if (value == null) {
+        fieldsToClear.add(field);
+      } else {
+        overrides.put(field, coerce(field, value));
       }
     }
+
+    bundleConfigService.applyPatch(bundleId, overrides, fieldsToClear);
+    return ResponseEntity.ok().build();
+  }
+
+  private static Field parseField(String jsonName) {
+    try {
+      return Field.fromJsonName(jsonName);
+    } catch (IllegalArgumentException e) {
+      throw new ClientException("Unknown bundle config property: " + jsonName);
+    }
+  }
+
+  private static Object coerce(Field field, Object value) {
+    return switch (field) {
+      case TIMEOUT_SECONDS -> {
+        if (value instanceof Integer i) {
+          yield i;
+        }
+        if (value instanceof Number n) {
+          yield n.intValue();
+        }
+        throw new ClientException("Property '" + field.jsonName()
+            + "' must be a JSON integer");
+      }
+      case CLIENT_TYPE, SERVICE_URL, COMPLIANCE_PATH, API_VERSION, TRUST_ANCHOR_URL -> {
+        if (value instanceof String s) {
+          yield s;
+        }
+        throw new ClientException("Property '" + field.jsonName()
+            + "' must be a JSON string");
+      }
+    };
+  }
+
+  /**
+   * Clears every persisted override for the given bundle, reverting the runtime
+   * configuration to the YAML baseline. Idempotent.
+   *
+   * @param bundleId registry bundle profile ID
+   * @return 200 on success, 404 if the bundle is not registered
+   */
+  @Override
+  public ResponseEntity<Void> deleteTrustFrameworkBundleConfig(String bundleId) {
+    bundleConfigService.clear(bundleId);
     return ResponseEntity.ok().build();
   }
 
@@ -119,11 +189,7 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
     TrustFrameworkEntry entry = new TrustFrameworkEntry();
     entry.setId(config.id());
     entry.setName(config.name());
-    entry.setServiceUrl(config.serviceUrl());
-    entry.setApiVersion(config.apiVersion());
-    entry.setTimeoutSeconds(config.timeoutSeconds());
     entry.setEnabled(config.enabled());
-    entry.setConnected(checkConnectivity(config));
     entry.setBundles(buildBundleEntries(config.id()));
     return entry;
   }
@@ -142,29 +208,36 @@ public class TrustFrameworkAdminService implements TrustFrameworkAdminApiDelegat
       if (!familyId.equals(bundle.config().family())) {
         continue;
       }
+      String bundleId = bundle.config().id();
       TrustFrameworkBundleEntry bundleEntry = new TrustFrameworkBundleEntry();
-      bundleEntry.setId(bundle.config().id());
-      bundleEntry.setRoles(trustFrameworkService.getRoleStates(bundle.config().id()));
+      bundleEntry.setId(bundleId);
+      bundleEntry.setRoles(trustFrameworkService.getRoleStates(bundleId));
+      bundleConfigService.getEffectiveConfig(bundleId).ifPresent(eff -> {
+        bundleEntry.setEffectiveConfig(toEffectiveConfigDto(eff));
+        bundleEntry.setOverriddenFields(eff.overriddenFields().stream()
+            .map(Field::jsonName)
+            .sorted()
+            .toList());
+      });
       result.add(bundleEntry);
     }
     return result;
   }
 
-  private boolean checkConnectivity(TrustFrameworkConfig config) {
-    if (config.serviceUrl() == null || config.serviceUrl().isBlank()) {
-      return false;
+  private static TrustFrameworkBundleEffectiveConfig toEffectiveConfigDto(
+      TrustFrameworkBundleConfigService.EffectiveBundleConfig effective) {
+    TrustFrameworkBundleEffectiveConfig dto = new TrustFrameworkBundleEffectiveConfig();
+    Map<Field, Object> values = effective.values();
+    dto.setClientType((String) values.get(Field.CLIENT_TYPE));
+    dto.setServiceUrl((String) values.get(Field.SERVICE_URL));
+    dto.setCompliancePath((String) values.get(Field.COMPLIANCE_PATH));
+    dto.setApiVersion((String) values.get(Field.API_VERSION));
+    Object timeout = values.get(Field.TIMEOUT_SECONDS);
+    if (timeout instanceof Integer i) {
+      dto.setTimeoutSeconds(i);
     }
-    try {
-      adminDashboardConfig.getWebClient().get().uri(config.serviceUrl())
-          .retrieve().toBodilessEntity()
-          .timeout(Duration.ofSeconds(config.timeoutSeconds() > 0
-              ? Math.min(config.timeoutSeconds(), CONNECTIVITY_TIMEOUT.getSeconds())
-              : CONNECTIVITY_TIMEOUT.getSeconds()))
-          .block();
-      return true;
-    } catch (Exception e) {
-      log.warn("Trust framework connectivity check failed for {}", config.id(), e);
-      return false;
-    }
+    dto.setTrustAnchorUrl((String) values.get(Field.TRUST_ANCHOR_URL));
+    return dto;
   }
+
 }

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/ComplianceCheckControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/ComplianceCheckControllerTest.java
@@ -139,7 +139,7 @@ public class ComplianceCheckControllerTest {
   @WithMockUser
   void getTrustFrameworksPublic_noEnabledFrameworks_returnsEmptyArray() throws Exception {
     when(trustFrameworkService.findAll()).thenReturn(List.of(
-        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, false, null, null)));
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", false, null, null)));
     when(registry.getActiveBundles()).thenReturn(List.of());
 
     mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
@@ -153,7 +153,7 @@ public class ComplianceCheckControllerTest {
   @WithMockUser
   void getTrustFrameworksPublic_enabledFramework_returnsEntryWithIdAndName() throws Exception {
     when(trustFrameworkService.findAll()).thenReturn(List.of(
-        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, true, null, null)));
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", true, null, null)));
     when(registry.getActiveBundles()).thenReturn(List.of());
 
     mockMvc.perform(MockMvcRequestBuilders.get("/trust-frameworks")
@@ -169,7 +169,7 @@ public class ComplianceCheckControllerTest {
   @WithMockUser
   void getTrustFrameworksPublic_enabledFrameworkWithActiveProfile_returnsProfileInEntry() throws Exception {
     when(trustFrameworkService.findAll()).thenReturn(List.of(
-        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", null, "22.10", 30, true, null, null)));
+        new TrustFrameworkConfig("gaia-x", "Gaia-X Trust Framework", true, null, null)));
     var bundleCfg = new FrameworkBundleConfig("gaia-x-2511", "gaia-x",
         "https://compliance.gaia-x.eu/", ValidationType.SHACL, Map.of(), Map.of());
     when(registry.getActiveBundles()).thenReturn(List.of(new TrustFrameworkBundle(bundleCfg, null, null)));

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/QueryControllerFusekiTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/QueryControllerFusekiTest.java
@@ -45,7 +45,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureEmbeddedDatabase(provider = DatabaseProvider.ZONKY)
-@TestPropertySource(properties = {"graphstore.impl=fuseki"})
+// The embedded Fuseki dataset is a singleton in any Spring context the test framework caches
+// across `graphstore.impl=fuseki` tests. The "test.fuseki.isolate" marker below makes this class's
+// context cache key unique, so the dataset is dedicated to this test and only contains the two
+// claims seeded in @BeforeAll — no leakage from neighbouring fuseki tests.
+@TestPropertySource(properties = {"graphstore.impl=fuseki", "test.fuseki.isolate=QueryControllerFusekiTest"})
 @WithMockUser(roles = {QUERY_EXECUTE})
 public class QueryControllerFusekiTest {
 

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/QueryControllerFusekiTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/QueryControllerFusekiTest.java
@@ -86,7 +86,8 @@ public class QueryControllerFusekiTest {
   @Test
   void postQuery_withSparqlSelect_returnsUploadedClaimData() throws Exception {
     String sparqlQuery = "SELECT ?s ?p ?o WHERE { <<(?s ?p ?o)>> "
-        + "<https://www.w3.org/2018/credentials#credentialSubject> ?cs }";
+        + "<https://www.w3.org/2018/credentials#credentialSubject> "
+        + "<http://example.org/credential-fuseki-test> }";
 
     String response = postSparqlQuery(sparqlQuery)
         .andExpect(status().isOk())

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/controller/TrustFrameworkAdminControllerTest.java
@@ -41,6 +41,28 @@ public class TrustFrameworkAdminControllerTest {
   public static final String ENABLED_TRUE = """
       {"enabled":true}
       """;
+  public static final String BUNDLE_CONFIG_SERVICE_URL_OVERRIDE = """
+      {"serviceUrl":"https://mock.test/v2"}
+      """;
+  public static final String BUNDLE_CONFIG_SERVICE_URL_NULL = """
+      {"serviceUrl":null}
+      """;
+  public static final String BUNDLE_CONFIG_UNKNOWN_PROPERTY = """
+      {"unknownProperty":"x"}
+      """;
+  public static final String BUNDLE_CONFIG_WRONG_TYPE = """
+      {"timeoutSeconds":"not-a-number"}
+      """;
+  public static final String BUNDLE_CONFIG_FULL_OVERRIDE = """
+      {
+        "clientType":"jwt-vc-compliance",
+        "serviceUrl":"https://mock.test/v2",
+        "compliancePath":"/api/credential-offers/standard-compliance",
+        "apiVersion":"v2",
+        "timeoutSeconds":15,
+        "trustAnchorUrl":"https://registry.test/v1/trust-anchors"
+      }
+      """;
   @Autowired
   private MockMvc mockMvc;
 
@@ -120,63 +142,6 @@ public class TrustFrameworkAdminControllerTest {
             .content(ENABLED_TRUE)
             .with(csrf()))
         .andExpect(status().isNotFound());
-  }
-
-  @Test
-  @WithMockUser(roles = {ADMIN_ALL})
-  void patchTrustFramework_configFields_updatesConfig() throws Exception {
-    String body = """
-        {
-          "serviceUrl":"https://new.example.com",
-          "apiVersion":"v2",
-          "timeoutSeconds":60
-        }
-        """;
-
-    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
-            .contentType(MERGE_PATCH_JSON_VALUE)
-            .content(body)
-            .with(csrf()))
-        .andExpect(status().isOk());
-
-    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
-            .accept(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].serviceUrl").value(hasItem("https://new.example.com")))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].apiVersion").value(hasItem("v2")))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].timeoutSeconds").value(hasItem(60)));
-  }
-
-  @Test
-  @WithMockUser(roles = {ADMIN_ALL})
-  void patchTrustFramework_enabledAndConfigFields_appliesBoth() throws Exception {
-    String body = """
-        {
-          "enabled":true,
-          "serviceUrl":"https://combined.example.com",
-          "apiVersion":"v3",
-          "timeoutSeconds":45
-        }
-        """;
-
-    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
-            .contentType(MERGE_PATCH_JSON_VALUE)
-            .content(body)
-            .with(csrf()))
-        .andExpect(status().isOk());
-
-    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
-            .accept(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].enabled").value(hasItem(true)))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].serviceUrl").value(hasItem("https://combined.example.com")))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].apiVersion").value(hasItem("v3")))
-        .andExpect(jsonPath("$[?(@.id == 'gaia-x')].timeoutSeconds").value(hasItem(45)));
-
-    // Reset
-    mockMvc.perform(MockMvcRequestBuilders.patch("/admin/trust-frameworks/gaia-x")
-            .contentType(MERGE_PATCH_JSON_VALUE)
-            .content(ENABLED_FALSE)
-            .with(csrf()))
-        .andExpect(status().isOk());
   }
 
   @Test
@@ -266,6 +231,44 @@ public class TrustFrameworkAdminControllerTest {
 
   @Test
   @WithMockUser(roles = {ADMIN_ALL})
+  void getTrustFrameworks_bundleEntry_includesYamlEffectiveConfigBeforeAnyOverride() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].effectiveConfig.serviceUrl")
+            .value(hasItem(notNullValue())))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].effectiveConfig.compliancePath")
+            .value(hasItem(notNullValue())))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].overriddenFields")
+            .value(hasItem(hasSize(0))));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void getTrustFrameworks_bundleEntry_reflectsPatchedOverrideInEffectiveConfig() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/mock-2026")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].effectiveConfig.serviceUrl")
+            .value(hasItem("https://mock.test/v2")))
+        .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].overriddenFields")
+            .value(hasItem(hasItem("serviceUrl"))));
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/mock-2026")
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
   void getTrustFrameworks_includesBundlesField() throws Exception {
     mockMvc.perform(MockMvcRequestBuilders.get("/admin/trust-frameworks")
             .accept(MediaType.APPLICATION_JSON))
@@ -283,6 +286,179 @@ public class TrustFrameworkAdminControllerTest {
             .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[?(@.id == 'mock')].bundles[0].id").value(hasItem("mock-2026")));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_serviceUrlField_returns200() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_allFields_returns200() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_FULL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_unknownBundle_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/nonexistent-bundle")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.message", notNullValue()));
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_emptyBody_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content("{}")
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_missingBody_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            // missing body
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void patchTrustFrameworkBundleConfig_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void patchTrustFrameworkBundleConfig_wrongRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_explicitNull_clearsOverride() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_NULL)
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_unknownProperty_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_UNKNOWN_PROPERTY)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void patchTrustFrameworkBundleConfig_wrongType_returns400() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_WRONG_TYPE)
+            .with(csrf()))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void deleteTrustFrameworkBundleConfig_existingOverride_returns200() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .patch("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .contentType(MERGE_PATCH_JSON_VALUE)
+            .content(BUNDLE_CONFIG_SERVICE_URL_OVERRIDE)
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void deleteTrustFrameworkBundleConfig_noOverrideRow_isIdempotent() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser(roles = {ADMIN_ALL})
+  void deleteTrustFrameworkBundleConfig_unknownBundle_returns404() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/nonexistent-bundle")
+            .with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void deleteTrustFrameworkBundleConfig_unauthenticated_returns401() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(csrf()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void deleteTrustFrameworkBundleConfig_wrongRole_returns403() throws Exception {
+    mockMvc.perform(MockMvcRequestBuilders
+            .delete("/admin/trust-frameworks/bundles/gaia-x-2511")
+            .with(csrf()))
+        .andExpect(status().isForbidden());
   }
 
   @Test

--- a/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ComplianceCheckServiceTest.java
+++ b/fc-service-server/src/test/java/eu/xfsc/fc/server/service/ComplianceCheckServiceTest.java
@@ -28,6 +28,7 @@ import eu.xfsc.fc.core.dao.validation.ValidatorType;
 import eu.xfsc.fc.core.pojo.TrustFrameworkConfig;
 import eu.xfsc.fc.core.service.trustframework.FrameworkBundleConfig;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkBundle;
+import eu.xfsc.fc.core.service.trustframework.TrustFrameworkProfileResolver;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkRegistry;
 import eu.xfsc.fc.core.service.trustframework.TrustFrameworkService;
 import eu.xfsc.fc.core.service.trustframework.ValidationType;
@@ -55,6 +56,8 @@ class ComplianceCheckServiceTest {
   private TrustFrameworkService trustFrameworkService;
   @Mock
   private TrustFrameworkRegistry registry;
+  @Mock
+  private TrustFrameworkProfileResolver profileResolver;
 
   @InjectMocks
   private ComplianceCheckService service;
@@ -63,7 +66,7 @@ class ComplianceCheckServiceTest {
   void runComplianceCheck_issuedAttestation_returnsConformsTrueAndCredential() {
     var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
     when(orchestrator.check(ASSET_ID, PROFILE_ID, CREDENTIAL)).thenReturn(outcome);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
 
     var response = service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
 
@@ -77,7 +80,7 @@ class ComplianceCheckServiceTest {
   void runComplianceCheck_unverifiableAttestation_returnsConformsFalseAndFailureCategory() {
     var outcome = new UnverifiableAttestation(FailureCategory.UNVERIFIABLE_ATTESTATION, "raw", "bad sig");
     when(orchestrator.check(ASSET_ID, PROFILE_ID, CREDENTIAL)).thenReturn(outcome);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
 
     var response = service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
 
@@ -93,7 +96,7 @@ class ComplianceCheckServiceTest {
         PROFILE_ID, FAMILY_ID, "jwt-vc-compliance", null, "/api/credential-offers/standard-compliance", "1.0", 30);
     var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
     when(orchestrator.check(any(), any(), any())).thenReturn(outcome);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(profileConfig));
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(profileConfig));
 
     service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
 
@@ -104,7 +107,7 @@ class ComplianceCheckServiceTest {
   void runComplianceCheck_profileConfigAbsent_storeReceivesProfileIdAsFamilyId() {
     var outcome = new IssuedAttestation(CANNED_VC_JWT, null);
     when(orchestrator.check(any(), any(), any())).thenReturn(outcome);
-    when(registry.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.empty());
 
     service.runComplianceCheck(ASSET_ID, request(PROFILE_ID, CREDENTIAL));
 
@@ -203,7 +206,7 @@ class ComplianceCheckServiceTest {
   }
 
   private static TrustFrameworkConfig tfConfig(String id, String name, boolean enabled) {
-    return new TrustFrameworkConfig(id, name, null, "1.0", 30, enabled, null, null);
+    return new TrustFrameworkConfig(id, name, enabled, null, null);
   }
 
   private static TrustFrameworkBundle bundle(String profileId, String familyId) {

--- a/openapi/fc_openapi.yaml
+++ b/openapi/fc_openapi.yaml
@@ -669,18 +669,6 @@ components:
         name:
           type: string
           description: Display name
-        serviceUrl:
-          type: string
-          description: Trust framework service URL
-        apiVersion:
-          type: string
-          description: API version
-        timeoutSeconds:
-          type: integer
-          description: Connection timeout in seconds
-        connected:
-          type: boolean
-          description: Whether the service is currently reachable
         enabled:
           type: boolean
           description: Whether this framework is active
@@ -700,6 +688,35 @@ components:
           additionalProperties:
             type: boolean
           description: Per-role enabled state for this bundle, keyed by role name.
+        effectiveConfig:
+          $ref: '#/components/schemas/TrustFrameworkBundleEffectiveConfig'
+        overriddenFields:
+          type: array
+          description: >-
+            Names of effective-config fields whose value currently comes from a
+            persisted override (DB row) rather than the bundle YAML. Allows the
+            UI to distinguish operator-set values from YAML defaults.
+          items:
+            type: string
+    TrustFrameworkBundleEffectiveConfig:
+      type: object
+      description: >-
+        Effective compliance configuration of a bundle after applying any per-bundle
+        overrides on top of the YAML baseline. Resolved by the catalogue server at
+        request time; read-only.
+      properties:
+        clientType:
+          type: string
+        serviceUrl:
+          type: string
+        compliancePath:
+          type: string
+        apiVersion:
+          type: string
+        timeoutSeconds:
+          type: integer
+        trustAnchorUrl:
+          type: string
     TrustFrameworkPatch:
       type: object
       description: >-
@@ -712,17 +729,6 @@ components:
         enabled:
           type: boolean
           description: Desired enabled state of the trust framework family.
-        serviceUrl:
-          type: string
-          description: New compliance service URL.
-        apiVersion:
-          type: string
-          description: New API version string.
-        timeoutSeconds:
-          type: integer
-          description: Connection timeout in seconds.
-          minimum: 1
-          maximum: 300
     SchemaModulePatch:
       type: object
       description: >-
@@ -877,9 +883,12 @@ components:
     GraphDatabaseSwitchResult:
       type: object
       properties:
+        restartRequired:
+          type: boolean
+          description: Whether a restart is needed for the switch to take effect
         message:
           type: string
-          description: Human-readable status message describing the live switch result
+          description: Human-readable status message
 
     StoredValidationResult:
       type: object
@@ -1410,6 +1419,86 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
+  /admin/trust-frameworks/bundles/{bundleId}:
+    patch:
+      tags:
+        - TrustFrameworkAdmin
+      summary: Merge-patch external client identifiers of a trust-framework bundle
+      description: >-
+        Merge-patch semantics (RFC 7396): only fields present in the body are modified.
+        Overrides the per-bundle compliance endpoint URL, API version, timeout,
+        client implementation key, and trust-anchor list URL. The bundle YAML remains
+        the baseline; absent override fields fall back to the YAML value. The change
+        takes effect on the next compliance call against the bundle — no restart is
+        required. At least one field must be present (minProperties: 1).
+      operationId: patchTrustFrameworkBundleConfig
+      security:
+        - jwt: [ ]
+      parameters:
+        - name: bundleId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/merge-patch+json:
+            schema:
+              type: object
+              minProperties: 1
+              additionalProperties: true
+              description: >-
+                Free-form merge-patch object. Recognised keys are clientType,
+                serviceUrl, compliancePath, apiVersion, timeoutSeconds, trustAnchorUrl.
+                Setting a key's value to a non-null primitive overrides the bundle
+                YAML for that field. Setting a key's value to JSON null clears the
+                override for that field (the YAML value is used again). Omitting a
+                key leaves any existing override or YAML value unchanged. At least
+                one key must be present.
+      responses:
+        '200':
+          description: Bundle configuration updated
+        '400':
+          $ref: '#/components/responses/ClientError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      tags:
+        - TrustFrameworkAdmin
+      summary: Clear all external-identifier overrides for a trust-framework bundle
+      description: >-
+        Removes any persisted overrides for the given bundle, restoring the bundle YAML
+        as the sole source of compliance configuration. Idempotent — a bundle without
+        an override row still returns 200. Use when an operator wants to revert all
+        runtime adjustments at once; for partial reverts, PATCH with the desired
+        fields instead.
+      operationId: deleteTrustFrameworkBundleConfig
+      security:
+        - jwt: [ ]
+      parameters:
+        - name: bundleId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bundle overrides cleared (or already absent)
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /admin/trust-frameworks/{bundleId}/roles/{roleName}:
     patch:
       tags:
@@ -1568,17 +1657,7 @@ paths:
     post:
       tags:
         - GraphDatabaseAdmin
-      summary: Switch the graph database backend
-      description: |
-        Performs a live in-process swap to the target backend and persists the
-        choice to `admin_config[graphstore.preferred.backend]` so the same backend
-        is reactivated on the next cold boot.
-
-        The target backend is pre-flighted before either the swap or the persist:
-        if the configured URI for that backend is unreachable, the request is
-        rejected with `400 Bad Request` and a message describing what to fix. The
-        active adapter and the persisted preference are both left untouched on
-        rejection.
+      summary: Switch the graph database backend (requires restart)
       operationId: switchGraphDatabase
       security:
         - jwt: []
@@ -1602,15 +1681,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GraphDatabaseSwitchResult'
         '400':
-          description: |
-            Invalid backend value, or target backend is unreachable. The response
-            body's `message` field carries the specific reason (probe failure
-            message for unreachable targets, list of valid values for invalid
-            input).
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
+          $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':


### PR DESCRIPTION
## 🚀 Summary

The rebuild path fed raw JWT bytes to the claim extractors, unlike the upload path, so JWT-format RDF assets (vc+jwt, vp+jwt, Loire variants) re-indexed with zero claims and left the active-graph 'no claims' banner stuck.

Reuse the upload path's CredentialFormatDetector to decode JWT content to JSON-LD before extraction, via the processors' unwrapNested() (content decode only - no signature verification or trust-framework policy enforcement). Inject the detector into GraphRebuilder and unwrap in extractClaims().

Tests: unwrapToJsonLd unit cases (danubetech/Loire VC+VP, pass-through, invalid JWT -> ClientException); Neo4j integration test asserting a JWT-wrapped credential restores the same claims after rebuild.

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnit tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style
