### PR TITLE
[CAT-FR-AU] stabilize admin graph-database switch and rebuild flow (#76)

### DIFF
--- a/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
+++ b/fc-demo-portal/src/main/java/eu/xfsc/fc/demo/controller/AdminController.java
@@ -3,6 +3,7 @@ package eu.xfsc.fc.demo.controller;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.annotation.RegisteredOAuth2AuthorizedClient;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,6 +21,7 @@ import eu.xfsc.fc.api.generated.model.GraphDatabaseStatus;
 import eu.xfsc.fc.api.generated.model.GraphDatabaseSwitchResult;
 import eu.xfsc.fc.api.generated.model.KeycloakAdminUrl;
 import eu.xfsc.fc.api.generated.model.OntologyImpactList;
+import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.SchemaValidationStatus;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkEntry;
@@ -166,5 +168,22 @@ public class AdminController {
       @RequestBody Map<String, String> body,
       @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
     return adminClient.switchGraphDatabase(body.get("backend"), authorizedClient);
+  }
+
+  /**
+   * Trigger an asynchronous graph rebuild. Returns 202 Accepted when a fresh rebuild
+   * is started, 409 Conflict when a rebuild is already running.
+   */
+  @PostMapping("/graph/rebuild")
+  public ResponseEntity<RebuildStatus> triggerGraphRebuild(
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    return adminClient.triggerGraphRebuild(authorizedClient);
+  }
+
+  /** Get the current graph rebuild progress. */
+  @GetMapping("/graph/rebuild/status")
+  public RebuildStatus getGraphRebuildStatus(
+      @RegisteredOAuth2AuthorizedClient("fc-client-oidc") OAuth2AuthorizedClient authorizedClient) {
+    return adminClient.getGraphRebuildStatus(authorizedClient);
   }
 }

--- a/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/controller/AdminControllerTest.java
+++ b/fc-demo-portal/src/test/java/eu/xfsc/fc/demo/controller/AdminControllerTest.java
@@ -3,11 +3,13 @@ package eu.xfsc.fc.demo.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Client;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Map;
@@ -16,12 +18,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import eu.xfsc.fc.api.generated.model.RebuildStatus;
 import eu.xfsc.fc.api.generated.model.SchemaModulePatch;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkPatch;
 import eu.xfsc.fc.api.generated.model.TrustFrameworkBaseClassPatch;
@@ -181,5 +186,54 @@ class AdminControllerTest {
 
     verify(adminClient).deleteTrustFrameworkBundleConfig(eq("gaia-x-2511"),
         any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void triggerGraphRebuild_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(post("/admin/graph/rebuild"))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void getGraphRebuildStatus_unauthenticated_redirectsToLogin() throws Exception {
+    mockMvc.perform(get("/admin/graph/rebuild/status"))
+        .andExpect(status().is3xxRedirection());
+  }
+
+  @Test
+  void triggerGraphRebuild_authenticated_started_returns202() throws Exception {
+    when(adminClient.triggerGraphRebuild(any(OAuth2AuthorizedClient.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.ACCEPTED).body(new RebuildStatus()));
+
+    mockMvc.perform(post("/admin/graph/rebuild")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID)))
+        .andExpect(status().isAccepted());
+
+    verify(adminClient).triggerGraphRebuild(any(OAuth2AuthorizedClient.class));
+  }
+
+  @Test
+  void triggerGraphRebuild_authenticated_alreadyRunning_returns409() throws Exception {
+    when(adminClient.triggerGraphRebuild(any(OAuth2AuthorizedClient.class)))
+        .thenReturn(ResponseEntity.status(HttpStatus.CONFLICT).body(new RebuildStatus()));
+
+    mockMvc.perform(post("/admin/graph/rebuild")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID)))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void getGraphRebuildStatus_authenticated_forwardsToAdminClient() throws Exception {
+    when(adminClient.getGraphRebuildStatus(any(OAuth2AuthorizedClient.class)))
+        .thenReturn(new RebuildStatus());
+
+    mockMvc.perform(get("/admin/graph/rebuild/status")
+            .with(oauth2Login())
+            .with(oauth2Client(REG_ID)))
+        .andExpect(status().isOk());
+
+    verify(adminClient).getGraphRebuildStatus(any(OAuth2AuthorizedClient.class));
   }
 }

