### PR TITLE
fix(CAT-FR-CO-05): drop VP-id/asset-id gate for external-DCH 

### DIFF
--- a/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
+++ b/fc-service-core/src/main/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestrator.java
@@ -1,6 +1,5 @@
 package eu.xfsc.fc.core.service.trustframework.compliance;
 
-import com.nimbusds.jwt.JWTParser;
 import eu.xfsc.fc.core.exception.ClientException;
 import eu.xfsc.fc.core.exception.ConflictException;
 import eu.xfsc.fc.core.exception.ServiceUnavailableException;
@@ -46,12 +45,11 @@ public class ComplianceCheckOrchestrator {
   /**
    * Runs a compliance check for the given asset against the named trust-framework profile.
    *
-   * @param assetId            identifier of the asset being checked
+   * @param assetId            identifier of the asset being checked; used as logging context and as
+   *                           the key under which the caller stores the result
    * @param frameworkProfileId profile to use for the check; must not be {@code null}
    * @param assetPayload       raw credential payload forwarded to the compliance service; must not be {@code null}
-   * @return the compliance outcome; never {@code null}. Returns {@link UnverifiableAttestation}
-   *         when {@code assetPayload} is a parseable JWT whose {@code id} claim is non-blank and
-   *         does not equal {@code assetId}, without contacting the compliance service.
+   * @return the compliance outcome; never {@code null}
    * @throws ClientException              when inputs are null, the profile is not registered,
    *                                      or the resolved client type is unknown
    * @throws ConflictException            when the profile's family is disabled
@@ -66,15 +64,6 @@ public class ComplianceCheckOrchestrator {
       throw new ClientException("assetPayload must not be null");
     }
 
-    String vpId = extractVpId(assetPayload);
-    if (!vpId.isBlank() && !vpId.equals(assetId)) {
-      return new UnverifiableAttestation(
-          FailureCategory.UNVERIFIABLE_ATTESTATION,
-          assetPayload,
-          "VP id '%s' does not match requested asset id '%s'".formatted(vpId, assetId)
-      );
-    }
-
     MDC.put(MDC_ASSET_ID, assetId);
     MDC.put(MDC_PROFILE_ID, frameworkProfileId);
     try {
@@ -82,15 +71,6 @@ public class ComplianceCheckOrchestrator {
     } finally {
       MDC.remove(MDC_ASSET_ID);
       MDC.remove(MDC_PROFILE_ID);
-    }
-  }
-
-  private String extractVpId(String payload) {
-    try {
-      String value = JWTParser.parse(payload).getJWTClaimsSet().getStringClaim("id");
-      return value != null ? value : "";
-    } catch (Exception e) {
-      return "";
     }
   }
 

--- a/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
+++ b/fc-service-core/src/test/java/eu/xfsc/fc/core/service/trustframework/compliance/ComplianceCheckOrchestratorTest.java
@@ -31,15 +31,6 @@ class ComplianceCheckOrchestratorTest {
   private static final String FAMILY_ID = "mock";
   private static final String ASSET_ID = "https://example.com/asset-001";
   private static final String ASSET_PAYLOAD = "test-asset-payload";
-  // JWT with payload {"id":"urn:example:test-asset-001"}
-  private static final String VP_JWT_ASSET_ID = "urn:example:test-asset-001";
-  private static final String VP_JWT_MATCHING =
-      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
-          + ".eyJpZCI6InVybjpleGFtcGxlOnRlc3QtYXNzZXQtMDAxIn0.";
-  // JWT with payload {"id":"urn:example:different-asset"} — id differs from ASSET_ID
-  private static final String VP_JWT_MISMATCHED_ID =
-      "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
-          + ".eyJpZCI6InVybjpleGFtcGxlOmRpZmZlcmVudC1hc3NldCJ9.";
   private static final TrustFrameworkProfileConfig MOCK_CONFIG = new TrustFrameworkProfileConfig(
       PROFILE_ID, FAMILY_ID, "jwt-vc-compliance", "http://localhost",
       "/api/credential-offers/standard-compliance", "loire", 30);
@@ -116,6 +107,28 @@ class ComplianceCheckOrchestratorTest {
   }
 
   @Test
+  void check_credentialIdDiffersFromAssetId_delegatesToClient() {
+    // The catalogue keys an asset by its credential-subject id, which differs from a VP
+    // envelope's own 'id' claim. The orchestrator must still forward such a credential to the
+    // client — credentials destined for an external clearing house are not indexed by VP id.
+    var expected = new IssuedAttestation("cred-jwt", null);
+    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
+    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
+    when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
+    when(mockClient.check(any(), any())).thenReturn(expected);
+
+    // JWT payload {"id":"urn:example:different-asset"} — differs from ASSET_ID
+    String credentialWithDifferentId =
+        "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+            + ".eyJpZCI6InVybjpleGFtcGxlOmRpZmZlcmVudC1hc3NldCJ9.";
+
+    ComplianceCheckOutcome result =
+        orchestrator.check(ASSET_ID, PROFILE_ID, credentialWithDifferentId);
+
+    assertInstanceOf(IssuedAttestation.class, result);
+  }
+
+  @Test
   void check_clientThrowsTimeoutException_propagates() {
     when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
     when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
@@ -146,26 +159,6 @@ class ComplianceCheckOrchestratorTest {
 
     assertThrows(ServiceUnavailableException.class,
         () -> orchestrator.check(ASSET_ID, PROFILE_ID, ASSET_PAYLOAD));
-  }
-
-  @Test
-  void check_vpIdMismatch_returnsUnverifiableAttestation() {
-    ComplianceCheckOutcome outcome = orchestrator.check(ASSET_ID, PROFILE_ID, VP_JWT_MISMATCHED_ID);
-
-    assertInstanceOf(UnverifiableAttestation.class, outcome);
-  }
-
-  @Test
-  void check_vpIdMatches_delegatesToClient() {
-    var expected = new IssuedAttestation("cred-jwt", null);
-    when(profileResolver.getProfileConfig(PROFILE_ID)).thenReturn(Optional.of(MOCK_CONFIG));
-    when(tfService.isEnabled(FAMILY_ID)).thenReturn(true);
-    when(clientRegistry.resolve("jwt-vc-compliance")).thenReturn(mockClient);
-    when(mockClient.check(any(), any())).thenReturn(expected);
-
-    ComplianceCheckOutcome result = orchestrator.check(VP_JWT_ASSET_ID, PROFILE_ID, VP_JWT_MATCHING);
-
-    assertInstanceOf(IssuedAttestation.class, result);
   }
 
   @Test


### PR DESCRIPTION
## 🚀 Summary

ComplianceCheckOrchestrator short-circuited to UNVERIFIABLE_ATTESTATION whenever the submitted VP's top-level `id` claim differed from the path asset id. But the catalogue keys an asset by its credential-subject id (typedCredentials.getID()), e.g. .../participant.json#cs, which is a different field from a VP envelope's own id (.../participant-vp.json). The gate therefore compared two unrelated identifiers and rejected every legitimate compliance check for a credential destined for an external clearing house (e.g. Gaia-X Lab /development), whose vocabulary the catalogue does not index.

This is the compliance-path counterpart of the upload-path fix in #77.

- Remove the gate and its extractVpId helper (+ unused JWTParser import). The JwtVcComplianceClient already derives the DCH vcid from the VP's own id, so the check now reaches the clearing house.
- Drop the two tests that pinned the old gate; add a regression test asserting a credential whose id differs from the asset id still delegates to the client.


## ✅ What’s Changed

- [x] Feature implemented / Bug fixed
- [x] Documentation updated (if needed)
- [x] Tests added or updated
- [x] Code formatted and linted

## 🧪 How to Test

Covered by JUnits tests

## 📋 Checklist

- [x] I’ve tested my code locally
- [x] I’ve added tests if needed
- [x] I’ve updated documentation if necessary
- [x] My changes follow the project’s coding style
