### PR TITLE
fix(CAT-FR-CO-04): align GXDCH compliance client with live DCH

### DIFF
--- a/fc-service-api/src/main/java/eu/xfsc/fc/api/FcMediaTypes.java
+++ b/fc-service-api/src/main/java/eu/xfsc/fc/api/FcMediaTypes.java
@@ -22,6 +22,16 @@ public final class FcMediaTypes {
    */
   public static final MediaType MERGE_PATCH_JSON = MediaType.valueOf(MERGE_PATCH_JSON_VALUE);
 
+  /**
+   * Verifiable Presentation JWT content type (W3C VC-JOSE-COSE).
+   */
+  public static final String VP_JWT_VALUE = "application/vp+jwt";
+
+  /**
+   * {@link MediaType} form of {@link #VP_JWT_VALUE}.
+   */
+  public static final MediaType VP_JWT = MediaType.valueOf(VP_JWT_VALUE);
+
   private FcMediaTypes() {
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/IssuedAttestation.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/IssuedAttestation.java
@@ -8,8 +8,9 @@ import java.time.Instant;
  *
  * @param attestationCredential raw attestation credential string (JWT), or {@code null} if not
  *                              retained; the JWT's {@code iss} claim identifies the issuing service
- * @param credentialValidUntil  expiry timestamp of the issued credential; {@code null} if the
- *                              credential carries no {@code exp} claim
+ * @param credentialValidUntil  expiry timestamp of the issued credential, taken from the JWT
+ *                              {@code exp} claim or the VC 2.0 {@code validUntil} claim;
+ *                              {@code null} if the credential carries neither
  */
 public record IssuedAttestation(
     String attestationCredential, Instant credentialValidUntil

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/JwtVcComplianceClient.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/JwtVcComplianceClient.java
@@ -2,6 +2,7 @@ package eu.xfsc.fc.core.service.trustframework.compliance;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
+import eu.xfsc.fc.api.FcMediaTypes;
 import eu.xfsc.fc.core.exception.ServiceUnavailableException;
 import eu.xfsc.fc.core.exception.TimeoutException;
 import eu.xfsc.fc.core.pojo.ContentAccessor;
@@ -13,13 +14,13 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.concurrent.ConcurrentHashMap;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
@@ -107,7 +108,10 @@ public class JwtVcComplianceClient implements TrustFrameworkClient {
         + "?" + VCID_QUERY_PARAM + "=" + URLEncoder.encode(assetId, StandardCharsets.UTF_8));
 
     HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.TEXT_PLAIN);
+    // application/vp+jwt is the content type the GXDCH compliance endpoint declares for this
+    // operation. Body-parser-handled types (e.g. text/plain) make the service consume the request
+    // stream before the handler reads it, yielding HTTP 500 "stream is not readable".
+    headers.setContentType(FcMediaTypes.VP_JWT);
     HttpEntity<String> request = new HttpEntity<>(vpJwt, headers);
 
     RestTemplate rest = buildRestTemplate(config.timeoutSeconds());
@@ -156,10 +160,7 @@ public class JwtVcComplianceClient implements TrustFrameworkClient {
   private ComplianceCheckOutcome parseComplianceJwt(String jwt) {
     try {
       JWTClaimsSet claims = readJwtPayload(jwt);
-      Instant validUntil = claims.getExpirationTime() != null
-          ? claims.getExpirationTime().toInstant()
-          : null;
-      return new IssuedAttestation(jwt, validUntil);
+      return new IssuedAttestation(jwt, extractValidUntil(claims));
     } catch (Exception e) {
       log.warn("Failed to parse compliance credential JWT", e);
       return new UnverifiableAttestation(
@@ -172,5 +173,26 @@ public class JwtVcComplianceClient implements TrustFrameworkClient {
 
   private JWTClaimsSet readJwtPayload(String jwt) throws ParseException {
     return JWTParser.parse(jwt).getJWTClaimsSet();
+  }
+
+  /**
+   * Resolves the attestation's validity end instant. Prefers the numeric JWT {@code exp} claim;
+   * falls back to the ISO-8601 {@code validUntil} claim used by W3C VC 2.0 credentials (which the
+   * Gaia-X GXDCH compliance attestation carries instead of a payload {@code exp}). Returns
+   * {@code null} when neither is present nor parseable.
+   */
+  private Instant extractValidUntil(JWTClaimsSet claims) {
+    if (claims.getExpirationTime() != null) {
+      return claims.getExpirationTime().toInstant();
+    }
+    try {
+      String validUntil = claims.getStringClaim("validUntil");
+      if (validUntil != null && !validUntil.isBlank()) {
+        return Instant.parse(validUntil);
+      }
+    } catch (ParseException | DateTimeParseException e) {
+      log.warn("Failed to parse VC validUntil claim: {}", e.getMessage());
+    }
+    return null;
   }
 }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/JwtVcComplianceClientTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/JwtVcComplianceClientTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
@@ -44,6 +45,13 @@ class JwtVcComplianceClientTest {
   private static final String CANNED_CC_JWT =
       "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
           + ".eyJpc3MiOiJkaWQ6d2ViOmNvbXBsaWFuY2UuZXhhbXBsZSIsImV4cCI6MTc2NzIyMzk5OX0.";
+
+  // VC 2.0 compliance credential JWT — no payload exp, validUntil=2099-12-31T23:59:59Z
+  // (the shape the live GXDCH Loire attestation uses; exp lives only in the JOSE header).
+  private static final String CANNED_CC_JWT_VC2 =
+      "eyJhbGciOiJub25lIiwidHlwIjoidmMrand0In0"
+          + ".eyJpc3MiOiJkaWQ6d2ViOmNvbXBsaWFuY2UubGFiLmdhaWEteC5ldTpkZXZlbG9wbWVu"
+          + "dCIsInZhbGlkVW50aWwiOiIyMDk5LTEyLTMxVDIzOjU5OjU5WiJ9.";
 
   private MockWebServer server;
   private JwtVcComplianceClient client;
@@ -101,6 +109,25 @@ class JwtVcComplianceClientTest {
     assertTrue(req.getPath().contains("vcid=" + expectedVcid),
         "vcid query param must be single-percent-encoded");
     assertEquals(TEST_VP_JWT, req.getBody().readUtf8());
+    // application/vp+jwt is the content type the GXDCH endpoint declares for this request.
+    assertEquals("application/vp+jwt", req.getHeader("Content-Type"));
+  }
+
+  @Test
+  void check_201WithVc2ValidUntil_setsCredentialValidUntilFromValidUntilClaim() {
+
+    server.enqueue(new MockResponse()
+        .setResponseCode(201)
+        .setBody(CANNED_CC_JWT_VC2)
+        .addHeader("Content-Type", "application/jwt"));
+
+    var credential = new ContentAccessorDirect(TEST_VP_JWT);
+
+    ComplianceCheckOutcome outcome = client.check(credential, config);
+
+    var attestation = assertInstanceOf(IssuedAttestation.class, outcome);
+    // GXDCH attestations carry validity as the VC 2.0 validUntil claim, not a numeric exp.
+    assertEquals(Instant.parse("2099-12-31T23:59:59Z"), attestation.credentialValidUntil());
   }
 
   @Test


### PR DESCRIPTION
## 🚀 Summary

The catalogue-orchestrated compliance check failed against the live Gaia-X GXDCH (Loire), surfaced while building the live-DCH showcase.

Request Content-Type was text/plain, which the GXDCH compliance service rejects with HTTP 500 "stream is not readable". Send application/vp+jwt, the content type its OpenAPI contract declares for the standard-compliance operation.

credentialValidUntil was read only from the JWT exp claim, but the GXDCH attestation (W3C VC 2.0) carries validity in the validUntil payload field (exp lives only in the JOSE header). Fall back to validUntil so the value is populated.

Both gaps were masked by WireMock-based tests (content-type-agnostic); added request content-type and validUntil-extraction assertions.

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnit tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style