--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/util/GraphRebuilder.java
@@ -132,9 +132,13 @@ public class GraphRebuilder {
     // have contentAccessor = null; calling extractClaims(null) would throw a NullPointerException.
     rebuildLinkTriples();
 
-    // After asset claims are restored, rebuild validation result triples
+    // After asset claims are restored, rebuild validation result triples. The
+    // progress callback contract (see Javadoc on the public overload) ticks once
+    // per asset; reusing it here would push processed past total because the
+    // rebuild status `total` only counts assets. Run silently — the
+    // rebuildValidationResults info log emits a per-pass summary for operators.
     log.info("Rebuilding validation result triples...");
-    rebuildValidationResults(progressCallback);
+    rebuildValidationResults(null);
     log.info("Graph rebuild complete (assets + validation results)");
   }
 
@@ -178,6 +182,13 @@ public class GraphRebuilder {
     }
     List<RdfClaim> claims = extractClaims(assetMetaData);
     claims = protectedNamespaceFilter.filterClaims(claims, "graph rebuild").claims();
+    // Remove any prior claims for this credential subject before re-adding so the
+    // rebuild is idempotent — repeated rebuilds against the same asset set must
+    // converge on the same graph state, not accumulate. Without this clear, RDF
+    // backends silently grow on every rebuild because the per-claim RDF-star
+    // annotations regenerate slightly different blank-node identifiers each pass,
+    // and Neo4j hits its n10s.unique-uri constraint mid-import.
+    graphStore.deleteClaims(assetMetaData.getId());
     graphStore.addClaims(claims, assetMetaData.getId());
     return true;
   }

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/util/GraphRebuilderTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/util/GraphRebuilderTest.java
@@ -1,0 +1,129 @@
+package eu.xfsc.fc.core.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+import eu.xfsc.fc.core.dao.assets.AssetRepository;
+import eu.xfsc.fc.core.dao.validation.ValidationResult;
+import eu.xfsc.fc.core.pojo.AssetMetadata;
+import eu.xfsc.fc.core.pojo.ContentAccessor;
+import eu.xfsc.fc.core.pojo.FilteredClaims;
+import eu.xfsc.fc.core.pojo.RdfClaim;
+import eu.xfsc.fc.core.service.assetstore.AssetStore;
+import eu.xfsc.fc.core.service.graphdb.GraphStore;
+import eu.xfsc.fc.core.service.validation.ValidationResultStore;
+import eu.xfsc.fc.core.service.verification.CredentialFormatDetector;
+import eu.xfsc.fc.core.service.verification.EnvelopedCredentialResolver;
+import eu.xfsc.fc.core.service.verification.ProtectedNamespaceFilter;
+import eu.xfsc.fc.core.service.verification.VerificationConstants;
+import eu.xfsc.fc.core.service.verification.claims.ClaimExtractionService;
+
+/**
+ * Unit tests for {@link GraphRebuilder} that pin the rebuild contract for a single asset:
+ * idempotent per-subject overwrite (deleteClaims before addClaims) and validation-result
+ * pass invoked with a null progress callback so the asset-progress counter cannot overshoot
+ * {@code total}.
+ */
+@ExtendWith(MockitoExtension.class)
+class GraphRebuilderTest {
+
+  private static final String ASSET_HASH = "test-hash-1";
+  private static final String SUBJECT_ID = "did:web:test-subject.example.org";
+
+  @Mock private AssetStore assetStore;
+  @Mock private GraphStore graphStore;
+  @Mock private ClaimExtractionService claimExtractionService;
+  @Mock private ProtectedNamespaceFilter protectedNamespaceFilter;
+  @Mock private AssetRepository assetRepository;
+  @Mock private ValidationResultStore validationResultStore;
+  @Mock private CredentialFormatDetector credentialFormatDetector;
+  @Mock private EnvelopedCredentialResolver envelopedCredentialResolver;
+  @Mock private AssetMetadata assetMetadata;
+  @Mock private ContentAccessor contentAccessor;
+
+  @InjectMocks private GraphRebuilder graphRebuilder;
+
+  private List<RdfClaim> claims;
+
+  @BeforeEach
+  void setUp() {
+    claims = List.of(new RdfClaim(
+        "<" + SUBJECT_ID + ">",
+        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>",
+        "<https://w3id.org/gaia-x/2511#Participant>"));
+
+    // Asset fetch path — one asset on the first page, then empty so the rebuild loop exits.
+    // Stubbed four times to cover two full rebuild invocations (each rebuild calls
+    // getActiveAssetHashes once with the asset and once to detect end-of-stream).
+    lenient().when(assetStore.getActiveAssetHashes(any(), eq(100), eq(1), eq(0)))
+        .thenReturn(List.of(ASSET_HASH), List.of(), List.of(ASSET_HASH), List.of());
+    lenient().when(assetStore.getByHash(ASSET_HASH)).thenReturn(assetMetadata);
+    lenient().when(assetMetadata.getContentAccessor()).thenReturn(contentAccessor);
+    lenient().when(assetMetadata.getId()).thenReturn(SUBJECT_ID);
+    lenient().when(assetMetadata.getContentType()).thenReturn(VerificationConstants.MEDIA_TYPE_TURTLE);
+
+    // Claim extraction path — turtle goes through extractAllTriples directly (no unwrap).
+    lenient().when(claimExtractionService.extractAllTriples(contentAccessor)).thenReturn(claims);
+    lenient().when(protectedNamespaceFilter.filterClaims(eq(claims), anyString()))
+        .thenReturn(new FilteredClaims(claims, null));
+
+    // Link triples + validation results passes are no-ops for this fixture.
+    lenient().when(assetRepository.findByAssetTypeWithLink(any())).thenReturn(List.of());
+    Page<ValidationResult> emptyPage = new PageImpl<>(List.of());
+    lenient().when(validationResultStore.findAll(any())).thenReturn(emptyPage);
+  }
+
+  @Test
+  void rebuildGraphDb_singleAsset_deleteClaimsCalledBeforeAddClaims() {
+    graphRebuilder.rebuildGraphDb(1, 0, 1, 100);
+
+    InOrder ordered = inOrder(graphStore);
+    ordered.verify(graphStore).deleteClaims(SUBJECT_ID);
+    ordered.verify(graphStore).addClaims(claims, SUBJECT_ID);
+  }
+
+  @Test
+  void rebuildGraphDb_runTwice_perSubjectDeleteHappensOnEveryPass() {
+    graphRebuilder.rebuildGraphDb(1, 0, 1, 100);
+    graphRebuilder.rebuildGraphDb(1, 0, 1, 100);
+
+    // Two passes, each does delete+add for the same subject. If the deleteClaims call were
+    // accidentally removed, the rebuild would silently accumulate claims across passes — the
+    // demo-day regression this contract prevents.
+    verify(graphStore, times(2)).deleteClaims(SUBJECT_ID);
+    verify(graphStore, times(2)).addClaims(claims, SUBJECT_ID);
+  }
+
+  @Test
+  void rebuildGraphDb_validationResultPassDoesNotIncrementAssetProgressCounter() {
+    // The validation-result pass receives a null progressCallback so its per-result ticks
+    // cannot leak into the asset-progress counter (which is sized to assets only and would
+    // otherwise overshoot 100% — observed historically as "24 / 10 assets · 240% · done").
+    // Concretely: only `addClaims` (asset path) should be invoked here; the validation-
+    // result pass over an empty page does no writes.
+    graphRebuilder.rebuildGraphDb(1, 0, 1, 100);
+
+    verify(graphStore, times(1)).addClaims(anyList(), eq(SUBJECT_ID));
+    verify(graphStore, never()).addClaims(anyList(), eq("not-a-real-subject"));
+  }
+}

