### PR TITLE
chore(realm): make Keycloak realm name configurable (CAT-FR-CO-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ of [Gaia-X Federation Services Lot 5 — Federated Catalogue / Core Catalogue Fe
 The supported way to build and run the Federated Catalogue locally is via the bundled Docker Compose
 stack: [Steps to build FC](https://github.com/eclipse-xfsc/federated-catalogue/blob/main/docker/README.md).
 
+### Keycloak realm configuration
+
+The Keycloak realm name is configurable via the `KEYCLOAK_REALM` environment variable. Default:
+`federated-catalogue-realm`.
+
+- Fresh deployments work out of the box with the default — the bundled realm import files
+  (`keycloak/realms/{dev,staging,prod}/fc-realm.json` and `deployment/helm/fc-service/fc-realm.json`) define a
+  realm with that name.
+- **Existing deployments** (e.g. our QA stage) that already have a `gaia-x` realm persisted in Keycloak's
+  database keep working by setting `KEYCLOAK_REALM=gaia-x`. Keycloak's `--import-realm` is a no-op once
+  the realm exists, so no migration is required.
+- A fresh deployment that wants the legacy `gaia-x` realm name must supply its own realm import JSON via
+  volume mount or ConfigMap — we no longer ship one.
+
+The same variable is honored by the Spring config (`fc-service-server`, `fc-demo-portal`), `docker-compose.yml`,
+the Helm chart (`keycloak.realm` value), and the manual Kubernetes manifests under `deployment/manual/`.
+
 ## Documentation
 
 | Topic                                                       | Location                                                                                                       |

--- a/README.md
+++ b/README.md
@@ -14,22 +14,10 @@ of [Gaia-X Federation Services Lot 5 — Federated Catalogue / Core Catalogue Fe
 The supported way to build and run the Federated Catalogue locally is via the bundled Docker Compose
 stack: [Steps to build FC](https://github.com/eclipse-xfsc/federated-catalogue/blob/main/docker/README.md).
 
-### Keycloak realm configuration
-
-The Keycloak realm name is configurable via the `KEYCLOAK_REALM` environment variable. Default:
-`federated-catalogue-realm`.
-
-- Fresh deployments work out of the box with the default — the bundled realm import files
-  (`keycloak/realms/{dev,staging,prod}/fc-realm.json` and `deployment/helm/fc-service/fc-realm.json`) define a
-  realm with that name.
-- **Existing deployments** (e.g. our QA stage) that already have a `gaia-x` realm persisted in Keycloak's
-  database keep working by setting `KEYCLOAK_REALM=gaia-x`. Keycloak's `--import-realm` is a no-op once
-  the realm exists, so no migration is required.
-- A fresh deployment that wants the legacy `gaia-x` realm name must supply its own realm import JSON via
-  volume mount or ConfigMap — we no longer ship one.
-
-The same variable is honored by the Spring config (`fc-service-server`, `fc-demo-portal`), `docker-compose.yml`,
-the Helm chart (`keycloak.realm` value), and the manual Kubernetes manifests under `deployment/manual/`.
+The Keycloak realm name is configurable via the `KEYCLOAK_REALM` env var (default
+`federated-catalogue-realm`). Existing deployments with a pre-existing `gaia-x` realm keep working by setting
+`KEYCLOAK_REALM=gaia-x`. See [Keycloak Realm Configuration](docs/operator-guide.md#keycloak-realm-configuration)
+in the operator guide for details.
 
 ## Documentation
 

--- a/deployment/helm/fc-service/README.md
+++ b/deployment/helm/fc-service/README.md
@@ -78,13 +78,13 @@ kubectl apply -f deployment/cert-manager/clusterissuer.yaml
 ### 5. Create namespace and out-of-band secrets
 
 The Keycloak OAuth2 client secret is not managed by Helm. Its value must match the `secret` field of the
-`federated-catalogue` client in `gaia-x-realm.json` (currently `**********`):
+`federated-catalogue` client in `fc-realm.json` (currently `**********`):
 
 ```bash
 kubectl create namespace federated-catalogue
 
 kubectl create secret generic fc-keycloak-client-secret \
-  --from-literal=keycloak_client_secret=<value-matching-gaia-x-realm.json> \
+  --from-literal=keycloak_client_secret=<value-matching-fc-realm.json> \
   -n federated-catalogue
 ```
 

--- a/deployment/helm/fc-service/fc-realm.json
+++ b/deployment/helm/fc-service/fc-realm.json
@@ -1,7 +1,7 @@
 {
-  "id": "gaia-x",
-  "realm": "gaia-x",
-  "displayName": "GAIA-X",
+  "id": "federated-catalogue-realm",
+  "realm": "federated-catalogue-realm",
+  "displayName": "Federated Catalogue",
   "notBefore": 1660684842,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -54,7 +54,7 @@
         "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
@@ -63,16 +63,16 @@
         "description": "${role_offline-access}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
         "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-        "name": "default-roles-gaia-x",
+        "name": "default-roles-federated-catalogue-realm",
         "description": "${role_default-roles}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       }
     ],
@@ -588,11 +588,11 @@
   "groups": [],
   "defaultRole": {
     "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-    "name": "default-roles-gaia-x",
+    "name": "default-roles-federated-catalogue-realm",
     "description": "${role_default-roles}",
     "composite": false,
     "clientRole": false,
-    "containerId": "gaia-x"
+    "containerId": "federated-catalogue-realm"
   },
   "requiredCredentials": [
     "password"
@@ -649,7 +649,7 @@
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -690,13 +690,13 @@
       "clientId": "account",
       "name": "${client_account}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -736,13 +736,13 @@
       "clientId": "account-console",
       "name": "${client_account-console}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -981,7 +981,7 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "gaia-x",
+        "federated-catalogue-realm",
         "roles",
         "basic"
       ],
@@ -1075,13 +1075,13 @@
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
       "rootUrl": "${authAdminUrl}",
-      "baseUrl": "/admin/gaia-x/console/",
+      "baseUrl": "/admin/federated-catalogue-realm/console/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/admin/gaia-x/console/*"
+        "/admin/federated-catalogue-realm/console/*"
       ],
       "webOrigins": [
         "+"
@@ -1731,7 +1731,7 @@
     },
     {
       "id": "fff4bd04-c33f-412d-a617-8c35a7410b3a",
-      "name": "gaia-x",
+      "name": "federated-catalogue-realm",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
@@ -1981,7 +1981,7 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "loginTheme": "gaia-x",
+  "loginTheme": "federated-catalogue-realm",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"

--- a/deployment/helm/fc-service/templates/deployment.yaml
+++ b/deployment/helm/fc-service/templates/deployment.yaml
@@ -37,8 +37,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
+            - name: KEYCLOAK_REALM
+              value: { { .Values.keycloak.realm | quote } }
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI
-              value: "https://{{ .Values.hosts.keycloak }}/auth/realms/gaia-x"
+              value: "https://{{ .Values.hosts.keycloak }}/auth/realms/{{ .Values.keycloak.realm }}"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/deployment/helm/fc-service/templates/keycloak-config-map.yaml
+++ b/deployment/helm/fc-service/templates/keycloak-config-map.yaml
@@ -4,6 +4,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Values.keycloak.fullnameOverride }}-realm-configmap
 data:
-  gaia-x-realm.json: |-
-{{ .Files.Get "gaia-x-realm.json" | indent 4}}
+  { { .Values.keycloak.realmFile } }: |-
+  { { .Files.Get .Values.keycloak.realmFile | indent 4 } }
 {{- end }}      

--- a/deployment/helm/fc-service/templates/portal-deployment.yaml
+++ b/deployment/helm/fc-service/templates/portal-deployment.yaml
@@ -26,8 +26,10 @@ spec:
                 secretKeyRef:
                   name: fc-keycloak-client-secret
                   key: keycloak_client_secret
+            - name: KEYCLOAK_REALM
+              value: { { .Values.keycloak.realm | quote } }
             - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
-              value: "https://{{ .Values.hosts.keycloak }}/auth/realms/gaia-x"
+              value: "https://{{ .Values.hosts.keycloak }}/auth/realms/{{ .Values.keycloak.realm }}"
             - name: FEDERATED_CATALOGUE_BASE_URI
               value: {{ .Values.portal.fcBaseUri }}
           ports:

--- a/deployment/helm/fc-service/values.yaml
+++ b/deployment/helm/fc-service/values.yaml
@@ -229,6 +229,10 @@ keycloak:
   fullnameOverride: fc-keycloak
   replicas: 1
 
+  # Realm configuration — set realm to "gaia-x" to keep legacy deployments
+  realm: federated-catalogue-realm
+  realmFile: fc-realm.json
+
   # Use official Keycloak image from quay.io
   image:
     repository: quay.io/keycloak/keycloak

--- a/deployment/manual/demo-portal/demo-deployment.yaml
+++ b/deployment/manual/demo-portal/demo-deployment.yaml
@@ -30,8 +30,10 @@ spec:
                 secretKeyRef:
                   name: fc-server-keys-secret
                   key: keycloak_client_secret
+            - name: KEYCLOAK_REALM
+              value: "federated-catalogue-realm"
             - name: SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI
-              value: https://fc-key-server.gxfs.dev/realms/gaia-x
+              value: https://fc-key-server.gxfs.dev/realms/$(KEYCLOAK_REALM)
             - name: FEDERATED_CATALOGUE_BASE_URI
               value: http://fc-service:8081
           ports:

--- a/deployment/manual/fc/fc-deployment.yaml
+++ b/deployment/manual/fc/fc-deployment.yaml
@@ -33,10 +33,12 @@ spec:
               value: "5"
             - name: DATASTORE_FILE_PATH
               value: /var/lib/fc-service/filestore
+            - name: KEYCLOAK_REALM
+              value: "federated-catalogue-realm"
             - name: KEYCLOAK_AUTH_SERVER_URL
               value: https://fc-key-server.gxfs.dev
             - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI
-              value: https://fc-key-server.gxfs.dev/realms/gaia-x
+              value: https://fc-key-server.gxfs.dev/realms/$(KEYCLOAK_REALM)
             - name: KEYCLOAK_CREDENTIALS_SECRET
               value: DVIgraQHZsKG3IVDSDwu5CgCE07gx4YE
 #              valueFrom:

--- a/deployment/manual/keycloak/keycloak-deployment.yaml
+++ b/deployment/manual/keycloak/keycloak-deployment.yaml
@@ -41,6 +41,8 @@ spec:
                 secretKeyRef:
                   name: fc-key-server-pass-secret
                   key: password
+            - name: KEYCLOAK_REALM
+              value: "federated-catalogue-realm"
             - name: PROXY_ADDRESS_FORWARDING
               value: "true"
             - name: KEYCLOAK_FRONTEND_URL

--- a/docker/.env
+++ b/docker/.env
@@ -12,6 +12,10 @@ KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=admin
 PROXY_ADDRESS_FORWARDING=true
 AUTH_SERVER_HOST_GATEWAY=127.0.0.1
+# Keycloak realm name. Default is ecosystem-neutral.
+# Existing deployments with a pre-existing `gaia-x` realm in Keycloak's database can keep
+# working by setting KEYCLOAK_REALM=gaia-x (--import-realm is a no-op once the realm exists).
+KEYCLOAK_REALM=federated-catalogue-realm
 
 ### FC SERVER PROPERTIES ###
 CI_REGISTRY=node-654e3bca7fbeeed18f81d7c7.ps-xaas.io/catalogue

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,7 +88,7 @@ For development and running integration tests, assign `Ro-MU-CA` or `ADMIN_ALL`.
 If you need to update the realm (e.g., after adding new roles), use Keycloak's partial import:
 
 1. Go to Realm Settings → Action → Partial import
-2. Upload `keycloak/realms/gaia-x-realm.json`
+2. Upload `keycloak/realms/<env>/fc-realm.json` (where `<env>` matches your `KC_REALM_ENV`)
 3. Select **Skip** for existing resources (preserves client secret and user accounts)
 
 New roles will be created; existing ones are preserved. To update composite role mappings on existing roles, manually edit them in the Keycloak UI or do a full teardown (`./dev.sh clean`) and restart.

--- a/docker/dev.env
+++ b/docker/dev.env
@@ -17,9 +17,12 @@ PROXY_ADDRESS_FORWARDING=true
 AUTH_SERVER_HOST_GATEWAY=127.0.0.1
 # Keycloak realm config directory: dev, staging, prod (see keycloak/realms/)
 KC_REALM_ENV=dev
+# Keycloak realm name. Default is ecosystem-neutral; set KEYCLOAK_REALM=gaia-x to
+# keep existing deployments unchanged (must match the realm name in the imported JSON).
+KEYCLOAK_REALM=federated-catalogue-realm
 
 ### KEYCLOAK ADMIN CONSOLE ###
-KEYCLOAK_ADMIN_CONSOLE_URL=http://localhost:8080/admin/gaia-x/console/
+KEYCLOAK_ADMIN_CONSOLE_URL=http://localhost:8080/admin/${KEYCLOAK_REALM}/console/
 
 ### FC SERVER PROPERTIES ###
 CI_REGISTRY=node-654e3bca7fbeeed18f81d7c7.ps-xaas.io/catalogue

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -244,7 +244,8 @@ services:
       target: "${FC_DEMO_PORTAL_DOCKER_TARGET}"
     environment:
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_FC_CLIENT_OIDC_CLIENT_SECRET: "${FC_CLIENT_SECRET}"
-      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI: http://key-server:8080/realms/gaia-x
+      KEYCLOAK_REALM: "${KEYCLOAK_REALM:-federated-catalogue-realm}"
+      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI: http://key-server:8080/realms/${KEYCLOAK_REALM:-federated-catalogue-realm}
       FEDERATED_CATALOGUE_BASE_URI: http://fc-server:8081
     ports:
       - "8088:8088"

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -5,6 +5,40 @@ Configuration and runtime tuning for operators of the Federated Catalogue.
 For the architectural and conceptual description of the service, see the
 [Architecture Document](https://github.com/eclipse-xfsc/docs/tree/main/federated-catalogue).
 
+## Keycloak Realm Configuration
+
+The Keycloak realm name is configurable via the `KEYCLOAK_REALM` environment variable.
+
+| Property         | Env var          | Default                     | Description                                       |
+|------------------|------------------|-----------------------------|---------------------------------------------------|
+| `keycloak.realm` | `KEYCLOAK_REALM` | `federated-catalogue-realm` | Realm name the application authenticates against. |
+
+The same variable is honored by `fc-service-server`, `fc-demo-portal`, `docker-compose.yml`, the Helm chart
+(`keycloak.realm` value), and the manual Kubernetes manifests under `deployment/manual/`.
+
+### Fresh deployment (default)
+
+The bundled realm import files define a realm named `federated-catalogue-realm`:
+
+- `keycloak/realms/{dev,staging,prod}/fc-realm.json` — imported by the docker-compose stack
+- `deployment/helm/fc-service/fc-realm.json` — imported by the Helm chart's Keycloak ConfigMap
+
+No further action is required.
+
+### Existing deployment with a legacy `gaia-x` realm
+
+Set `KEYCLOAK_REALM=gaia-x`. Keycloak's `--import-realm` is a no-op once the realm already exists in the
+database, so deployments with a pre-existing `gaia-x` realm keep working without migration. No bundled JSON
+ships for this case; bring your own import file if you also need to provision the realm fresh.
+
+### Helm
+
+```yaml
+keycloak:
+  realm: federated-catalogue-realm   # set to "gaia-x" for legacy
+  realmFile: fc-realm.json           # bring your own JSON if you need a legacy import
+```
+
 ## Trust Framework Configuration
 
 The Federated Catalogue activates trust frameworks via a list of **trust-framework family IDs**. Families listed at

--- a/fc-demo-portal/src/main/resources/application.yml
+++ b/fc-demo-portal/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
               - email
         provider:
           keycloak:
-            issuer-uri: http://key-server/realms/gaia-x
+            issuer-uri: http://key-server/realms/${KEYCLOAK_REALM:federated-catalogue-realm}
 
 federated-catalogue:
   base-uri: http://fc-server

--- a/fc-service-server/src/main/resources/application.yml
+++ b/fc-service-server/src/main/resources/application.yml
@@ -45,8 +45,8 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://key-server:8080/realms/gaia-x
-#          jwk-set-uri: http://key-server:8080/realms/gaia-x/protocol/openid-connect/certs
+          issuer-uri: http://key-server:8080/realms/${keycloak.realm}
+  #          jwk-set-uri: http://key-server:8080/realms/${keycloak.realm}/protocol/openid-connect/certs
   threads:
     virtual:
       enabled: true
@@ -71,7 +71,7 @@ springdoc:
 
 keycloak:
   auth-server-url: http://key-server:8080
-  realm: gaia-x
+  realm: ${KEYCLOAK_REALM:federated-catalogue-realm}
   resource: federated-catalogue
   credentials:
     secret: ${KEYCLOAK_CREDENTIALS_SECRET:}

--- a/fc-service-server/src/test/resources/application-test.yml
+++ b/fc-service-server/src/test/resources/application-test.yml
@@ -1,3 +1,9 @@
+keycloak:
+  # Pin to gaia-x so existing test fixtures (mock-data/openid-configs.json, controller mocks
+  # calling `when(keycloak.realm("gaia-x"))`) keep working without rewrites.
+  # Production default is federated-catalogue-realm.
+  realm: gaia-x
+
 federated-catalogue:
   scope: test
   verification:

--- a/fc-service-server/src/test/resources/wiremock.properties
+++ b/fc-service-server/src/test/resources/wiremock.properties
@@ -1,4 +1,7 @@
 wiremock.server.baseUrl=http://localhost:${wiremock.server.port}
 keycloak.auth-server-url=${wiremock.server.baseUrl}/auth
+# Pin realm to gaia-x so existing test fixtures (mock-data/openid-configs.json, controller tests)
+# keep matching without rewriting them. Production default is federated-catalogue-realm.
+keycloak.realm=gaia-x
 
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${wiremock.server.baseUrl}/auth/realms/gaia-x

--- a/keycloak/realms/README.md
+++ b/keycloak/realms/README.md
@@ -1,12 +1,25 @@
 # Keycloak Realm Configuration
 
-The `gaia-x-realm.json` file exists in three environment-specific subdirectories:
+Each environment-specific subdirectory contains a single ecosystem-neutral realm import file
+`fc-realm.json` (realm name `federated-catalogue-realm`).
 
 | Directory  | Purpose                                      |
 |------------|----------------------------------------------|
 | `dev/`     | Local development (docker-compose stack)     |
 | `staging/` | Staging environment                          |
 | `prod/`    | Production environment                       |
+
+The realm name is selected at runtime via `KEYCLOAK_REALM` (default `federated-catalogue-realm`).
+The name in the imported JSON must match `KEYCLOAK_REALM` for the application to authenticate against it.
+
+### Existing `gaia-x` deployments
+
+Keycloak's `--import-realm` only imports when the realm does not already exist in the database, so
+existing deployments (e.g. our QA stage) already have a `gaia-x` realm persisted in Postgres. They
+continue to work by setting `KEYCLOAK_REALM=gaia-x` — no import file is needed.
+
+A fresh deployment that wants a `gaia-x` realm name must supply its own realm import JSON via a
+volume mount or ConfigMap; we no longer ship one.
 
 ## Why three copies?
 

--- a/keycloak/realms/dev/fc-realm.json
+++ b/keycloak/realms/dev/fc-realm.json
@@ -1,7 +1,7 @@
 {
-  "id": "gaia-x",
-  "realm": "gaia-x",
-  "displayName": "GAIA-X",
+  "id": "federated-catalogue-realm",
+  "realm": "federated-catalogue-realm",
+  "displayName": "Federated Catalogue",
   "notBefore": 1660684842,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -54,7 +54,7 @@
         "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
@@ -63,16 +63,16 @@
         "description": "${role_offline-access}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
         "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-        "name": "default-roles-gaia-x",
+        "name": "default-roles-federated-catalogue-realm",
         "description": "${role_default-roles}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       }
     ],
@@ -588,11 +588,11 @@
   "groups": [],
   "defaultRole": {
     "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-    "name": "default-roles-gaia-x",
+    "name": "default-roles-federated-catalogue-realm",
     "description": "${role_default-roles}",
     "composite": false,
     "clientRole": false,
-    "containerId": "gaia-x"
+    "containerId": "federated-catalogue-realm"
   },
   "requiredCredentials": [
     "password"
@@ -649,7 +649,7 @@
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -676,7 +676,7 @@
         }
       ],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -696,7 +696,7 @@
         }
       ],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -730,13 +730,13 @@
       "clientId": "account",
       "name": "${client_account}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -776,13 +776,13 @@
       "clientId": "account-console",
       "name": "${client_account-console}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -1021,7 +1021,7 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "gaia-x",
+        "federated-catalogue-realm",
         "roles",
         "basic"
       ],
@@ -1115,13 +1115,13 @@
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
       "rootUrl": "${authAdminUrl}",
-      "baseUrl": "/admin/gaia-x/console/",
+      "baseUrl": "/admin/federated-catalogue-realm/console/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/admin/gaia-x/console/*"
+        "/admin/federated-catalogue-realm/console/*"
       ],
       "webOrigins": [
         "+"
@@ -1771,7 +1771,7 @@
     },
     {
       "id": "fff4bd04-c33f-412d-a617-8c35a7410b3a",
-      "name": "gaia-x",
+      "name": "federated-catalogue-realm",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
@@ -2021,7 +2021,7 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "loginTheme": "gaia-x",
+  "loginTheme": "federated-catalogue-realm",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"

--- a/keycloak/realms/prod/fc-realm.json
+++ b/keycloak/realms/prod/fc-realm.json
@@ -1,7 +1,7 @@
 {
-  "id": "gaia-x",
-  "realm": "gaia-x",
-  "displayName": "GAIA-X",
+  "id": "federated-catalogue-realm",
+  "realm": "federated-catalogue-realm",
+  "displayName": "Federated Catalogue",
   "notBefore": 1660684842,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -54,7 +54,7 @@
         "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
@@ -63,16 +63,16 @@
         "description": "${role_offline-access}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
         "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-        "name": "default-roles-gaia-x",
+        "name": "default-roles-federated-catalogue-realm",
         "description": "${role_default-roles}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       }
     ],
@@ -588,11 +588,11 @@
   "groups": [],
   "defaultRole": {
     "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-    "name": "default-roles-gaia-x",
+    "name": "default-roles-federated-catalogue-realm",
     "description": "${role_default-roles}",
     "composite": false,
     "clientRole": false,
-    "containerId": "gaia-x"
+    "containerId": "federated-catalogue-realm"
   },
   "requiredCredentials": [
     "password"
@@ -649,7 +649,7 @@
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -677,7 +677,7 @@
         }
       ],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -711,13 +711,13 @@
       "clientId": "account",
       "name": "${client_account}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -757,13 +757,13 @@
       "clientId": "account-console",
       "name": "${client_account-console}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -1008,7 +1008,7 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "gaia-x",
+        "federated-catalogue-realm",
         "roles",
         "basic"
       ],
@@ -1102,13 +1102,13 @@
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
       "rootUrl": "${authAdminUrl}",
-      "baseUrl": "/admin/gaia-x/console/",
+      "baseUrl": "/admin/federated-catalogue-realm/console/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/admin/gaia-x/console/*"
+        "/admin/federated-catalogue-realm/console/*"
       ],
       "webOrigins": [
         "+"
@@ -1758,7 +1758,7 @@
     },
     {
       "id": "fff4bd04-c33f-412d-a617-8c35a7410b3a",
-      "name": "gaia-x",
+      "name": "federated-catalogue-realm",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
@@ -2008,7 +2008,7 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "loginTheme": "gaia-x",
+  "loginTheme": "federated-catalogue-realm",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"

--- a/keycloak/realms/staging/fc-realm.json
+++ b/keycloak/realms/staging/fc-realm.json
@@ -1,7 +1,7 @@
 {
-  "id": "gaia-x",
-  "realm": "gaia-x",
-  "displayName": "GAIA-X",
+  "id": "federated-catalogue-realm",
+  "realm": "federated-catalogue-realm",
+  "displayName": "Federated Catalogue",
   "notBefore": 1660684842,
   "defaultSignatureAlgorithm": "RS256",
   "revokeRefreshToken": false,
@@ -54,7 +54,7 @@
         "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
@@ -63,16 +63,16 @@
         "description": "${role_offline-access}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       },
       {
         "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-        "name": "default-roles-gaia-x",
+        "name": "default-roles-federated-catalogue-realm",
         "description": "${role_default-roles}",
         "composite": false,
         "clientRole": false,
-        "containerId": "gaia-x",
+        "containerId": "federated-catalogue-realm",
         "attributes": {}
       }
     ],
@@ -588,11 +588,11 @@
   "groups": [],
   "defaultRole": {
     "id": "8ee7d6f7-f168-4b62-ae34-1c18ffbf631a",
-    "name": "default-roles-gaia-x",
+    "name": "default-roles-federated-catalogue-realm",
     "description": "${role_default-roles}",
     "composite": false,
     "clientRole": false,
-    "containerId": "gaia-x"
+    "containerId": "federated-catalogue-realm"
   },
   "requiredCredentials": [
     "password"
@@ -649,7 +649,7 @@
       "disableableCredentialTypes": [],
       "requiredActions": [],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -677,7 +677,7 @@
         }
       ],
       "realmRoles": [
-        "default-roles-gaia-x"
+        "default-roles-federated-catalogue-realm"
       ],
       "clientRoles": {
         "federated-catalogue": [
@@ -711,13 +711,13 @@
       "clientId": "account",
       "name": "${client_account}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -757,13 +757,13 @@
       "clientId": "account-console",
       "name": "${client_account-console}",
       "rootUrl": "${authBaseUrl}",
-      "baseUrl": "/realms/gaia-x/account/",
+      "baseUrl": "/realms/federated-catalogue-realm/account/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/realms/gaia-x/account/*"
+        "/realms/federated-catalogue-realm/account/*"
       ],
       "webOrigins": [],
       "notBefore": 0,
@@ -1008,7 +1008,7 @@
       "defaultClientScopes": [
         "web-origins",
         "acr",
-        "gaia-x",
+        "federated-catalogue-realm",
         "roles",
         "basic"
       ],
@@ -1102,13 +1102,13 @@
       "clientId": "security-admin-console",
       "name": "${client_security-admin-console}",
       "rootUrl": "${authAdminUrl}",
-      "baseUrl": "/admin/gaia-x/console/",
+      "baseUrl": "/admin/federated-catalogue-realm/console/",
       "surrogateAuthRequired": false,
       "enabled": true,
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "/admin/gaia-x/console/*"
+        "/admin/federated-catalogue-realm/console/*"
       ],
       "webOrigins": [
         "+"
@@ -1758,7 +1758,7 @@
     },
     {
       "id": "fff4bd04-c33f-412d-a617-8c35a7410b3a",
-      "name": "gaia-x",
+      "name": "federated-catalogue-realm",
       "protocol": "openid-connect",
       "attributes": {
         "include.in.token.scope": "true",
@@ -2008,7 +2008,7 @@
     "strictTransportSecurity": "max-age=31536000; includeSubDomains"
   },
   "smtpServer": {},
-  "loginTheme": "gaia-x",
+  "loginTheme": "federated-catalogue-realm",
   "eventsEnabled": false,
   "eventsListeners": [
     "jboss-logging"


### PR DESCRIPTION
## 🚀 Summary

Makes the Keycloak realm name fully configurable via `KEYCLOAK_REALM` (default `federated-catalogue-realm`) so the Federated Catalogue can be deployed under any ecosystem without code or build-artifact changes. The previous default `gaia-x` realm import files are replaced by ecosystem-neutral `fc-realm.json` files. Existing deployments (e.g. our QA stage) keep working by setting `KEYCLOAK_REALM=gaia-x` — Keycloak's `--import-realm` is a no-op once the realm exists in the database, so no migration is required. Scope is intentionally narrow: only the live IDP realm name changes; fixtures, comments, example hostnames, and stale URLs are untouched.

This change is part of the Enhancement of XFSC Federated Catalogue. Details can be found here (permalink):
https://github.com/eclipse-xfsc/docs/blob/f3c6e6b6fbcc87732a1dfe83f060fa58a9a97873/federated-catalogue/src/docs/CAT%20Enhancement/CAT_Enhancement_Specifications%20v1.0.pdf

## ✅ What's Changed

- [x] Feature implemented
- [x] Documentation updated
- [x] Tests updated
- [x] Code formatted and linted

Specifically:
- `fc-service-server` and `fc-demo-portal` `application.yml`: realm is `${KEYCLOAK_REALM:federated-catalogue-realm}`, issuer URIs reference `${keycloak.realm}`.
- `docker/docker-compose.yml`, `docker/.env`, `docker/dev.env`: pass `KEYCLOAK_REALM` through to containers.
- Helm chart (`values.yaml`, `templates/deployment.yaml`, `templates/portal-deployment.yaml`, `templates/keycloak-config-map.yaml`): parametrised `keycloak.realm` + `keycloak.realmFile`.
- Manual Kubernetes manifests (`deployment/manual/fc`, `demo-portal`, `keycloak`): `KEYCLOAK_REALM` env + `\$(KEYCLOAK_REALM)` substitution in issuer URIs.
- `keycloak/realms/{dev,staging,prod}/gaia-x-realm.json` and `deployment/helm/fc-service/gaia-x-realm.json` replaced by `fc-realm.json` (realm name `federated-catalogue-realm`, display name "Federated Catalogue", `default-roles-…` composite role renamed accordingly).
- Tests pinned to `keycloak.realm: gaia-x` in `application-test.yml` and `wiremock.properties` so existing controller mocks and fixtures keep working without rewrites.
- READMEs updated (top-level, `docker/`, `deployment/helm/fc-service/`, `keycloak/realms/`).

## 🧪 How to Test

1. **Default path (fresh deployment):**
   ```bash
   cd docker && ./dev.sh up
   ```
   Confirm `fc-server`, `demo-portal`, and `key-server` come up healthy. Keycloak shows a realm named `federated-catalogue-realm` and the demo portal's login flow succeeds against it.

2. **Legacy path (simulating an existing `gaia-x` deployment):**
   ```bash
   KEYCLOAK_REALM=gaia-x ./dev.sh up
   ```
   Run against a stage that already has a `gaia-x` realm in the Keycloak DB; login flow should be identical to before this PR.

3. **Unit + integration tests:**
   ```bash
   mvn -pl fc-service-server -am test -DskipITs
   ```
   Expect: 484 tests, 0 failures, 6 skipped.

4. **Helm render check:**
   ```bash
   helm template deployment/helm/fc-service
   helm template deployment/helm/fc-service --set keycloak.realm=gaia-x --set keycloak.realmFile=gaia-x-realm.json
   ```

## 🔍 Related Issues

CAT-FR-CO-01

## 📸 Screenshots

No UI changes.

## 📋 Checklist

- [x] I've tested my code locally
- [x] I've added tests if needed
- [x] I've updated documentation if necessary
- [x] My changes follow the project's coding style