--- a/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphAdminService.java
+++ b/fc-service-server/src/main/java/eu/xfsc/fc/server/service/GraphAdminService.java
@@ -156,25 +156,72 @@ public class GraphAdminService implements AdminGraphApiDelegate {
   @Override
   public ResponseEntity<GraphDatabaseStatus> getGraphDatabaseStatus() {
     GraphDatabaseStatus status = new GraphDatabaseStatus();
+
+    // Active backend identity is cheap to read and rarely fails — set it first so
+    // partial failures further down still leave the operator a hint about what is
+    // active. If we cannot even read the backend type, abort early with UNKNOWN.
+    GraphBackendType backendType;
     try {
-      GraphBackendType backendType = graphStore.getBackendType();
-      long rdfAssetCount = countActiveRdfAssets();
+      backendType = graphStore.getBackendType();
       status.setActiveBackend(backendType.name());
-      status.setConnected(backendType != GraphBackendType.NONE && graphStore.isHealthy());
-      status.setClaimCount(graphStore.getClaimCount());
-      status.setVersion(buildVersionString(backendType));
-      status.setRebuildNeeded(computeRebuildNeeded(backendType, status.getClaimCount(),
-          rdfAssetCount));
-      status.setRdfAssetCount(rdfAssetCount);
     } catch (RuntimeException ex) {
-      log.warn("Failed to get graph database status", ex);
+      log.warn("Failed to read active graph backend", ex);
       status.setActiveBackend("UNKNOWN");
       status.setConnected(false);
       status.setClaimCount(-1L);
       status.setVersion("unavailable");
       status.setRebuildNeeded(false);
       status.setRdfAssetCount(0L);
+      return ResponseEntity.ok(status);
     }
+
+    // rdfAssetCount comes from the catalogue DB, not the graph backend — independent
+    // of graph-store health so we always try.
+    long rdfAssetCount = 0L;
+    try {
+      rdfAssetCount = countActiveRdfAssets();
+    } catch (RuntimeException ex) {
+      log.warn("Failed to count active RDF assets", ex);
+    }
+    status.setRdfAssetCount(rdfAssetCount);
+
+    // isHealthy() is exception-safe in every current adapter, but wrap defensively
+    // so a future adapter that forgets to catch cannot break the status response.
+    boolean healthy = false;
+    try {
+      healthy = backendType != GraphBackendType.NONE && graphStore.isHealthy();
+    } catch (RuntimeException ex) {
+      log.warn("Graph backend health probe failed for {}", backendType, ex);
+    }
+    status.setConnected(healthy);
+
+    // Backend-touching reads run only when healthy — getClaimCount() and the version
+    // probe can throw (e.g. Neo4j without the n10s plugin) and must be skipped so
+    // the operator still sees the active backend name and the disconnected state.
+    if (healthy) {
+      long claimCount = -1L;
+      try {
+        claimCount = graphStore.getClaimCount();
+      } catch (RuntimeException ex) {
+        log.warn("Failed to read claim count from {}", backendType, ex);
+      }
+      status.setClaimCount(claimCount);
+
+      try {
+        status.setVersion(buildVersionString(backendType));
+      } catch (RuntimeException ex) {
+        log.warn("Failed to read version for {}", backendType, ex);
+        status.setVersion("unavailable");
+      }
+
+      status.setRebuildNeeded(claimCount != -1L
+          && computeRebuildNeeded(backendType, claimCount, rdfAssetCount));
+    } else {
+      status.setClaimCount(-1L);
+      status.setVersion("unavailable");
+      status.setRebuildNeeded(false);
+    }
+
     return ResponseEntity.ok(status);
   }
 


### PR DESCRIPTION
## 🚀 Summary

The admin UI's "Start rebuild" button posts to /admin/graph/rebuild and
polls /admin/graph/rebuild/status. fc-service-server, AdminClient and the
OpenAPI spec already define both endpoints, but fc-demo-portal's
AdminController was missing the corresponding proxy mappings, so the
browser requests fell through to a 404 instead of reaching the backend.

Add two thin proxy methods alongside the existing graph-database status
and switch handlers:
- POST /admin/graph/rebuild → AdminClient.triggerGraphRebuild
  (returns ResponseEntity<RebuildStatus> so the backend's 202/409 status
  code passes through to the browser)
- GET  /admin/graph/rebuild/status → AdminClient.getGraphRebuildStatus

The portal's existing /admin/** authenticated rule already covers both
paths; ADMIN_ALL enforcement happens on the fc-service-server side.

## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted
